### PR TITLE
fix(selection): resolve run-on-selection false empty-state

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -24,7 +24,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | Priority | Ticket | Issue | Status | PR Scope |
 |---|---|---|---|---|
 | P0 | Fix paste-at-cursor output failed partial regression | #62 | TODO | Output/paste reliability only |
-| P0 | Fix selection-target transformation execution errors | #63 | TODO | Selection transform path only |
+| P0 | Fix selection-target transformation execution errors | #63 | DONE | Selection transform path only |
 | P0 | Fix change-default-transformation shortcut no-op | #64 | TODO | Shortcut command behavior only |
 | P0 | Fix duplicate action sound playback | #65 | TODO | Sound trigger dedup only |
 | P0 | Fix malformed Groq status handling and diagnostics | #66 | CANCELED | Provider error parsing only |
@@ -60,7 +60,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [ ] Verify `pnpm run test` and `pnpm run test:e2e` pass.
 
 ### #63 - [P0] Fix selection-target transformation execution errors
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Ensure selection-target transformation works when text exists and fails gracefully when absent.
 - Constraints:
   - Must follow selection shortcut semantics (`specs/spec.md:171-179`).
@@ -70,10 +70,10 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - With selected text, transformation runs and returns expected success status.
   - Without selected text, user receives actionable no-selection feedback.
 - Tasks:
-  - [ ] Trace selection retrieval to transform enqueue path.
-  - [ ] Fix valid-selection execution path.
-  - [ ] Keep no-selection actionable feedback path intact.
-  - [ ] Add/adjust unit/e2e coverage.
+  - [x] Trace selection retrieval to transform enqueue path.
+  - [x] Fix valid-selection execution path.
+  - [x] Keep no-selection actionable feedback path intact.
+  - [x] Add/adjust unit/e2e coverage.
 
 ### #64 - [P0] Fix change-default-transformation shortcut no-op
 - Status: `TODO`

--- a/src/main/infrastructure/selection-client.test.ts
+++ b/src/main/infrastructure/selection-client.test.ts
@@ -72,6 +72,22 @@ describe('SelectionClient', () => {
     expect(clipboard.writeText).toHaveBeenCalledWith('existing content')
   })
 
+  it('reads selection even when selected text matches previous clipboard content', async () => {
+    const clipboard = createClipboardStub('same text')
+    const exec = createExecStub(clipboard, 'same text')
+
+    const client = new SelectionClient({
+      clipboard,
+      runCommand: exec as any,
+      pollTimeoutMs: 50,
+      platform: 'darwin'
+    })
+
+    const result = await client.readSelection()
+    expect(result).toBe('same text')
+    expect(clipboard.writeText).toHaveBeenCalledWith('same text')
+  })
+
   it('returns null when clipboard changes to whitespace only', async () => {
     const clipboard = createClipboardStub('original')
     const exec = createExecStub(clipboard, '   ')


### PR DESCRIPTION
## Summary
- fix selection-read detection when selected text equals existing clipboard text
- seed clipboard with a temporary probe token before Cmd+C to reliably detect actual selection changes
- keep no-selection actionable path unchanged
- add regression test for same-content clipboard/selection case
- update execution plan status for #63

## Why
Issue #63 reports valid selection runs incorrectly failing as no-selection. The previous implementation inferred success only when clipboard content changed from its original value, which fails when selected text is identical to prior clipboard content.

## Validation
- `pnpm exec vitest run /workspace/src/main/infrastructure/selection-client.test.ts` passed (includes new regression test).

## Current blockers in this workspace
- `pnpm run test:e2e` fails before test start due existing build resolution error: `Rollup failed to resolve import "valibot" from /workspace/src/shared/domain.ts`.
- `pnpm run test` currently traverses mirrored `.worktrees`/`.pnpm-store` test copies, producing long noisy runs with unrelated `0 test` suites outside this PR scope.
