### PR TITLE
fix(sound): dedupe action-event playback

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -26,7 +26,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P0 | Fix paste-at-cursor output failed partial regression | #62 | TODO | Output/paste reliability only |
 | P0 | Fix selection-target transformation execution errors | #63 | DONE | Selection transform path only |
 | P0 | Fix change-default-transformation shortcut no-op | #64 | DONE | Shortcut command behavior only |
-| P0 | Fix duplicate action sound playback | #65 | TODO | Sound trigger dedup only |
+| P0 | Fix duplicate action sound playback | #65 | DONE | Sound trigger dedup only |
 | P0 | Fix malformed Groq status handling and diagnostics | #66 | CANCELED | Provider error parsing only |
 | P1 | Add ElevenLabs scribe_v1 model support | #67 | CANCELED | STT allowlist/adapter/model path only |
 | P1 | Support per-provider STT/LLM base URL overrides | #68 | TODO | Settings + resolver override mapping only |
@@ -91,7 +91,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [x] Add positive and regression tests.
 
 ### #65 - [P0] Fix duplicate action sound playback
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Play each required sound exactly once per event.
 - Constraints:
   - Must preserve required sound events (`specs/spec.md:190-197`).
@@ -100,9 +100,9 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - Each required sound event is emitted exactly once per user action.
   - No required event sound is lost while deduplicating.
 - Tasks:
-  - [ ] Identify duplicate listeners/invocations.
-  - [ ] Deduplicate sound triggers in renderer/main flows.
-  - [ ] Add tests asserting single invocation per event.
+  - [x] Identify duplicate listeners/invocations.
+  - [x] Deduplicate sound triggers in renderer/main flows.
+  - [x] Add tests asserting single invocation per event.
 
 ### #66 - [P0] Fix malformed Groq status handling and diagnostics
 - Status: `CANCELED`

--- a/src/main/services/sound-service.test.ts
+++ b/src/main/services/sound-service.test.ts
@@ -27,25 +27,14 @@ describe('ElectronSoundService', () => {
     vi.useRealTimers()
   })
 
-  it('plays a single beep for recording_started', () => {
+  it.each(ALL_EVENTS)('plays exactly one beep for %s', (event) => {
     vi.useFakeTimers()
     const beep = vi.fn()
     const service = new ElectronSoundService(beep)
 
-    service.play('recording_started')
+    service.play(event)
     vi.runAllTimers()
 
     expect(beep).toHaveBeenCalledTimes(1)
-  })
-
-  it('plays multi-beep pattern for transformation_failed', () => {
-    vi.useFakeTimers()
-    const beep = vi.fn()
-    const service = new ElectronSoundService(beep)
-
-    service.play('transformation_failed')
-    vi.runAllTimers()
-
-    expect(beep).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/main/services/sound-service.ts
+++ b/src/main/services/sound-service.ts
@@ -1,6 +1,6 @@
 // src/main/services/sound-service.ts
 // Interface and concrete implementation for sound notifications.
-// Phase 6: use Electron shell.beep() with event-specific beep patterns.
+// Phase 6: use Electron shell.beep() with exactly one beep per event.
 
 import { shell } from 'electron'
 import type { SoundEvent } from '../../shared/ipc'
@@ -18,10 +18,10 @@ export class NoopSoundService implements SoundService {
 
 const SOUND_EVENT_DELAYS_MS: Record<SoundEvent, readonly number[]> = {
   recording_started: [0],
-  recording_stopped: [0, 120],
-  recording_cancelled: [0, 90, 180],
+  recording_stopped: [0],
+  recording_cancelled: [0],
   transformation_succeeded: [0],
-  transformation_failed: [0, 110, 220]
+  transformation_failed: [0]
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize sound playback to one beep per action event
- remove multi-beep delay patterns for stop/cancel/transformation-failed events
- strengthen tests to assert exactly one beep per supported sound event
- update execution plan status for #65

## Root cause
Duplicate/"3x" playback came from intentional multi-beep patterns in `ElectronSoundService` (`recording_stopped`, `recording_cancelled`, `transformation_failed`).

## Validation
- `pnpm exec vitest run /workspace/src/main/services/sound-service.test.ts` passed.

## Scope
- `src/main/services/sound-service.ts`
- `src/main/services/sound-service.test.ts`
- `docs/p0-p1-p2-react-execution-plan.md`
