### PR TITLE
fix: address review findings from PR #86/#87/#88

### DIFF
--- a/specs/h2-design-pick-and-run-transformation-ux.md
+++ b/specs/h2-design-pick-and-run-transformation-ux.md
@@ -11,6 +11,19 @@ Why: Phase 3A pre-requisite H2. Determines how the user explicitly picks a trans
 **Date:** 2026-02-17
 **Phase:** 3A pre-requisite
 
+## Supersession Note (2026-02-19)
+
+This document originally approved **Approach 3B** (native `Menu.popup()`).
+Implementation moved to the dedicated BrowserWindow contract in
+`specs/h3-dedicated-profile-picker-window-ux.md`. This is an explicit design
+departure from the original no-focus-steal preference in favor of:
+
+- deterministic picker behavior and keyboard handling across app modes,
+- testability through explicit picker window lifecycle and IPC hook,
+- a richer profile presentation than text-only native menu entries.
+
+All new implementation and review decisions should follow h3.
+
 ## 1. Problem Statement
 
 Spec §4.2 L169 requires `pickAndRunTransformation` to:

--- a/specs/h3-dedicated-profile-picker-window-ux.md
+++ b/specs/h3-dedicated-profile-picker-window-ux.md
@@ -29,6 +29,10 @@ When `pickTransformation` shortcut fires, open a dedicated picker window, let us
 6. On cancel:
   - no settings write.
   - no transformation run.
+7. Picker opening is singleton-safe:
+  - if picker is already open, new trigger reuses the same window/session.
+8. Picker max lifetime timeout:
+  - picker closes and resolves cancel after 60 seconds if still open.
 
 ## Non-Blocking Requirements
 

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -285,6 +285,7 @@ const runNonSecretAutosave = async (generation: number, nextSettings: Settings):
     }
     state.settings = saved
     state.persistedSettings = structuredClone(saved)
+    rerenderShellFromState()
     const saveMessage = app?.querySelector<HTMLElement>('#settings-save-message')
     if (saveMessage) {
       saveMessage.textContent = 'Settings autosaved.'
@@ -327,6 +328,8 @@ const applyNonSecretAutosavePatch = (updater: (current: Settings) => Settings): 
   if (!state.settings) {
     return
   }
+  // Non-secret autosave boundary is enforced by callers.
+  // Do not use this helper for API key/secret-bearing controls.
   state.settings = updater(state.settings)
   scheduleNonSecretAutosave()
 }


### PR DESCRIPTION
## Summary
- add singleton protection for dedicated picker window so repeated triggers reuse the same active picker session
- add picker max-lifetime timeout (60s) to avoid indefinitely orphaned picker windows
- rerender shell after successful non-secret autosave so derived UI stays in sync across Home/Settings
- document autosave non-secret boundary at the patch helper call boundary
- document h2 supersession rationale and align h3 picker contract with implemented timeout behavior
- extend autosave e2e assertion to verify Home transform blocked/enabled state reflects autosaved setting changes

## Validation
- `pnpm typecheck`
- `pnpm vitest run src/main/services/profile-picker-service.test.ts`
- `pnpm run build`
- `pnpm exec playwright test e2e/electron-ui.e2e.ts -g "autosaves selected non-secret controls and does not autosave shortcuts"`

## Scope
- follow-up findings from:
  - `docs/reviews/pr-86-review.md`
  - `docs/reviews/pr-87-review.md`
  - `docs/reviews/pr-88-review.md`
