### PR TITLE
feat: add structured redacted error logging policy

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -30,7 +30,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P0 | Fix malformed Groq status handling and diagnostics | #66 | CANCELED | Provider error parsing only |
 | P1 | Add ElevenLabs scribe_v1 model support | #67 | CANCELED | STT allowlist/adapter/model path only |
 | P1 | Support per-provider STT/LLM base URL overrides | #68 | DONE | Settings + resolver override mapping only |
-| P1 | Add structured error logging policy (main + renderer) | #69 | TODO | Logging/redaction/diagnostics only |
+| P1 | Add structured error logging policy (main + renderer) | #69 | DONE | Logging/redaction/diagnostics only |
 | P2 | Resolve pick-and-run persistence spec conflict | #70 | TODO | Decision/spec alignment only |
 | P2 | Add dedicated transformation profile picker window UX | #71 | TODO | Picker UX only (depends on #70) |
 | P2 | Implement safe autosave for selected settings controls | #72 | TODO | Settings autosave behavior only |
@@ -144,15 +144,15 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [x] Add resolver and integration tests.
 
 ### #69 - [P1] Add structured error logging policy (main + renderer)
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Introduce consistent, redacted logs for actionable diagnostics.
 - Constraints:
   - Must not leak API keys/secrets.
   - Must complement user-facing error clarity (`specs/spec.md:549-560`).
 - Tasks:
-  - [ ] Define logging levels and redact rules.
-  - [ ] Add logging hooks in main/renderer critical paths.
-  - [ ] Add checks/tests for redaction and key error classes.
+  - [x] Define logging levels and redact rules.
+  - [x] Add logging hooks in main/renderer critical paths.
+  - [x] Add checks/tests for redaction and key error classes.
 
 ---
 

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -17,6 +17,7 @@ import {
   type SoundEvent
 } from '../../shared/ipc'
 import type { Settings } from '../../shared/domain'
+import { logStructured } from '../../shared/error-logging'
 import { SettingsService } from '../services/settings-service'
 import { RecordingOrchestrator } from '../orchestrators/recording-orchestrator'
 import { HistoryService } from '../services/history-service'
@@ -135,7 +136,17 @@ const hotkeyService = new HotkeyService({
       combo: payload.combo,
       message: payload.message
     }
-    console.error(`Global shortcut failed [${payload.combo} -> ${payload.accelerator}]: ${payload.message}`)
+    logStructured({
+      level: 'error',
+      scope: 'main',
+      event: 'hotkey.dispatch_failed',
+      message: 'Global shortcut dispatch failed.',
+      context: {
+        combo: payload.combo,
+        accelerator: payload.accelerator,
+        detail: payload.message
+      }
+    })
     broadcastHotkeyError(notification)
   }
 })

--- a/src/shared/error-logging.test.ts
+++ b/src/shared/error-logging.test.ts
@@ -1,0 +1,83 @@
+// Where: src/shared/error-logging.test.ts
+// What:  Unit tests for structured logging + redaction behavior.
+// Why:   Prevent secret leakage while keeping logs actionable.
+
+import { describe, expect, it, vi } from 'vitest'
+import { buildStructuredLogEntry, logStructured } from './error-logging'
+
+describe('error-logging', () => {
+  it('redacts sensitive keys and inline token-like values from context', () => {
+    const entry = buildStructuredLogEntry({
+      level: 'error',
+      scope: 'main',
+      event: 'test.redaction',
+      context: {
+        provider: 'groq',
+        apiKey: 'sk-live-123456789',
+        nested: {
+          authorization: 'Bearer abcdefghijklmnop',
+          note: 'token=abcd1234'
+        }
+      }
+    })
+
+    const serialized = JSON.stringify(entry)
+    expect(serialized).not.toContain('sk-live-123456789')
+    expect(serialized).not.toContain('Bearer abcdefghijklmnop')
+    expect(serialized).not.toContain('abcd1234')
+    expect(serialized).toContain('[REDACTED]')
+  })
+
+  it('redacts error message content before emitting', () => {
+    const error = new Error('Upstream failed: api_key=secret-value')
+    const entry = buildStructuredLogEntry({
+      level: 'error',
+      scope: 'renderer',
+      event: 'test.error',
+      error
+    })
+
+    expect(entry.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('[REDACTED]')
+      })
+    )
+    expect(JSON.stringify(entry.error)).not.toContain('secret-value')
+  })
+
+  it('routes output to console.error for error level logs', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logStructured({
+      level: 'error',
+      scope: 'main',
+      event: 'pipeline.failed',
+      message: 'apiKey=abc'
+    })
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0]?.[0]).toContain('[REDACTED]')
+    spy.mockRestore()
+  })
+
+  it('keeps error class name in structured output for diagnosis', () => {
+    class ApiAuthError extends Error {
+      constructor(message: string) {
+        super(message)
+        this.name = 'ApiAuthError'
+      }
+    }
+
+    const entry = buildStructuredLogEntry({
+      level: 'error',
+      scope: 'main',
+      event: 'adapter.auth_failed',
+      error: new ApiAuthError('status 401')
+    })
+
+    expect(entry.error).toEqual(
+      expect.objectContaining({
+        name: 'ApiAuthError',
+        message: 'status 401'
+      })
+    )
+  })
+})

