### PR TITLE
Fix #23: harden transform execution path

### DIFF
--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -58,11 +58,7 @@ export const registerIpcHandlers = (): void => {
   })
   ipcMain.handle(IPC_CHANNELS.getHistory, () => historyService.getRecords())
   ipcMain.handle(IPC_CHANNELS.runRecordingCommand, (_event, command: RecordingCommand) => runRecordingCommand(command))
-  ipcMain.handle(IPC_CHANNELS.runCompositeTransformFromClipboard, async () => {
-    const result = await transformationOrchestrator.runCompositeFromClipboard()
-    broadcastCompositeTransformStatus(result)
-    return result
-  })
+  ipcMain.handle(IPC_CHANNELS.runCompositeTransformFromClipboard, async () => transformationOrchestrator.runCompositeFromClipboard())
 
   hotkeyService.registerFromSettings()
 }

--- a/src/main/orchestrators/transformation-orchestrator.ts
+++ b/src/main/orchestrators/transformation-orchestrator.ts
@@ -54,6 +54,9 @@ export class TransformationOrchestrator {
 
   async runCompositeFromClipboard(): Promise<CompositeResult> {
     const settings = this.settingsService.getSettings()
+    if (!settings.transformation.enabled) {
+      return { status: 'error', message: 'Transformation is disabled in Settings.' }
+    }
     const preset = this.resolveActivePreset(settings)
     const clipboardText = this.readTopmostClipboardText()
     if (!clipboardText) {
@@ -82,8 +85,9 @@ export class TransformationOrchestrator {
       }
 
       return { status: 'ok', message: transformed.text }
-    } catch {
-      return { status: 'error', message: 'Transformation failed.' }
+    } catch (error) {
+      const detail = error instanceof Error && error.message.trim().length > 0 ? error.message.trim() : 'Unknown error'
+      return { status: 'error', message: `Transformation failed: ${detail}` }
     }
   }
 }

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -789,7 +789,8 @@ const wireActions = (): void => {
     addActivity('Running clipboard transform...')
     refreshTimeline()
     try {
-      await window.speechToTextApi.runCompositeTransformFromClipboard()
+      const result = await window.speechToTextApi.runCompositeTransformFromClipboard()
+      applyCompositeResult(result)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown transform error'
       addActivity(`Transform failed: ${message}`, 'error')


### PR DESCRIPTION
## Summary
- adds explicit disabled-transformation guard in composite transform orchestration
- returns adapter error details instead of generic "Transformation failed" responses
- makes renderer apply direct IPC transform results immediately (no dependency on broadcast for button-triggered runs)
- keeps global hotkey status broadcast path intact

## Validation
- `npm run test -- src/main/orchestrators/transformation-orchestrator.test.ts`
- `npm run typecheck`

Closes #23
