### PR TITLE
Phase 3A PR B: add shortcut behavior matrix tests

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -14,6 +14,7 @@ This checklist defines the minimum release workflow for direct macOS distributio
 - [ ] `pnpm run test`
 - [ ] `pnpm run build`
 - [ ] `pnpm run contract:smoke`
+- [ ] Confirm transformation shortcut behavior matrix tests pass (default-target, pick-and-run, change-default, selection-target).
 
 ## 3. Packaging
 - [ ] `pnpm run dist:mac`

--- a/src/main/services/hotkey-service.test.ts
+++ b/src/main/services/hotkey-service.test.ts
@@ -142,14 +142,17 @@ describe('HotkeyService', () => {
 
     const setSettings = vi.fn()
     const settings = makeSettings()
+    const runCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
+    const runDefaultCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
+    const runCompositeFromSelection = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
 
     const service = new HotkeyService({
       globalShortcut: { register, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
-        runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
-        runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
+        runCompositeFromClipboard,
+        runDefaultCompositeFromClipboard,
+        runCompositeFromSelection
       },
       runRecordingCommand: vi.fn(async () => undefined),
       pickProfile: vi.fn(async () => 'a'),
@@ -169,6 +172,9 @@ describe('HotkeyService', () => {
         })
       })
     )
+    expect(runCompositeFromClipboard).not.toHaveBeenCalled()
+    expect(runCompositeFromSelection).not.toHaveBeenCalled()
+    expect(runDefaultCompositeFromClipboard).not.toHaveBeenCalled()
   })
 
   it('executes recording command when recording shortcut callback fires', async () => {


### PR DESCRIPTION
## Summary
- add matrix-focused CommandRouter tests for Phase 3A shortcut semantics
  - per-request active profile snapshot binding
  - per-request default profile snapshot binding
  - per-request source text snapshot binding
- strengthen HotkeyService test for `changeDefaultTransformation`
  - verifies it does not invoke any transformation dispatch path
- update release checklist to explicitly include shortcut matrix test verification

## Validation
- `pnpm vitest run src/main/core/command-router.test.ts src/main/services/hotkey-service.test.ts`

## Scope
- tests/docs only (no runtime behavior changes)
