### PR TITLE
Sync hotkey shortcuts and v1 spec/UI requirements

### DIFF
--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -130,6 +130,25 @@ test('shows blocked transform reason and deep-links to Settings when disabled', 
   await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
 })
 
+test('shows disabled-transform toast when Home composite transform button is pressed', async ({ page }) => {
+  await page.locator('[data-route-tab="settings"]').click()
+
+  const transformEnabled = page.locator('#settings-transform-enabled')
+  if (await transformEnabled.isChecked()) {
+    await transformEnabled.click()
+  }
+  await page.getByRole('button', { name: 'Save Settings' }).click()
+  await expect(page.locator('#settings-save-message')).toHaveText('Settings saved.')
+
+  await page.locator('[data-route-tab="home"]').click()
+  await page.locator('#run-composite-transform').click()
+  await expect(
+    page.locator('#toast-layer .toast-item').filter({
+      hasText: 'Transformation is disabled. Enable it in Settings > Transformation.'
+    })
+  ).toBeVisible()
+})
+
 test('shows provider API key inputs in Settings', async ({ page }) => {
   await page.locator('[data-route-tab="settings"]').click()
   await expect(page.locator('#settings-api-key-groq')).toBeVisible()
@@ -158,6 +177,10 @@ test('supports run-selected preset, restore-defaults, and recording roadmap link
   await expect(page.locator('#settings-run-selected-preset')).toBeVisible()
   await expect(page.locator('#settings-restore-defaults')).toBeVisible()
   await expect(page.locator('a.inline-link[href*="/issues/8"]')).toBeVisible()
+  await expect(page.locator('#settings-shortcut-start-recording')).toBeVisible()
+  await expect(page.locator('#settings-shortcut-stop-recording')).toBeVisible()
+  await expect(page.locator('#settings-shortcut-toggle-recording')).toBeVisible()
+  await expect(page.locator('#settings-shortcut-cancel-recording')).toBeVisible()
 
   const transformEnabled = page.locator('#settings-transform-enabled')
   if (await transformEnabled.isChecked()) {
@@ -169,14 +192,31 @@ test('supports run-selected preset, restore-defaults, and recording roadmap link
   await page.locator('#settings-run-selected-preset').click()
   await expect(page.locator('#toast-layer .toast-item').filter({ hasText: 'Transformation is disabled.' })).toBeVisible()
 
+  await page.locator('#settings-shortcut-start-recording').fill('Cmd+Shift+1')
+  await page.locator('#settings-shortcut-stop-recording').fill('Cmd+Shift+2')
+  await page.locator('#settings-shortcut-toggle-recording').fill('Cmd+Shift+3')
+  await page.locator('#settings-shortcut-cancel-recording').fill('Cmd+Shift+4')
   await page.locator('#settings-shortcut-run-transform').fill('Cmd+Shift+9')
   await page.locator('#settings-transcript-copy').uncheck()
   await page.getByRole('button', { name: 'Save Settings' }).click()
+  await expect(page.locator('#settings-shortcut-start-recording')).toHaveValue('Cmd+Shift+1')
+  await expect(page.locator('#settings-shortcut-stop-recording')).toHaveValue('Cmd+Shift+2')
+  await expect(page.locator('#settings-shortcut-toggle-recording')).toHaveValue('Cmd+Shift+3')
+  await expect(page.locator('#settings-shortcut-cancel-recording')).toHaveValue('Cmd+Shift+4')
   await expect(page.locator('#settings-shortcut-run-transform')).toHaveValue('Cmd+Shift+9')
   await expect(page.locator('#settings-transcript-copy')).not.toBeChecked()
 
+  await page.locator('[data-route-tab="home"]').click()
+  await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toBeVisible()
+  await expect(page.locator('.shortcut-combo')).toContainText(['Cmd+Shift+1', 'Cmd+Shift+2', 'Cmd+Shift+3', 'Cmd+Shift+4'])
+  await page.locator('[data-route-tab="settings"]').click()
+
   await page.locator('#settings-restore-defaults').click()
   await expect(page.locator('#settings-save-message')).toHaveText('Defaults restored.')
+  await expect(page.locator('#settings-shortcut-start-recording')).toHaveValue('Cmd+Opt+R')
+  await expect(page.locator('#settings-shortcut-stop-recording')).toHaveValue('Cmd+Opt+S')
+  await expect(page.locator('#settings-shortcut-toggle-recording')).toHaveValue('Cmd+Opt+T')
+  await expect(page.locator('#settings-shortcut-cancel-recording')).toHaveValue('Cmd+Opt+C')
   await expect(page.locator('#settings-shortcut-run-transform')).toHaveValue('Cmd+Opt+L')
   await expect(page.locator('#settings-transcript-copy')).toBeChecked()
 })

--- a/specs/ui-components-requirements.md
+++ b/specs/ui-components-requirements.md
@@ -13,7 +13,7 @@ This document translates latest testing feedback into concrete UI requirements f
 Goals:
 - Make recording/transform flows discoverable and operable.
 - Add missing configuration surfaces (API keys, transformation setup, audio source).
-- Reduce noise (remove Session Activity panel from default Home).
+- Remove output matrix and processing history/session activity from v1 UI.
 - Improve error visibility with toast notifications.
 
 ## 2. Information Architecture
@@ -35,9 +35,9 @@ Purpose:
 - Start/stop/toggle/cancel recording.
 
 Requirements:
-- If `recording.ffmpeg_enabled=false`, `Start` and `Toggle` are disabled.
-- Disabled state must show clear inline reason: "Recording is disabled. Enable it in Settings > Recording."
-- Include CTA button/link: `Open Settings`.
+- Normal recording is available in v1 without FFmpeg setup.
+- `Start` and `Toggle` are enabled when microphone permission is granted.
+- If blocked, disabled state must show concrete reason and next step.
 - Show current recording state badge (`Idle`, `Recording`, `Busy`, `Error`).
 
 User inputs:
@@ -60,20 +60,15 @@ User inputs:
 - Click: `Run Composite Transform`
 - Click: `Open Settings`
 
-### H-03 Recent Results Panel (Replace Session Activity)
+### H-03 Home Surface Simplification
 
 Purpose:
-- Show recent processing outputs, not internal activity logs.
+- Keep Home focused on operational controls only.
 
 Requirements:
-- Remove current Session Activity panel from default Home.
-- Display recent persisted jobs (status + transcript/transformed preview).
-- Include filters for status and search.
-
-User inputs:
-- Change: status filter
-- Input: text search
-- Click: refresh
+- Remove Session Activity panel.
+- Remove processing history/session activity UI entirely.
+- Do not add replacement history/result list in v1 Home.
 
 ## 4. Settings Page Components
 
@@ -135,12 +130,11 @@ User inputs:
 ### S-03 Recording & FFmpeg Section
 
 Purpose:
-- Preserve forward-compatible recording section while clarifying FFmpeg is not implemented in v1.
+- Define recording behavior and optional/deferred FFmpeg information.
 
 Requirements:
-- FFmpeg controls must not be presented as functional in v1.
-- Show explicit status: "Recording via FFmpeg is not implemented in v1."
-- Recording controls in Home must show consistent disabled/unsupported behavior while this limitation exists.
+- Settings must not require FFmpeg enablement for normal recording.
+- If FFmpeg settings are shown, they must be informational only and clearly marked deferred/optional.
 - Include pointer to roadmap/post-v1 support note.
 
 User inputs:
@@ -149,14 +143,14 @@ User inputs:
 ### S-04 Output and Shortcut Section
 
 Purpose:
-- Keep output behavior and shortcuts configurable in one place.
+- Keep shortcut behavior configurable and remove output matrix complexity.
 
 Requirements:
-- Existing output matrix controls for transcript/transformed copy/paste.
+- Do not expose transcript/transformed output matrix UI.
+- Keep only simplified output behavior settings if needed by implementation.
 - Shortcut reference and editable bindings where supported.
 
 User inputs:
-- Toggle: output matrix options
 - Input: shortcut bindings
 - Click: restore defaults
 
@@ -167,7 +161,7 @@ User inputs:
 Requirements:
 - Global toast system for `error`, `success`, `info`.
 - Error toast is mandatory for:
-  - recording blocked (FFmpeg disabled/missing)
+  - recording blocked (permission/device/configuration failure)
   - missing API key on transform/transcription
   - transformation failure
   - provider network failure
@@ -191,9 +185,9 @@ Requirements:
 
 1. `UI-F1` Home/Settings page split + navigation.
 2. `UI-F2` Settings API key components + secure save/test flow.
-3. `UI-F3` Transformation configuration UI and state (enabled/model/auto-run/system prompt/user prompt).
-4. `UI-F4` Recording/FFmpeg section updated for v1 unsupported-state UX.
-5. `UI-F5` Replace Session Activity with Recent Results panel.
+3. `UI-F3` Transformation configuration UI and state (enabled/model/system prompt/user prompt).
+4. `UI-F4` Recording section aligned to normal recording availability (FFmpeg optional/deferred messaging only).
+5. `UI-F5` Remove Session Activity/history UI and output matrix UI.
 6. `UI-F6` Global toast/error system and deep-link actions.
 
 ## 7. Acceptance Checklist
@@ -203,7 +197,9 @@ Requirements:
 - Transformation configuration exists and is editable, including `system prompt` and `user prompt`.
 - Multiple transformation presets can be created and one default preset can be selected.
 - Shortcut-triggered transformation executes current clipboard topmost text.
-- Session Activity is removed from Home default view.
-- FFmpeg section clearly communicates unsupported status in v1.
+- Session Activity and all processing history UI are absent in v1.
+- Output matrix UI is absent in v1.
+- Recording works without FFmpeg setup.
+- FFmpeg section (if present) is informational only and marked deferred/optional.
 - Error toasts appear on all blocked/failing actions.
 - Recording cannot start silently; failures always explain why.

--- a/src/main/services/hotkey-service.test.ts
+++ b/src/main/services/hotkey-service.test.ts
@@ -28,7 +28,7 @@ describe('HotkeyService', () => {
     }
   })
 
-  it('registers three shortcut handlers from settings', () => {
+  it('registers all recording and transformation shortcuts from settings', () => {
     const register = vi.fn(() => true)
     const unregisterAll = vi.fn()
     const settings = makeSettings()
@@ -44,6 +44,10 @@ describe('HotkeyService', () => {
 
     expect(unregisterAll).toHaveBeenCalledTimes(1)
     expect(register).toHaveBeenCalledTimes(7)
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Alt+R', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Alt+S', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Alt+T', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('CommandOrControl+Alt+C', expect.any(Function))
   })
 
   it('pick-and-run updates active preset and runs transform', async () => {
@@ -135,5 +139,28 @@ describe('HotkeyService', () => {
     await Promise.resolve()
 
     expect(runCommand).toHaveBeenCalledWith('startRecording')
+  })
+
+  it('uses recording shortcut combos from settings', () => {
+    const register = vi.fn(() => true)
+    const settings = makeSettings()
+    settings.shortcuts.startRecording = 'Ctrl+Shift+1'
+    settings.shortcuts.stopRecording = 'Ctrl+Shift+2'
+    settings.shortcuts.toggleRecording = 'Ctrl+Shift+3'
+    settings.shortcuts.cancelRecording = 'Ctrl+Shift+4'
+
+    const service = new HotkeyService({
+      globalShortcut: { register, unregisterAll: vi.fn() },
+      settingsService: { getSettings: () => settings, setSettings: vi.fn() },
+      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      recordingOrchestrator: { runCommand: vi.fn(async () => undefined) }
+    })
+
+    service.registerFromSettings()
+
+    expect(register).toHaveBeenCalledWith('Control+Shift+1', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('Control+Shift+2', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('Control+Shift+3', expect.any(Function))
+    expect(register).toHaveBeenCalledWith('Control+Shift+4', expect.any(Function))
   })
 })

--- a/src/main/services/hotkey-service.ts
+++ b/src/main/services/hotkey-service.ts
@@ -83,10 +83,10 @@ export class HotkeyService {
 
     const settings = this.settingsService.getSettings()
     const bindings = [
-      { combo: 'Cmd+Opt+R', run: () => this.runRecordingCommand('startRecording') },
-      { combo: 'Cmd+Opt+S', run: () => this.runRecordingCommand('stopRecording') },
-      { combo: 'Cmd+Opt+T', run: () => this.runRecordingCommand('toggleRecording') },
-      { combo: 'Cmd+Opt+C', run: () => this.runRecordingCommand('cancelRecording') },
+      { combo: settings.shortcuts.startRecording, run: () => this.runRecordingCommand('startRecording') },
+      { combo: settings.shortcuts.stopRecording, run: () => this.runRecordingCommand('stopRecording') },
+      { combo: settings.shortcuts.toggleRecording, run: () => this.runRecordingCommand('toggleRecording') },
+      { combo: settings.shortcuts.cancelRecording, run: () => this.runRecordingCommand('cancelRecording') },
       { combo: settings.shortcuts.runTransform, run: () => this.runTransform() },
       { combo: settings.shortcuts.pickTransformation, run: () => this.pickAndRunTransform() },
       { combo: settings.shortcuts.changeTransformationDefault, run: () => this.changeDefaultTransform() }


### PR DESCRIPTION
## Summary
- make recording global shortcuts read from settings in `HotkeyService`
- expand hotkey unit tests to verify recording shortcut registration from configured combos
- add/adjust Electron E2E assertions for disabled transform toast and recording shortcut fields/default restore behavior
- align `specs/v1-spec.md` and `specs/ui-components-requirements.md` with current direction: normal recording path, no history/output-matrix UI in v1, and FFmpeg optional/deferred messaging

## Validation
- npm run test -- src/main/services/hotkey-service.test.ts
