### PR TITLE
fix: address Claude review findings for PR #98

### DIFF
--- a/docs/reviews/pr-98-claude-review-followup.md
+++ b/docs/reviews/pr-98-claude-review-followup.md
@@ -1,0 +1,21 @@
+<!--
+Where: docs/reviews/pr-98-claude-review-followup.md
+What: Follow-up notes for Claude review findings on PR #98.
+Why: Record what was fixed and what validation was run after external review.
+-->
+
+# PR #98 Claude Review Follow-up
+
+## Findings Addressed
+- Added coverage for transient paste recovery when both `copyToClipboard=true` and `pasteAtCursor=true`.
+- Added a brief retry backoff between paste attempts (`150ms`) to make second attempt meaningful after transient automation failures.
+- Clarified retry failure control flow by using an explicit non-null error invariant after attempts are exhausted.
+
+## Validation
+- `pnpm exec vitest run src/main/services/output-service.test.ts`
+- `pnpm run typecheck`
+- `pnpm run test`
+
+## Files Updated
+- `src/main/services/output-service.ts`
+- `src/main/services/output-service.test.ts`


### PR DESCRIPTION
## Summary
- run Claude-based review on PR #98 patch and apply concrete follow-up fixes
- add a short delay between retry attempts for transient paste automation failures
- add missing test coverage for transient recovery when copy+pasting together
- make retry-failure error invariant explicit in output failure message path
- add follow-up review note in docs

## Why
Claude review identified:
1. missing combined copy+paste transient-recovery test coverage
2. immediate retry without backoff
3. nullable error chain where control flow guarantees a final error

## Validation
- pnpm exec vitest run src/main/services/output-service.test.ts
- pnpm run typecheck
- pnpm run test

## Files
- src/main/services/output-service.ts
- src/main/services/output-service.test.ts
- docs/reviews/pr-98-claude-review-followup.md
