### PR TITLE
feat: wire CommandRouter into composition root (Phase 1)

### DIFF
--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Where: src/main/core/command-router.test.ts
+ * What:  Tests for CommandRouter — IPC-facing mode-aware command routing.
+ * Why:   Verify that CommandRouter validates mode via Phase 0 ModeRouter and
+ *        correctly delegates to existing orchestrators.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { CommandRouter } from './command-router'
+import { DEFAULT_SETTINGS, type Settings } from '../../shared/domain'
+import type { CompositeTransformResult, RecordingCommandDispatch } from '../../shared/ipc'
+import type { CaptureResult } from '../services/capture-types'
+
+const makeSettings = (): Settings => structuredClone(DEFAULT_SETTINGS)
+
+const makeFakeRecordingOrchestrator = () => ({
+  runCommand: vi.fn<[string], RecordingCommandDispatch>().mockReturnValue({ command: 'startRecording' }),
+  submitRecordedAudio: vi.fn().mockReturnValue({
+    jobId: 'job-1',
+    audioFilePath: '/tmp/test.webm',
+    capturedAt: '2026-02-17T00:00:00Z'
+  } satisfies CaptureResult),
+  getAudioInputSources: vi.fn().mockReturnValue([{ id: 'system_default', label: 'Default' }])
+})
+
+const makeFakeTransformationOrchestrator = () => ({
+  runCompositeFromClipboard: vi.fn<[], Promise<CompositeTransformResult>>().mockResolvedValue({
+    status: 'ok',
+    message: 'transformed text'
+  })
+})
+
+describe('CommandRouter', () => {
+  it('delegates runRecordingCommand to recording orchestrator', () => {
+    const settingsService = { getSettings: () => makeSettings() }
+    const recording = makeFakeRecordingOrchestrator()
+    const transformation = makeFakeTransformationOrchestrator()
+
+    const router = new CommandRouter({
+      settingsService,
+      recordingOrchestrator: recording,
+      transformationOrchestrator: transformation
+    })
+
+    const dispatch = router.runRecordingCommand('startRecording')
+
+    expect(recording.runCommand).toHaveBeenCalledWith('startRecording')
+    expect(dispatch.command).toBe('startRecording')
+  })
+
+  it('delegates submitRecordedAudio to recording orchestrator', () => {
+    const settingsService = { getSettings: () => makeSettings() }
+    const recording = makeFakeRecordingOrchestrator()
+    const transformation = makeFakeTransformationOrchestrator()
+
+    const router = new CommandRouter({
+      settingsService,
+      recordingOrchestrator: recording,
+      transformationOrchestrator: transformation
+    })
+
+    const payload = { data: new Uint8Array([1, 2, 3]), mimeType: 'audio/webm', capturedAt: '2026-02-17T00:00:00Z' }
+    const result = router.submitRecordedAudio(payload)
+
+    expect(recording.submitRecordedAudio).toHaveBeenCalledWith(payload)
+    expect(result.jobId).toBe('job-1')
+  })
+
+  it('delegates getAudioInputSources to recording orchestrator', () => {
+    const settingsService = { getSettings: () => makeSettings() }
+    const recording = makeFakeRecordingOrchestrator()
+    const transformation = makeFakeTransformationOrchestrator()
+
+    const router = new CommandRouter({
+      settingsService,
+      recordingOrchestrator: recording,
+      transformationOrchestrator: transformation
+    })
+
+    const sources = router.getAudioInputSources()
+
+    expect(sources).toEqual([{ id: 'system_default', label: 'Default' }])
+    expect(recording.getAudioInputSources).toHaveBeenCalledOnce()
+  })
+
+  it('delegates runCompositeFromClipboard to transformation orchestrator', async () => {
+    const settingsService = { getSettings: () => makeSettings() }
+    const recording = makeFakeRecordingOrchestrator()
+    const transformation = makeFakeTransformationOrchestrator()
+
+    const router = new CommandRouter({
+      settingsService,
+      recordingOrchestrator: recording,
+      transformationOrchestrator: transformation
+    })
+
+    const result = await router.runCompositeFromClipboard()
+
+    expect(transformation.runCompositeFromClipboard).toHaveBeenCalledOnce()
+    expect(result).toEqual({ status: 'ok', message: 'transformed text' })
+  })
+
+  it('validates mode on recording commands (default mode succeeds)', () => {
+    const settingsService = { getSettings: () => makeSettings() }
+    const recording = makeFakeRecordingOrchestrator()
+    const transformation = makeFakeTransformationOrchestrator()
+
+    const router = new CommandRouter({
+      settingsService,
+      recordingOrchestrator: recording,
+      transformationOrchestrator: transformation
+    })
+
+    // Should not throw — LegacyProcessingModeSource always returns 'default'
+    expect(() => router.runRecordingCommand('toggleRecording')).not.toThrow()
+    expect(() => router.runRecordingCommand('stopRecording')).not.toThrow()
+  })
+})

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -1,0 +1,89 @@
+/**
+ * Where: src/main/core/command-router.ts
+ * What:  IPC-facing command router that validates processing mode and delegates
+ *        to existing orchestrators.
+ * Why:   Spec §3.4 / §12.4 requires a mode-aware orchestration entrypoint.
+ *        This bridges between IPC handlers (which call runCommand, submitRecordedAudio,
+ *        runCompositeFromClipboard) and the Phase 0 routing/ModeRouter (which validates
+ *        processing mode). v1 only supports 'default' mode; streaming fails fast.
+ *
+ *        Phase 2 will replace direct orchestrator delegation with queue-based dispatch
+ *        using CaptureQueue, TransformQueue, and SerialOutputCoordinator.
+ */
+
+import type { AudioInputSource, CompositeTransformResult, RecordingCommand, RecordingCommandDispatch } from '../../shared/ipc'
+import type { CaptureResult } from '../services/capture-types'
+import type { RecordingOrchestrator } from '../orchestrators/recording-orchestrator'
+import type { TransformationOrchestrator } from '../orchestrators/transformation-orchestrator'
+import { ModeRouter } from '../routing/mode-router'
+import { LegacyProcessingModeSource } from '../routing/processing-mode-source'
+import { createCaptureRequestSnapshot } from '../routing/capture-request-snapshot'
+import type { SettingsService } from '../services/settings-service'
+
+interface CommandRouterDependencies {
+  settingsService: Pick<SettingsService, 'getSettings'>
+  recordingOrchestrator: Pick<RecordingOrchestrator, 'runCommand' | 'submitRecordedAudio' | 'getAudioInputSources'>
+  transformationOrchestrator: Pick<TransformationOrchestrator, 'runCompositeFromClipboard'>
+}
+
+export class CommandRouter {
+  private readonly modeRouter: ModeRouter
+  private readonly settingsService: Pick<SettingsService, 'getSettings'>
+  private readonly recordingOrchestrator: Pick<RecordingOrchestrator, 'runCommand' | 'submitRecordedAudio' | 'getAudioInputSources'>
+  private readonly transformationOrchestrator: Pick<TransformationOrchestrator, 'runCompositeFromClipboard'>
+
+  constructor(dependencies: CommandRouterDependencies) {
+    this.settingsService = dependencies.settingsService
+    this.recordingOrchestrator = dependencies.recordingOrchestrator
+    this.transformationOrchestrator = dependencies.transformationOrchestrator
+    // Use Phase 0's ModeRouter with legacy mode source for mode validation.
+    this.modeRouter = new ModeRouter({ modeSource: new LegacyProcessingModeSource() })
+  }
+
+  /** Dispatch a recording command. Validates mode via ModeRouter, then delegates. */
+  runRecordingCommand(command: RecordingCommand): RecordingCommandDispatch {
+    // Validate mode by routing a minimal snapshot through ModeRouter.
+    // This ensures fail-fast on unsupported modes (spec §12.4).
+    this.assertCaptureMode()
+    return this.recordingOrchestrator.runCommand(command)
+  }
+
+  /** Submit captured audio for processing. Validates mode, then delegates. */
+  submitRecordedAudio(payload: { data: Uint8Array; mimeType: string; capturedAt: string }): CaptureResult {
+    this.assertCaptureMode()
+    return this.recordingOrchestrator.submitRecordedAudio(payload)
+  }
+
+  /** List available audio input sources. Mode-agnostic — no mode check needed. */
+  getAudioInputSources(): AudioInputSource[] {
+    return this.recordingOrchestrator.getAudioInputSources()
+  }
+
+  /** Run clipboard-based transformation. Validates mode, then delegates. */
+  async runCompositeFromClipboard(): Promise<CompositeTransformResult> {
+    // Transformation shortcuts are always allowed regardless of capture mode.
+    return this.transformationOrchestrator.runCompositeFromClipboard()
+  }
+
+  /**
+   * Validate that capture operations are allowed in current mode.
+   * Uses Phase 0's ModeRouter.routeCapture with a minimal snapshot probe.
+   * Throws if mode is unsupported (e.g. streaming in v1).
+   */
+  private assertCaptureMode(): void {
+    const settings = this.settingsService.getSettings()
+    const snapshot = createCaptureRequestSnapshot({
+      snapshotId: '__mode_check__',
+      capturedAt: new Date().toISOString(),
+      audioFilePath: '',
+      sttProvider: settings.transcription.provider,
+      sttModel: settings.transcription.model,
+      outputLanguage: settings.transcription.outputLanguage,
+      temperature: settings.transcription.temperature,
+      transformationProfile: null,
+      output: settings.output
+    })
+    // If mode is unsupported, routeCapture throws — that's the fail-fast behavior.
+    this.modeRouter.routeCapture(snapshot)
+  }
+}

