### PR TITLE
feat: support per-provider STT/LLM base URL overrides

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -29,7 +29,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P0 | Fix duplicate action sound playback | #65 | DONE | Sound trigger dedup only |
 | P0 | Fix malformed Groq status handling and diagnostics | #66 | CANCELED | Provider error parsing only |
 | P1 | Add ElevenLabs scribe_v1 model support | #67 | CANCELED | STT allowlist/adapter/model path only |
-| P1 | Support per-provider STT/LLM base URL overrides | #68 | TODO | Settings + resolver override mapping only |
+| P1 | Support per-provider STT/LLM base URL overrides | #68 | DONE | Settings + resolver override mapping only |
 | P1 | Add structured error logging policy (main + renderer) | #69 | TODO | Logging/redaction/diagnostics only |
 | P2 | Resolve pick-and-run persistence spec conflict | #70 | TODO | Decision/spec alignment only |
 | P2 | Add dedicated transformation profile picker window UX | #71 | TODO | Picker UX only (depends on #70) |
@@ -132,16 +132,16 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [ ] Add tests for supported and rejected combinations.
 
 ### #68 - [P1] Support per-provider STT/LLM base URL overrides
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Configure overrides per provider for STT/LLM.
 - Constraints:
   - STT override rules (`specs/spec.md:270-272`).
   - LLM override rules (`specs/spec.md:308-310`).
 - Tasks:
