### PR TITLE
feat: add dedicated transformation profile picker window

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -32,7 +32,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P1 | Support per-provider STT/LLM base URL overrides | #68 | DONE | Settings + resolver override mapping only |
 | P1 | Add structured error logging policy (main + renderer) | #69 | DONE | Logging/redaction/diagnostics only |
 | P2 | Resolve pick-and-run persistence spec conflict | #70 | DONE | Decision/spec alignment only |
-| P2 | Add dedicated transformation profile picker window UX | #71 | TODO | Picker UX only (depends on #70) |
+| P2 | Add dedicated transformation profile picker window UX | #71 | DONE | Picker UX only (depends on #70) |
 | P2 | Implement safe autosave for selected settings controls | #72 | TODO | Settings autosave behavior only |
 | P2 | Simplify Home by removing shortcut reference panel | #73 | TODO | Home UX simplification only |
 | R0 | React kickoff: bootstrap renderer root with parity | #74 | TODO | React bootstrap with zero feature change |
@@ -170,15 +170,15 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - Follow-up issue: #83 (clarify persistence in user-facing copy).
 
 ### #71 - [P2] Dedicated transformation profile picker window UX
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Provide dedicated picker UX if approved by #70 decision.
 - Constraints:
   - Depends on #70.
   - Must preserve shortcut responsiveness/non-blocking behavior (`specs/spec.md:179`, `specs/spec.md:209-225`).
 - Tasks:
-  - [ ] Define UX flow and behavior contract.
-  - [ ] Implement picker window and command integration.
-  - [ ] Add e2e coverage for picker flow.
+  - [x] Define UX flow and behavior contract.
+  - [x] Implement picker window and command integration.
+  - [x] Add e2e coverage for picker flow.
 
 ### #72 - [P2] Safe autosave for selected settings controls
 - Status: `TODO`

--- a/specs/h2-design-pick-and-run-transformation-ux.md
+++ b/specs/h2-design-pick-and-run-transformation-ux.md
@@ -7,7 +7,7 @@ Why: Phase 3A pre-requisite H2. Determines how the user explicitly picks a trans
 
 # H2 — Design: `pickAndRunTransformation` Profile Picker UX
 
-**Status:** Decision document
+**Status:** Superseded by `specs/h3-dedicated-profile-picker-window-ux.md`
 **Date:** 2026-02-17
 **Phase:** 3A pre-requisite
 

--- a/specs/h3-dedicated-profile-picker-window-ux.md
+++ b/specs/h3-dedicated-profile-picker-window-ux.md
@@ -1,0 +1,42 @@
+<!--
+Where: specs/h3-dedicated-profile-picker-window-ux.md
+What: Behavior contract for dedicated transformation profile picker window UX.
+Why: Align #71 implementation with predictable pick-and-run shortcut behavior.
+-->
+
+# H3 — Dedicated Profile Picker Window UX
+
+**Status:** Accepted  
+**Date:** 2026-02-19  
+**Issue:** #71
+
+## Goal
+
+When `pickTransformation` shortcut fires, open a dedicated picker window, let user choose a profile, then run transformation with that profile.
+
+## UX Contract
+
+1. Picker opens in a dedicated always-on-top BrowserWindow.
+2. Picker displays all transformation profiles with active-state hinting.
+3. Keyboard controls:
+  - Up/Down selects profile.
+  - Enter confirms selected profile.
+  - Escape cancels and closes picker.
+4. Mouse click on a profile confirms selection.
+5. On confirm:
+  - `transformation.activePresetId` is updated to chosen profile.
+  - shortcut flow runs clipboard transformation using selected profile.
+6. On cancel:
+  - no settings write.
+  - no transformation run.
+
+## Non-Blocking Requirements
+
+- Shortcut callback remains async and does not block recording flows.
+- In-flight transform requests keep their own snapshot semantics.
+
+## Test Coverage
+
+- Unit: picker window selection/cancel behavior.
+- Unit: hotkey pick-and-run semantics remain stable.
+- E2E: pick shortcut opens picker window and selection updates active preset.

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -6,7 +6,7 @@
  *        with SerialOutputCoordinator for ordered output commits.
  */
 
