### PR TITLE
feat: simplify Home by removing shortcut reference panel

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -34,7 +34,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 | P2 | Resolve pick-and-run persistence spec conflict | #70 | DONE | Decision/spec alignment only |
 | P2 | Add dedicated transformation profile picker window UX | #71 | DONE | Picker UX only (depends on #70) |
 | P2 | Implement safe autosave for selected settings controls | #72 | DONE | Settings autosave behavior only |
-| P2 | Simplify Home by removing shortcut reference panel | #73 | TODO | Home UX simplification only |
+| P2 | Simplify Home by removing shortcut reference panel | #73 | DONE | Home UX simplification only |
 | R0 | React kickoff: bootstrap renderer root with parity | #74 | TODO | React bootstrap with zero feature change |
 | R0 | React phase 1: migrate Home page with behavior parity | #75 | TODO | Home-only React migration |
 
@@ -195,14 +195,14 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [x] Verify shortcuts page/config behavior remains as-is.
 
 ### #73 - [P2] Remove shortcut reference panel from Home
-- Status: `TODO`
+- Status: `DONE`
 - Goal: Simplify Home UX without harming discoverability.
 - Constraints:
   - Must keep required shortcut affordances discoverable.
 - Tasks:
-  - [ ] Remove Home shortcut panel and adjust layout.
-  - [ ] Ensure guidance remains available from Settings/help surfaces.
-  - [ ] Update e2e assertions and docs snapshots.
+  - [x] Remove Home shortcut panel and adjust layout.
+  - [x] Ensure guidance remains available from Settings/help surfaces.
+  - [x] Update e2e assertions and docs snapshots.
 
 ---
 

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -86,6 +86,7 @@ test('shows Home operational cards and hides Session Activity panel by default',
   await expect(page.locator('#command-status-dot')).toHaveText('Idle')
   await expect(page.getByRole('heading', { name: 'Processing History' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Session Activity' })).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Output Matrix' })).toHaveCount(0)
   await expect(page.locator('#history-refresh')).toHaveCount(0)
   await expect(page.locator('[data-activity-filter]')).toHaveCount(0)
@@ -311,9 +312,10 @@ test('supports run-selected preset, restore-defaults, and recording roadmap link
   await expect(page.locator('#settings-transcript-copy')).not.toBeChecked()
 
   await page.locator('[data-route-tab="home"]').click()
+  await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toHaveCount(0)
+  await page.locator('[data-route-tab="settings"]').click()
   await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toBeVisible()
   await expect(page.locator('.shortcut-combo')).toContainText(['Cmd+Shift+1', 'Cmd+Shift+2', 'Cmd+Shift+3', 'Cmd+Shift+4'])
-  await page.locator('[data-route-tab="settings"]').click()
 
   await page.locator('#settings-restore-defaults').click()
   await expect(page.locator('#settings-save-message')).toHaveText('Defaults restored.')

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,8 @@ Phase 4 adds provider contract hardening:
 ## Home UI (Phase 5A)
 
 - Top-level navigation is limited to `Home` and `Settings`; app launches on `Home`.
-- Home keeps only operational cards (Recording Controls, Transform Shortcut, Shortcut Contract).
+- Home keeps only operational cards (Recording Controls, Transform Shortcut).
+- Shortcut Contract reference is available on Settings.
 - Recording status badge supports `Idle`, `Recording`, `Busy`, and `Error`.
 - Recording and transform cards show blocked reasons and provide direct Settings navigation when prerequisites are missing.
 - Legacy history/timeline/output-matrix renderer paths are removed from active Home UI code.

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -328,9 +328,6 @@ const applyNonSecretAutosavePatch = (updater: (current: Settings) => Settings): 
     return
   }
   state.settings = updater(state.settings)
-  rerenderShellFromState()
-  state.currentPage = 'settings'
-  refreshRouteTabs()
   scheduleNonSecretAutosave()
 }
 
@@ -1026,7 +1023,6 @@ const renderShell = (pong: string, settings: Settings, apiKeyStatus: ApiKeyStatu
     <section class="grid page-home" data-page="home">
       ${renderRecordingPanel(settings, apiKeyStatus)}
       ${renderTransformPanel(settings, apiKeyStatus, state.lastTransformSummary)}
-      ${renderShortcutsPanel(settings)}
     </section>
     <section class="grid page-settings is-hidden" data-page="settings">
       ${renderSettingsPanel(settings, apiKeyStatus)}
@@ -1380,6 +1376,12 @@ const wireActions = (): void => {
     const selectedProvider = transcriptionProviderSelect.value as Settings['transcription']['provider']
     const models = STT_MODEL_ALLOWLIST[selectedProvider]
     const selectedModel = models[0]
+    if (transcriptionModelSelect) {
+      transcriptionModelSelect.innerHTML = models
+        .map((model) => `<option value="${escapeHtml(model)}">${escapeHtml(model)}</option>`)
+        .join('')
+      transcriptionModelSelect.value = selectedModel
+    }
     applyNonSecretAutosavePatch((current) => ({
       ...current,
       transcription: {
@@ -1715,6 +1717,10 @@ const wireActions = (): void => {
         return
       }
       state.currentPage = route
+      if (route === 'home') {
+        rerenderShellFromState()
+        return
+      }
       refreshRouteTabs()
     })
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -254,6 +254,10 @@ h2 {
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
 }
 
+.page-settings .shortcuts {
+  grid-column: 1 / -1;
+}
+
 .is-hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- remove the Shortcut Contract card from Home to simplify operational focus
- keep shortcut discoverability in Settings by retaining Shortcut Contract there
- update Settings layout to keep shortcut card legible after relocation
- update README home-ui description to match current behavior
- update e2e expectations for Home/Settings shortcut panel location
- mark #73 done in execution plan

## Validation
- pnpm run typecheck
- pnpm run build && xvfb-run -a pnpm exec playwright test e2e/electron-ui.e2e.ts --grep "shows Home operational cards|supports run-selected preset|autosave"
