### PR TITLE
Fix #22: register global recording shortcuts

### DIFF
--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -26,6 +26,7 @@ const hotkeyService = new HotkeyService({
   globalShortcut,
   settingsService,
   transformationOrchestrator,
+  recordingOrchestrator,
   onCompositeResult: broadcastCompositeTransformStatus
 })
 


### PR DESCRIPTION
## Summary
- registers global recording shortcuts in main-process `HotkeyService` (`Cmd+Opt+R/S/T/C`)
- wires recording shortcut handlers to `RecordingOrchestrator.runCommand`
- keeps existing transform shortcut registration behavior
- expands hotkey unit tests to verify registration count and recording shortcut execution

## Validation
- `npm run test -- src/main/services/hotkey-service.test.ts`
- `npm run typecheck`

Closes #22