-  - [ ] Extend settings model for provider-level overrides.
-  - [ ] Update resolver/request routing.
-  - [ ] Update settings UI + validation.
-  - [ ] Add resolver and integration tests.
+  - [x] Extend settings model for provider-level overrides.
+  - [x] Update resolver/request routing.
+  - [x] Update settings UI + validation.
+  - [x] Add resolver and integration tests.
 
 ### #69 - [P1] Add structured error logging policy (main + renderer)
 - Status: `TODO`

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -160,11 +160,19 @@ describe('CommandRouter', () => {
     const settings = makeSettings({
       transcription: {
         ...DEFAULT_SETTINGS.transcription,
-        baseUrlOverride: 'https://stt-proxy.local'
+        baseUrlOverrides: {
+          ...DEFAULT_SETTINGS.transcription.baseUrlOverrides,
+          groq: 'https://stt-proxy.local'
+        },
+        baseUrlOverride: null
       },
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        baseUrlOverride: 'https://llm-proxy.local'
+        baseUrlOverrides: {
+          ...DEFAULT_SETTINGS.transformation.baseUrlOverrides,
+          google: 'https://llm-proxy.local'
+        },
+        baseUrlOverride: null
       }
     })
     const deps = makeDeps({

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -10,7 +10,7 @@
 
 import { randomUUID } from 'node:crypto'
 import type { AudioInputSource, CompositeTransformResult, RecordingCommand, RecordingCommandDispatch } from '../../shared/ipc'
-import type { Settings, TransformationPreset } from '../../shared/domain'
+import { resolveLlmBaseUrlOverride, resolveSttBaseUrlOverride, type Settings, type TransformationPreset } from '../../shared/domain'
 import type { CaptureResult } from '../services/capture-types'
 import type { RecordingOrchestrator } from '../orchestrators/recording-orchestrator'
 import type { CaptureQueue } from '../queues/capture-queue'
@@ -159,7 +159,7 @@ export class CommandRouter {
       profileId: preset.id,
       provider: preset.provider,
       model: preset.model,
-      baseUrlOverride: settings.transformation.baseUrlOverride,
+      baseUrlOverride: resolveLlmBaseUrlOverride(settings, preset.provider),
       systemPrompt: preset.systemPrompt,
       userPrompt: preset.userPrompt,
       outputRule: settings.output.transformed
@@ -187,7 +187,7 @@ export class CommandRouter {
       audioFilePath: capture.audioFilePath,
       sttProvider: settings.transcription.provider,
       sttModel: settings.transcription.model,
-      sttBaseUrlOverride: settings.transcription.baseUrlOverride,
+      sttBaseUrlOverride: resolveSttBaseUrlOverride(settings, settings.transcription.provider),
       outputLanguage: settings.transcription.outputLanguage,
       temperature: settings.transcription.temperature,
       transformationProfile: profile,
@@ -216,7 +216,7 @@ export class CommandRouter {
       profileId: preset.id,
       provider: preset.provider,
       model: preset.model,
-      baseUrlOverride: settings.transformation.baseUrlOverride,
+      baseUrlOverride: resolveLlmBaseUrlOverride(settings, preset.provider),
       systemPrompt: preset.systemPrompt,
       userPrompt: preset.userPrompt
     }
@@ -258,7 +258,7 @@ export class CommandRouter {
       audioFilePath: '',
       sttProvider: settings.transcription.provider,
       sttModel: settings.transcription.model,
-      sttBaseUrlOverride: settings.transcription.baseUrlOverride,
+      sttBaseUrlOverride: resolveSttBaseUrlOverride(settings, settings.transcription.provider),
       outputLanguage: settings.transcription.outputLanguage,
       temperature: settings.transcription.temperature,
       transformationProfile: null,

--- a/src/main/orchestrators/processing-orchestrator.test.ts
+++ b/src/main/orchestrators/processing-orchestrator.test.ts
@@ -251,11 +251,19 @@ describe('ProcessingOrchestrator', () => {
       ...baseSettings,
       transcription: {
         ...baseSettings.transcription,
-        baseUrlOverride: 'https://stt-proxy.local'
+        baseUrlOverrides: {
+          ...baseSettings.transcription.baseUrlOverrides,
+          groq: 'https://stt-proxy.local'
+        },
+        baseUrlOverride: null
       },
       transformation: {
         ...baseSettings.transformation,
-        baseUrlOverride: 'https://llm-proxy.local'
+        baseUrlOverrides: {
+          ...baseSettings.transformation.baseUrlOverrides,
+          google: 'https://llm-proxy.local'
+        },
+        baseUrlOverride: null
       }
     }
     const transcribe = vi.fn(async () => ({

--- a/src/main/orchestrators/processing-orchestrator.ts
+++ b/src/main/orchestrators/processing-orchestrator.ts
@@ -1,5 +1,6 @@
 import type { TerminalJobStatus } from '../../shared/domain'
 import type { Settings, TransformationPreset } from '../../shared/domain'
+import { resolveLlmBaseUrlOverride, resolveSttBaseUrlOverride } from '../../shared/domain'
 import type { QueueJobRecord } from '../services/job-queue-service'
 import { HistoryService } from '../services/history-service'
 import { OutputService } from '../services/output-service'
@@ -91,7 +92,7 @@ export class ProcessingOrchestrator {
           provider: settings.transcription.provider,
           model: settings.transcription.model,
           apiKey: transcriptionApiKey,
-          baseUrlOverride: settings.transcription.baseUrlOverride,
+          baseUrlOverride: resolveSttBaseUrlOverride(settings, settings.transcription.provider),
           audioFilePath: job.audioFilePath,
           language: settings.transcription.outputLanguage,
           temperature: settings.transcription.temperature
@@ -113,7 +114,7 @@ export class ProcessingOrchestrator {
             text: transcriptText,
             apiKey: transformationApiKey,
             model: defaultPreset.model,
-            baseUrlOverride: settings.transformation.baseUrlOverride,
+            baseUrlOverride: resolveLlmBaseUrlOverride(settings, defaultPreset.provider),
             prompt: {
               systemPrompt: defaultPreset.systemPrompt,
               userPrompt: defaultPreset.userPrompt

--- a/src/main/orchestrators/transformation-orchestrator.ts
+++ b/src/main/orchestrators/transformation-orchestrator.ts
@@ -4,6 +4,7 @@ import { SecretStore } from '../services/secret-store'
 import { SettingsService } from '../services/settings-service'
 import { TransformationService } from '../services/transformation-service'
 import type { Settings, TransformationPreset } from '../../shared/domain'
+import { resolveLlmBaseUrlOverride } from '../../shared/domain'
 
 interface CompositeResult {
   status: 'ok' | 'error'
@@ -73,7 +74,7 @@ export class TransformationOrchestrator {
         text: clipboardText,
         apiKey,
         model: preset.model,
-        baseUrlOverride: settings.transformation.baseUrlOverride,
+        baseUrlOverride: resolveLlmBaseUrlOverride(settings, preset.provider),
         prompt: {
           systemPrompt: preset.systemPrompt,
           userPrompt: preset.userPrompt

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,5 +1,5 @@
 import './styles.css'
-import { DEFAULT_SETTINGS, STT_MODEL_ALLOWLIST, type Settings } from '../shared/domain'
+import { DEFAULT_SETTINGS, resolveLlmBaseUrlOverride, resolveSttBaseUrlOverride, STT_MODEL_ALLOWLIST, type Settings } from '../shared/domain'
 import type {
   ApiKeyProvider,
   ApiKeyStatusSnapshot,
@@ -763,7 +763,7 @@ const renderSettingsPanel = (settings: Settings, apiKeyStatus: ApiKeyStatusSnaps
             id="settings-transcription-base-url"
             type="url"
             placeholder="https://stt-proxy.local"
-            value="${escapeHtml(settings.transcription.baseUrlOverride ?? '')}"
+            value="${escapeHtml(resolveSttBaseUrlOverride(settings, settings.transcription.provider) ?? '')}"
           />
         </label>
         <p class="field-error" id="settings-error-transcription-base-url">${renderSettingsFieldError('transcriptionBaseUrl')}</p>
@@ -776,7 +776,7 @@ const renderSettingsPanel = (settings: Settings, apiKeyStatus: ApiKeyStatusSnaps
             id="settings-transformation-base-url"
             type="url"
             placeholder="https://llm-proxy.local"
-            value="${escapeHtml(settings.transformation.baseUrlOverride ?? '')}"
+            value="${escapeHtml(resolveLlmBaseUrlOverride(settings, activePreset?.provider ?? 'google') ?? '')}"
           />
         </label>
         <p class="field-error" id="settings-error-transformation-base-url">${renderSettingsFieldError('transformationBaseUrl')}</p>
@@ -1362,6 +1362,11 @@ const wireActions = (): void => {
         autoRunDefaultTransform: app?.querySelector<HTMLInputElement>('#settings-transform-auto-run')?.checked ?? false,
         activePresetId: activePresetId || state.settings.transformation.activePresetId,
         defaultPresetId: defaultPresetId || state.settings.transformation.defaultPresetId,
+        baseUrlOverrides: {
+          ...state.settings.transformation.baseUrlOverrides,
+          [updatedActivePreset.provider]: formValidation.normalized.transformationBaseUrlOverride
+        },
+        // Deprecated scalar mirror for compatibility with legacy consumers.
         baseUrlOverride: formValidation.normalized.transformationBaseUrlOverride,
         presets: updatedPresets
       },
@@ -1369,6 +1374,11 @@ const wireActions = (): void => {
         ...state.settings.transcription,
         provider: selectedTranscriptionProvider,
         model: selectedTranscriptionModel,
+        baseUrlOverrides: {
+          ...state.settings.transcription.baseUrlOverrides,
+          [selectedTranscriptionProvider]: formValidation.normalized.transcriptionBaseUrlOverride
+        },
+        // Deprecated scalar mirror for compatibility with legacy consumers.
         baseUrlOverride: formValidation.normalized.transcriptionBaseUrlOverride
       },
       shortcuts: {


### PR DESCRIPTION
## Summary
- add provider-scoped settings fields for STT/LLM base URL overrides
- add domain resolver helpers with legacy scalar fallback compatibility
- migrate persisted legacy scalar override values into provider maps on settings load
- update command routing/orchestrators and renderer settings wiring to use provider-specific overrides
- add/update tests for routing and migration behavior
- mark #68 as DONE in execution plan

## Validation
- pnpm run typecheck
- pnpm exec vitest run src/main/services/settings-service.test.ts src/main/core/command-router.test.ts src/main/orchestrators/processing-orchestrator.test.ts --exclude '.worktrees/**' --exclude '.pnpm-store/**'

## Notes
- Groq connectivity can fail when traffic is forced through VPN; split-tunnel/allowlist api.groq.com when testing provider connectivity.