--- a/src/shared/error-logging.ts
+++ b/src/shared/error-logging.ts
@@ -1,0 +1,87 @@
+// Where: src/shared/error-logging.ts
+// What:  Structured logging helpers with sensitive-data redaction.
+// Why:   Enforce a consistent observability policy across main + renderer.
+
+export type LogLevel = 'error' | 'warn' | 'info'
+export type LogScope = 'main' | 'renderer'
+
+export interface StructuredLogInput {
+  level: LogLevel
+  scope: LogScope
+  event: string
+  message?: string
+  error?: unknown
+  context?: Record<string, unknown>
+}
+
+const REDACTED = '[REDACTED]'
+const SENSITIVE_KEY_PATTERN = /(api[_-]?key|token|secret|password|authorization)/i
+const TOKEN_PATTERNS: RegExp[] = [
+  /(bearer\s+)[a-z0-9._-]+/gi,
+  /\b(sk-[a-z0-9_-]{8,})\b/gi,
+  /\b(AIza[a-z0-9_-]{8,})\b/gi
+]
+
+const redactSensitiveString = (input: string): string => {
+  let output = input
+  output = output.replace(
+    /((?:api[_ -]?key|token|secret|password|authorization)\s*[:=]\s*)[^\s,;]+/gi,
+    `$1${REDACTED}`
+  )
+  for (const pattern of TOKEN_PATTERNS) {
+    output = output.replace(pattern, REDACTED)
+  }
+  return output
+}
+
+const redactValue = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    return redactSensitiveString(value)
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item))
+  }
+  if (value && typeof value === 'object') {
+    const next: Record<string, unknown> = {}
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      next[key] = SENSITIVE_KEY_PATTERN.test(key) ? REDACTED : redactValue(item)
+    }
+    return next
+  }
+  return value
+}
+
+const getErrorShape = (error: unknown): Record<string, unknown> | null => {
+  if (!(error instanceof Error)) {
+    return null
+  }
+  return {
+    name: error.name,
+    message: redactSensitiveString(error.message),
+    stack: typeof error.stack === 'string' ? redactSensitiveString(error.stack) : undefined
+  }
+}
+
+export const buildStructuredLogEntry = (input: StructuredLogInput): Record<string, unknown> => ({
+  timestamp: new Date().toISOString(),
+  level: input.level,
+  scope: input.scope,
+  event: input.event,
+  message: redactSensitiveString(input.message ?? ''),
+  context: redactValue(input.context ?? {}),
+  error: getErrorShape(input.error)
+})
+
+export const logStructured = (input: StructuredLogInput): void => {
+  const entry = buildStructuredLogEntry(input)
+  const serialized = JSON.stringify(entry)
+  if (input.level === 'error') {
+    console.error(serialized)
+    return
+  }
+  if (input.level === 'warn') {
+    console.warn(serialized)
+    return
+  }
+  console.info(serialized)
+}


### PR DESCRIPTION
## Summary
- add shared structured logger for main/renderer with log levels and redaction policy
- redact sensitive key/token patterns in messages, context objects, and error payloads
- add structured logging hooks in critical main paths (hotkey dispatch, capture/transform pipelines, processing orchestrator)
- add structured logging hooks in critical renderer catch paths (recording, transform, settings/API-key save, initialization)
- add unit tests for redaction, console routing, and error class capture
- mark #69 as DONE in execution plan

## Validation
- pnpm run typecheck
- pnpm exec vitest run src/shared/error-logging.test.ts src/main/orchestrators/capture-pipeline.test.ts src/main/orchestrators/transform-pipeline.test.ts src/main/orchestrators/processing-orchestrator.test.ts --exclude '.worktrees/**' --exclude '.pnpm-store/**'
