### PR TITLE
Phase 6 follow-up: address review findings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,11 @@ Commands flow from renderer -> IPC -> `CommandRouter` -> queue-based pipeline:
 Immutable snapshots (`CaptureRequestSnapshot`, `TransformationRequestSnapshot`) are frozen at enqueue time so in-flight jobs are isolated from concurrent settings changes.
 Profile/settings updates apply to subsequent requests only; already-enqueued requests keep their bound snapshot.
 
+Phase 4 adds provider contract hardening:
+- STT and LLM requests can use per-provider `baseUrlOverride` values from settings.
+- Gemini uses explicit model endpoints (`/v1beta/models/{model}:generateContent`) with no silent model fallback.
+- Unsupported provider/model pairs are rejected in preflight before any network call.
+
 ## Home UI (Phase 5A)
 
 - Top-level navigation is limited to `Home` and `Settings`; app launches on `Home`.
@@ -97,10 +102,5 @@ Profile/settings updates apply to subsequent requests only; already-enqueued req
 - Recording start/stop/cancel and transformation completion outcomes are wired to sound events.
 - Audio source discovery now attempts real macOS input-device enumeration and falls back safely to `System Default` when unavailable.
 - Failure feedback now maps `preflight`, `api_auth`, and `network` categories to actionable next-step guidance in the renderer.
-
-Phase 4 adds provider contract hardening:
-- STT and LLM requests can use per-provider `baseUrlOverride` values from settings.
-- Gemini uses explicit model endpoints (`/v1beta/models/{model}:generateContent`) with no silent model fallback.
-- Unsupported provider/model pairs are rejected in preflight before any network call.
 
 See [specs/spec.md](specs/spec.md) for the full normative specification and [docs/refactor-baseline-plan.md](docs/refactor-baseline-plan.md) for the phased implementation plan.

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -28,7 +28,7 @@ function makeDeps(overrides?: Partial<CommandRouterDependencies>): CommandRouter
         audioFilePath: '/tmp/test.webm',
         capturedAt: '2026-02-17T00:00:00Z'
       } satisfies CaptureResult),
-      getAudioInputSources: vi.fn().mockReturnValue([{ id: 'system_default', label: 'Default' }])
+      getAudioInputSources: vi.fn().mockResolvedValue([{ id: 'system_default', label: 'Default' }])
     },
     captureQueue: overrides?.captureQueue ?? { enqueue: vi.fn() },
     transformQueue: overrides?.transformQueue ?? { enqueue: vi.fn() },
@@ -58,11 +58,11 @@ describe('CommandRouter', () => {
     expect(() => router.runRecordingCommand('stopRecording')).not.toThrow()
   })
 
-  it('delegates getAudioInputSources to recording orchestrator', () => {
+  it('delegates getAudioInputSources to recording orchestrator', async () => {
     const deps = makeDeps()
     const router = new CommandRouter(deps)
 
-    const sources = router.getAudioInputSources()
+    const sources = await router.getAudioInputSources()
 
     expect(sources).toEqual([{ id: 'system_default', label: 'Default' }])
     expect(deps.recordingOrchestrator.getAudioInputSources).toHaveBeenCalledOnce()

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -70,7 +70,7 @@ export class CommandRouter {
   }
 
   /** List available audio input sources. Mode-agnostic — no mode check needed. */
-  getAudioInputSources(): AudioInputSource[] {
+  async getAudioInputSources(): Promise<AudioInputSource[]> {
     return this.recordingOrchestrator.getAudioInputSources()
   }
 

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -167,7 +167,7 @@ export const registerIpcHandlers = (): void => {
   })
   ipcMain.handle(IPC_CHANNELS.getHistory, () => historyService.getRecords())
   ipcMain.handle(IPC_CHANNELS.getAudioInputSources, () => commandRouter.getAudioInputSources())
-  ipcMain.handle(IPC_CHANNELS.playSound, (_event, event: SoundEvent) => {
+  ipcMain.on(IPC_CHANNELS.playSound, (_event, event: SoundEvent) => {
     soundService.play(event)
   })
   ipcMain.handle(IPC_CHANNELS.runRecordingCommand, (_event, command: RecordingCommand) => runRecordingCommand(command))

--- a/src/main/orchestrators/capture-pipeline.test.ts
+++ b/src/main/orchestrators/capture-pipeline.test.ts
@@ -320,6 +320,7 @@ describe('createCaptureProcessor', () => {
         failureCategory: 'unknown'
       })
     )
+    expect(deps.soundService!.play).toHaveBeenCalledWith('transformation_failed')
   })
 
   it('returns output_failed_partial when output application fails', async () => {

--- a/src/main/orchestrators/capture-pipeline.ts
+++ b/src/main/orchestrators/capture-pipeline.ts
@@ -110,7 +110,15 @@ export function createCaptureProcessor(deps: CapturePipelineDeps): CaptureProces
     }
 
     if (attemptedTransformation) {
-      deps.soundService?.play(terminalStatus === 'transformation_failed' ? 'transformation_failed' : 'transformation_succeeded')
+      const transformationSoundEvent =
+        terminalStatus === 'transformation_failed'
+          ? 'transformation_failed'
+          : terminalStatus === 'succeeded'
+            ? 'transformation_succeeded'
+            : null
+      if (transformationSoundEvent !== null) {
+        deps.soundService?.play(transformationSoundEvent)
+      }
     }
 
     // --- Stage 3: Ordered Output Commit ---

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,7 +21,9 @@ const api: IpcApi = {
     ipcRenderer.invoke(IPC_CHANNELS.testApiKeyConnection, provider, candidateApiKey),
   getHistory: async () => ipcRenderer.invoke(IPC_CHANNELS.getHistory),
   getAudioInputSources: async () => ipcRenderer.invoke(IPC_CHANNELS.getAudioInputSources),
-  playSound: async (event: SoundEvent) => ipcRenderer.invoke(IPC_CHANNELS.playSound, event),
+  playSound: async (event: SoundEvent) => {
+    ipcRenderer.send(IPC_CHANNELS.playSound, event)
+  },
   runRecordingCommand: async (command: RecordingCommand) =>
     ipcRenderer.invoke(IPC_CHANNELS.runRecordingCommand, command),
   submitRecordedAudio: async (payload) => ipcRenderer.invoke(IPC_CHANNELS.submitRecordedAudio, payload),


### PR DESCRIPTION
## Summary
- switch macOS audio input discovery to async process execution to avoid main-thread blocking
- make audio-input source discovery cache resilient: retry after transient failures and refresh after TTL
- tighten transformation sound-event mapping and add missing transformation-failure sound assertion
- switch renderer playSound IPC to fire-and-forget (send/on)
- reorder README phase sections for chronological clarity

## Validation
- pnpm exec vitest run src/main/orchestrators/recording-orchestrator.test.ts src/main/core/command-router.test.ts src/main/orchestrators/capture-pipeline.test.ts
- pnpm typecheck