--- a/src/main/services/hotkey-service.test.ts
+++ b/src/main/services/hotkey-service.test.ts
@@ -40,7 +40,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand: vi.fn(async () => undefined)
     })
 
@@ -69,7 +69,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll },
       settingsService: { getSettings: () => settings, setSettings },
-      transformationOrchestrator: { runCompositeFromClipboard },
+      commandRouter: { runCompositeFromClipboard },
       runRecordingCommand: vi.fn(async () => undefined)
     })
 
@@ -102,7 +102,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand: vi.fn(async () => undefined)
     })
 
@@ -133,7 +133,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand
     })
 
@@ -156,7 +156,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand: vi.fn(async () => undefined)
     })
 
@@ -179,7 +179,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand: vi.fn(async () => {
         throw new Error('No active renderer window is available to handle recording commands.')
       }),
@@ -212,7 +212,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand,
       onShortcutError
     })
@@ -232,7 +232,7 @@ describe('HotkeyService', () => {
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
-      transformationOrchestrator: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
+      commandRouter: { runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })) },
       runRecordingCommand: vi.fn(async () => undefined),
       onShortcutError
     })


### PR DESCRIPTION
## Summary
- Introduces `CommandRouter` (`src/main/core/command-router.ts`) as the IPC-facing entry point that validates processing mode via Phase 0's `routing/ModeRouter` and delegates to existing orchestrators
- IPC handlers in `register-handlers.ts` now route through `CommandRouter` instead of calling orchestrators directly
- `HotkeyService` depends on `CommandRouter` instead of `TransformationOrchestrator`

## Details
- `CommandRouter` uses `LegacyProcessingModeSource` + `routing/ModeRouter.routeCapture()` to validate that capture operations are allowed in the current mode (v1: default only)
- Transformation shortcuts bypass mode validation (always allowed per spec §4.5)
- No changes to orchestrator internals — Phase 0 skeleton modules preserved as-is
- Phase 2 will replace direct orchestrator delegation with queue-based dispatch

## Test plan
- [x] All 141 tests pass (136 existing + 5 new CommandRouter tests)
- [x] Zero regressions from Phase 0 baseline
- [x] CommandRouter delegates all 4 methods correctly (recording command, submit audio, audio sources, clipboard transform)
- [x] Mode validation exercised via Phase 0 ModeRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)