### PR TITLE
docs: resolve pick-and-run persistence decision (#70)

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -31,7 +31,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P1 | Add ElevenLabs scribe_v1 model support | #67 | CANCELED | STT allowlist/adapter/model path only |
 | P1 | Support per-provider STT/LLM base URL overrides | #68 | DONE | Settings + resolver override mapping only |
 | P1 | Add structured error logging policy (main + renderer) | #69 | DONE | Logging/redaction/diagnostics only |
-| P2 | Resolve pick-and-run persistence spec conflict | #70 | TODO | Decision/spec alignment only |
+| P2 | Resolve pick-and-run persistence spec conflict | #70 | DONE | Decision/spec alignment only |
 | P2 | Add dedicated transformation profile picker window UX | #71 | TODO | Picker UX only (depends on #70) |
 | P2 | Implement safe autosave for selected settings controls | #72 | TODO | Settings autosave behavior only |
 | P2 | Simplify Home by removing shortcut reference panel | #73 | TODO | Home UX simplification only |
@@ -159,14 +159,15 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 ## P2 Tickets
 
 ### #70 - [P2] Resolve pick-and-run persistence spec conflict
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Resolve mismatch between user feedback and current normative behavior.
 - Constraints:
   - Current spec mandates persistence (`specs/spec.md:176`).
 - Tasks:
-  - [ ] Record decision: persistent vs one-time behavior.
-  - [ ] If decision changes behavior, prepare spec update PR.
-  - [ ] Create/update implementation follow-up constraints for #71.
+  - [x] Record decision: persistent vs one-time behavior.
+  - [x] If decision changes behavior, prepare spec update PR. (N/A: behavior unchanged; clarity update only)
+  - [x] Create/update implementation follow-up constraints for #71.
+  - Follow-up issue: #83 (clarify persistence in user-facing copy).
 
 ### #71 - [P2] Dedicated transformation profile picker window UX
 - Status: `TODO`

--- a/specs/decision-pick-and-run-persistence.md
+++ b/specs/decision-pick-and-run-persistence.md
@@ -1,0 +1,35 @@
+<!--
+Where: specs/decision-pick-and-run-persistence.md
+What: Decision record for pick-and-run active-profile persistence behavior.
+Why: Resolve #70 conflict between user feedback and current normative spec.
+-->
+
+# Decision: pick-and-run active profile persistence
+
+- Date: 2026-02-19
+- Issue: #70
+- Status: Accepted
+
+## Decision
+
+`pickAndRunTransformation` remains **persistent**:
+
+1. User picks a profile.
+2. System updates `transformation.activePresetId` to the picked profile.
+3. Transformation executes with the picked profile.
+4. The picked profile remains active for subsequent active-target shortcuts.
+
+This is not one-time behavior.
+
+## Rationale
+
+- Current behavior and tests already enforce persistent active-profile updates.
+- Persistence keeps `pickAndRunTransformation`, `runTransformationOnSelection`, and
+  `changeDefaultTransformation` semantically consistent around the active profile.
+- Avoids introducing hidden temporary state that would increase shortcut ambiguity.
+
+## Consequences
+
+- No implementation change is required for #70.
+- Spec wording is clarified to explicitly call out persistence.
+- Follow-up work should improve user-facing copy so persistence is obvious.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -174,6 +174,7 @@ Transformation shortcut semantics:
 - `runDefaultTransformation` **MUST** execute with `transformationProfiles.defaultProfileId` when set.
 - if `transformationProfiles.defaultProfileId` is `null`, `runDefaultTransformation` **MUST NOT** invoke LLM transformation and **MUST** return a non-error skipped outcome.
 - `pickAndRunTransformation` **MUST** update `transformationProfiles.activeProfileId` to user-picked profile before execution, then execute using that active profile.
+- The `pickAndRunTransformation` active-profile update is **persistent** for subsequent active-target shortcuts (not one-time).
 - `changeDefaultTransformation` **MUST** set `transformationProfiles.defaultProfileId` to current `activeProfileId` without executing transformation.
 - `runTransformationOnSelection` **MUST** execute using current `activeProfileId`; if no selection text exists, it **MUST** fail with actionable user feedback.
 - when a transformation shortcut executes during active recording, execution **MUST** start immediately in parallel and **MUST NOT** wait for current recording job completion.


### PR DESCRIPTION
## Summary
- record explicit decision for #70: pick-and-run remains persistent (not one-time)
- add decision record: specs/decision-pick-and-run-persistence.md
- clarify persistence wording in specs/spec.md
- mark #70 DONE in execution plan and link follow-up issue #83 for UX copy clarity

## Validation
- pnpm exec vitest run src/main/services/hotkey-service.test.ts --exclude '.worktrees/**' --exclude '.pnpm-store/**'

## Follow-up
- #83 clarifies user-facing copy so persistence is obvious in the UI