### PR TITLE
fix: address review findings from PRs #78-#80

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -95,6 +95,7 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 - Goal: Play each required sound exactly once per event.
 - Constraints:
   - Must preserve required sound events (`specs/spec.md:190-197`).
+  - Distinct success vs failure tones are a deferred `SHOULD` follow-up (`specs/spec.md:198`), not part of dedup scope.
 - Repro + acceptance criteria:
   - Deterministic repro exists for duplicate sound trigger.
   - Each required sound event is emitted exactly once per user action.
@@ -103,6 +104,8 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
   - [x] Identify duplicate listeners/invocations.
   - [x] Deduplicate sound triggers in renderer/main flows.
   - [x] Add tests asserting single invocation per event.
+- Follow-up:
+  - Open a separate ticket to add distinct success/failure tones while keeping single-trigger behavior.
 
 ### #66 - [P0] Fix malformed Groq status handling and diagnostics
 - Status: `CANCELED`


### PR DESCRIPTION
## Summary
- remove fragile positional shortcut callback lookups in hotkey-service tests by using accelerator-keyed callback lookup
- keep review coverage stable for pick-and-run, change-default, transform, and selection callback tests
- document deferred specs/spec.md:198 distinct-tone SHOULD follow-up in the execution plan for ticket #65

## Validation
- pnpm vitest run src/main/services/hotkey-service.test.ts src/main/services/sound-service.test.ts

## Scope
- findings follow-up for reviews in docs/reviews/pr-78-review.md, docs/reviews/pr-79-review.md, docs/reviews/pr-80-review.md