### PR TITLE
spec: make pick-and-run transformation one-time per issue #85

### DIFF
--- a/docs/p0-p1-p2-react-execution-plan.md
+++ b/docs/p0-p1-p2-react-execution-plan.md
@@ -165,12 +165,12 @@ Why: Provide one-ticket-per-PR roadmap with status, constraints, and checklists 
 - Status: `DONE`
 - Goal: Resolve mismatch between user feedback and current normative behavior.
 - Constraints:
-  - Current spec mandates persistence (`specs/spec.md:176`).
+  - Superseded by issue #85: pick-and-run is one-time, not persistent.
 - Tasks:
   - [x] Record decision: persistent vs one-time behavior.
-  - [x] If decision changes behavior, prepare spec update PR. (N/A: behavior unchanged; clarity update only)
+  - [x] If decision changes behavior, prepare spec update PR.
   - [x] Create/update implementation follow-up constraints for #71.
-  - Follow-up issue: #83 (clarify persistence in user-facing copy).
+  - Note: issue #83 is invalid; issue #85 is authoritative.
 
 ### #71 - [P2] Dedicated transformation profile picker window UX
 - Status: `DONE`

--- a/specs/decision-pick-and-run-persistence.md
+++ b/specs/decision-pick-and-run-persistence.md
@@ -7,29 +7,26 @@ Why: Resolve #70 conflict between user feedback and current normative spec.
 # Decision: pick-and-run active profile persistence
 
 - Date: 2026-02-19
-- Issue: #70
-- Status: Accepted
+- Issue: #85
+- Status: Supersedes prior #70 decision
 
 ## Decision
 
-`pickAndRunTransformation` remains **persistent**:
+`pickAndRunTransformation` is **one-time** (request-scoped):
 
 1. User picks a profile.
-2. System updates `transformation.activePresetId` to the picked profile.
-3. Transformation executes with the picked profile.
-4. The picked profile remains active for subsequent active-target shortcuts.
-
-This is not one-time behavior.
+2. System executes transformation with that picked profile for the current request.
+3. System does not update persisted `transformation.activePresetId`.
+4. Subsequent active-target shortcuts continue using persisted active profile unless changed explicitly by other controls.
 
 ## Rationale
 
-- Current behavior and tests already enforce persistent active-profile updates.
-- Persistence keeps `pickAndRunTransformation`, `runTransformationOnSelection`, and
-  `changeDefaultTransformation` semantically consistent around the active profile.
-- Avoids introducing hidden temporary state that would increase shortcut ambiguity.
+- Issue #85 explicitly rejects the prior persistent interpretation.
+- One-time behavior matches user expectation for a temporary pick-and-run action.
+- Keeps persistent profile state changes scoped to explicit settings/profile actions.
 
 ## Consequences
 
-- No implementation change is required for #70.
-- Spec wording is clarified to explicitly call out persistence.
-- Follow-up work should improve user-facing copy so persistence is obvious.
+- Spec wording is updated to remove persistent side-effect semantics for pick-and-run.
+- Any implementation/tests relying on pick-and-run persistence must be updated to request-scoped behavior.
+- Issue #83 is treated as invalid and should not be used as normative direction.

--- a/specs/h3-dedicated-profile-picker-window-ux.md
+++ b/specs/h3-dedicated-profile-picker-window-ux.md
@@ -24,8 +24,8 @@ When `pickTransformation` shortcut fires, open a dedicated picker window, let us
   - Escape cancels and closes picker.
 4. Mouse click on a profile confirms selection.
 5. On confirm:
-  - `transformation.activePresetId` is updated to chosen profile.
-  - shortcut flow runs clipboard transformation using selected profile.
+  - shortcut flow runs clipboard transformation using selected profile for that request only.
+  - `transformation.activePresetId` is not changed.
 6. On cancel:
   - no settings write.
   - no transformation run.
@@ -43,4 +43,4 @@ When `pickTransformation` shortcut fires, open a dedicated picker window, let us
 
 - Unit: picker window selection/cancel behavior.
 - Unit: hotkey pick-and-run semantics remain stable.
-- E2E: pick shortcut opens picker window and selection updates active preset.
+- E2E: pick shortcut opens picker window and selection executes one-time override without changing active preset.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -173,8 +173,8 @@ Behavior:
 Transformation shortcut semantics:
 - `runDefaultTransformation` **MUST** execute with `transformationProfiles.defaultProfileId` when set.
 - if `transformationProfiles.defaultProfileId` is `null`, `runDefaultTransformation` **MUST NOT** invoke LLM transformation and **MUST** return a non-error skipped outcome.
-- `pickAndRunTransformation` **MUST** update `transformationProfiles.activeProfileId` to user-picked profile before execution, then execute using that active profile.
-- The `pickAndRunTransformation` active-profile update is **persistent** for subsequent active-target shortcuts (not one-time).
+- `pickAndRunTransformation` **MUST** execute using the user-picked profile for that request only.
+- `pickAndRunTransformation` **MUST NOT** update `transformationProfiles.activeProfileId` as a side effect.
 - `changeDefaultTransformation` **MUST** set `transformationProfiles.defaultProfileId` to current `activeProfileId` without executing transformation.
 - `runTransformationOnSelection` **MUST** execute using current `activeProfileId`; if no selection text exists, it **MUST** fail with actionable user feedback.
 - when a transformation shortcut executes during active recording, execution **MUST** start immediately in parallel and **MUST NOT** wait for current recording job completion.
@@ -184,7 +184,7 @@ Transformation shortcut semantics:
   - `default-target` => resolve profile from `defaultProfileId` when non-null; otherwise skip transformation with actionable non-error feedback.
   - `active-target` => resolve profile from `activeProfileId`.
   - `selection-target` => resolve profile from `activeProfileId` and selection text source.
-- profile updates from `pickAndRunTransformation` **MUST** take effect for subsequent requests only; in-flight requests **MUST NOT** be rewritten.
+- `pickAndRunTransformation` is request-scoped; subsequent requests **MUST** continue to use the current persisted `activeProfileId` unless explicitly changed elsewhere.
 
 ### 4.3 Sound notifications
 

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -131,8 +131,8 @@ Steps:
 1. User presses the `pickTransformation` shortcut.
 2. App opens the transformation selector.
 3. User chooses the desired transformation.
-4. App updates `transformationProfiles.activeProfileId` to the chosen profile.
-5. App immediately applies the chosen profile to current clipboard text.
+4. App immediately applies the chosen profile to current clipboard text.
+5. App does not persist that pick as the new active profile.
 6. After a short wait, transformed text becomes available.
 7. App applies transformation output rule:
    - Applies `copy_transformed_text_to_clipboard` if enabled.


### PR DESCRIPTION
## Summary
- treat issue #83 as invalid and use issue #85 as authoritative
- update spec semantics so `pickAndRunTransformation` is request-scoped (one-time)
- remove persisted active-profile side effects from pick-and-run flow docs
- align H2/H3 design docs and execution plan notes with one-time behavior

## Updated files
- `specs/spec.md`
- `specs/user-flow.md`
- `specs/h2-design-pick-and-run-transformation-ux.md`
- `specs/h3-dedicated-profile-picker-window-ux.md`
- `specs/decision-pick-and-run-persistence.md`
- `docs/p0-p1-p2-react-execution-plan.md`

## Validation
- grep consistency sweep across `specs/` and `docs/` for stale persistence wording
- docs/spec-only change; no runtime code or tests executed