### PR TITLE
fix: resolve preflight guard typecheck debt

### DIFF
--- a/src/main/orchestrators/preflight-guard.test.ts
+++ b/src/main/orchestrators/preflight-guard.test.ts
@@ -7,6 +7,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { checkSttPreflight, checkLlmPreflight, classifyAdapterError } from './preflight-guard'
 
 describe('checkSttPreflight', () => {
+  it('passes through provider strings for lookup and messaging', () => {
+    const secretStore = { getApiKey: vi.fn(() => null) }
+    const provider = 'custom-provider'
+    const result = checkSttPreflight(secretStore, provider)
+
+    expect(secretStore.getApiKey).toHaveBeenCalledWith(provider)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toContain(provider)
+    }
+  })
+
   it('returns ok when STT API key is present', () => {
     const secretStore = { getApiKey: vi.fn(() => 'valid-key') }
     const result = checkSttPreflight(secretStore, 'groq')

--- a/src/main/orchestrators/preflight-guard.ts
+++ b/src/main/orchestrators/preflight-guard.ts
@@ -7,6 +7,8 @@
 import type { FailureCategory } from '../../shared/domain'
 import type { SecretStore } from '../services/secret-store'
 
+type ApiKeyProvider = Parameters<SecretStore['getApiKey']>[0]
+
 // ---------------------------------------------------------------------------
 // Preflight result types
 // ---------------------------------------------------------------------------
@@ -40,7 +42,9 @@ function checkApiKeyPreflight(
   secretStore: Pick<SecretStore, 'getApiKey'>,
   provider: string
 ): PreflightResult {
-  const apiKey = secretStore.getApiKey(provider)
+  // Keep public preflight inputs as string for current call sites while
+  // satisfying SecretStore's provider contract for the API key lookup.
+  const apiKey = secretStore.getApiKey(provider as ApiKeyProvider)
   if (!apiKey) {
     return { ok: false, reason: `Missing ${provider} API key. Add it in Settings → API Keys.` }
   }


### PR DESCRIPTION
## Summary
- fix `checkApiKeyPreflight` type mismatch by aligning the `getApiKey` call to `SecretStore` provider parameter type
- keep `provider` function inputs as `string` to avoid changing existing behavior/callers
- add a regression test covering provider passthrough + user-facing missing-key reason content

## Validation
- pnpm -s typecheck
- pnpm -s vitest run src/main/orchestrators/preflight-guard.test.ts

## Scope
- kept separate from Phase 3A behavior changes
- removed the ad-hoc debt log doc since commit/PR history already captures this one-off cleanup
