### PR TITLE
test(e2e): add positive macOS provider key save test

### DIFF
--- a/docs/e2e-playwright.md
+++ b/docs/e2e-playwright.md
@@ -50,6 +50,7 @@ Artifacts are uploaded on every run:
 - App launch smoke test (Home/Settings navigation).
 - Settings save flow behavior assertion.
 - Provider API key input visibility in Settings.
+- macOS-only provider API key positive save/status path (`@macos` tagged).
 - Transform preflight blocking when Google API key is missing.
 
 ## Config

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -256,6 +256,21 @@ test('macOS provider-key preload smoke @macos', async ({ page }) => {
   }
 })
 
+test('macOS provider key save path reports configured status @macos', async ({ page }) => {
+  test.skip(process.platform !== 'darwin', 'macOS-only smoke test')
+
+  await page.locator('[data-route-tab="settings"]').click()
+
+  const keyValue = `macos-e2e-${Date.now()}`
+  await page.locator('#settings-api-key-groq').fill(keyValue)
+  await page.getByRole('button', { name: 'Save API Keys' }).click()
+  await expect(page.locator('#api-keys-save-message')).toHaveText('API keys saved.')
+  await expect(page.locator('#api-key-save-status-groq')).toHaveText('Saved.')
+
+  const keyStatus = await page.evaluate(async () => window.speechToTextApi.getApiKeyStatus())
+  expect(keyStatus.groq).toBe(true)
+})
+
 test('supports run-selected preset, restore-defaults, and recording roadmap link in Settings', async ({ page }) => {
   await page.locator('[data-route-tab="settings"]').click()
 


### PR DESCRIPTION
## Summary\n- add a new positive macOS E2E test for provider API key save/status path\n- keep macOS-only gating via `@macos` and runtime platform skip\n- update E2E docs coverage list\n\n## Validation\n- targeted Playwright run recognizes the new test; it is skipped on non-macOS hosts\n\n## Note\n- Groq connectivity may be rejected when routed through VPN/proxy split-tunnel policies. If Groq API calls fail with network signatures, disable VPN for Groq traffic or add explicit split-tunnel allow rules for Groq endpoints (for example `api.groq.com`).