-import { BrowserWindow, ipcMain, globalShortcut, Menu } from 'electron'
+import { BrowserWindow, ipcMain, globalShortcut } from 'electron'
 import {
   IPC_CHANNELS,
   type ApiKeyProvider,
@@ -51,7 +51,9 @@ const networkCompatibilityService = new NetworkCompatibilityService()
 const soundService = new ElectronSoundService()
 const clipboardClient = new ClipboardClient()
 const selectionClient = new SelectionClient({ clipboard: clipboardClient })
-const profilePickerService = new ProfilePickerService(Menu)
+const profilePickerService = new ProfilePickerService({
+  create: (options) => new BrowserWindow(options)
+})
 const apiKeyConnectionService = new ApiKeyConnectionService()
 
 // --- Broadcast helpers (defined early so they can be used by pipeline wiring) ---
@@ -189,6 +191,7 @@ export const registerIpcHandlers = (): void => {
     }
   )
   ipcMain.handle(IPC_CHANNELS.runCompositeTransformFromClipboard, async () => commandRouter.runCompositeFromClipboard())
+  ipcMain.handle(IPC_CHANNELS.runPickTransformationFromClipboard, async () => hotkeyService.runPickAndRunTransform())
 
   hotkeyService.registerFromSettings()
 }

--- a/src/main/services/hotkey-service.ts
+++ b/src/main/services/hotkey-service.ts
@@ -131,7 +131,7 @@ export class HotkeyService {
       { action: 'cancelRecording', combo: shortcuts.cancelRecording, run: () => this.runRecordingCommand('cancelRecording') },
       { action: 'runTransform', combo: shortcuts.runTransform, run: () => this.runTransform() },
       { action: 'runTransformOnSelection', combo: shortcuts.runTransformOnSelection, run: () => this.runTransformOnSelection() },
-      { action: 'pickTransformation', combo: shortcuts.pickTransformation, run: () => this.pickAndRunTransform() },
+      { action: 'pickTransformation', combo: shortcuts.pickTransformation, run: () => this.runPickAndRunTransform() },
       { action: 'changeTransformationDefault', combo: shortcuts.changeTransformationDefault, run: () => this.changeDefaultTransform() }
     ]
 
@@ -193,7 +193,7 @@ export class HotkeyService {
     this.onCompositeResult?.(result)
   }
 
-  private async pickAndRunTransform(): Promise<void> {
+  async runPickAndRunTransform(): Promise<void> {
     const settings = this.settingsService.getSettings()
     const presets = settings.transformation.presets
     if (presets.length === 0) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,7 @@ const api: IpcApi = {
     }
   },
   runCompositeTransformFromClipboard: async () => ipcRenderer.invoke(IPC_CHANNELS.runCompositeTransformFromClipboard),
+  runPickTransformationFromClipboard: async () => ipcRenderer.invoke(IPC_CHANNELS.runPickTransformationFromClipboard),
   onCompositeTransformStatus: (listener: (result: CompositeTransformResult) => void) => {
     const handler = (_event: unknown, result: CompositeTransformResult) => listener(result)
     ipcRenderer.on(IPC_CHANNELS.onCompositeTransformStatus, handler)

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -62,6 +62,7 @@ export interface IpcApi {
   submitRecordedAudio: (payload: { data: Uint8Array; mimeType: string; capturedAt: string }) => Promise<void>
   onRecordingCommand: (listener: (dispatch: RecordingCommandDispatch) => void) => () => void
   runCompositeTransformFromClipboard: () => Promise<CompositeTransformResult>
+  runPickTransformationFromClipboard: () => Promise<void>
   onCompositeTransformStatus: (listener: (result: CompositeTransformResult) => void) => () => void
   onHotkeyError: (listener: (notification: HotkeyErrorNotification) => void) => () => void
 }
@@ -80,6 +81,7 @@ export const IPC_CHANNELS = {
   submitRecordedAudio: 'recording:submit-recorded-audio',
   onRecordingCommand: 'recording:on-command',
   runCompositeTransformFromClipboard: 'transform:composite-from-clipboard',
+  runPickTransformationFromClipboard: 'transform:pick-and-run-from-clipboard',
   onCompositeTransformStatus: 'transform:composite-status',
   onHotkeyError: 'hotkey:error'
 } as const


### PR DESCRIPTION
## Summary
- replace menu-based profile picker with dedicated BrowserWindow picker UX
- keep pick-and-run semantics unchanged: selected profile becomes active, then transform runs
- add deterministic picker invocation IPC (`runPickTransformationFromClipboard`) to exercise the same hotkey pick path in tests
- add picker window UX contract doc and mark #71 done in execution plan
- add/update tests for picker lifecycle and e2e picker flow

## Validation
- pnpm run typecheck
- pnpm exec vitest run src/main/services/profile-picker-service.test.ts src/main/services/hotkey-service.test.ts src/main/test-support/ipc-round-trip.test.ts --exclude '.worktrees/**' --exclude '.pnpm-store/**'
- xvfb-run -a pnpm exec playwright test e2e/electron-ui.e2e.ts --grep "opens dedicated picker window for pick-and-run shortcut"
