### PR TITLE
feat(coordination): add starvation-protection timeout to SerialOutputCoordinator

### DIFF
--- a/src/main/coordination/ordered-output-coordinator.test.ts
+++ b/src/main/coordination/ordered-output-coordinator.test.ts
@@ -1,10 +1,14 @@
 // src/main/coordination/ordered-output-coordinator.test.ts
 // Tests for SerialOutputCoordinator hold-back behavior.
-// Verifies in-order commits, out-of-order hold-back, release/drain, and error handling.
+// Verifies in-order commits, out-of-order hold-back, release/drain, error handling,
+// and starvation-protection timeout (parked entries force-resolved when predecessor never arrives).
 
 import { describe, expect, it, vi } from 'vitest'
 import { SerialOutputCoordinator } from './ordered-output-coordinator'
 import type { TerminalJobStatus } from '../../shared/domain'
+
+// Short timeout used in starvation tests so they run fast with fake timers.
+const TEST_PARK_TIMEOUT_MS = 100
 
 describe('SerialOutputCoordinator', () => {
   it('commits in-order submissions immediately', async () => {
@@ -135,8 +139,100 @@ describe('SerialOutputCoordinator', () => {
     expect(seqs).toEqual([0, 1, 2, 3, 4])
   })
 
-  // Known gap: no starvation timeout mechanism yet.
-  // If sequence N is never submitted/released, all successors park forever.
-  // Phase 2A or Phase 6 should add a configurable timeout with forced release.
-  it.todo('times out parked entries when predecessor never completes')
+  it('times out parked entries when predecessor never completes', async () => {
+    // Starvation scenario: seq1 parks waiting for seq0, but seq0 never arrives.
+    // The park timeout must force-resolve seq1 as output_failed_partial.
+    vi.useFakeTimers()
+    try {
+      const coordinator = new SerialOutputCoordinator({ parkTimeoutMs: TEST_PARK_TIMEOUT_MS })
+
+      const seq0 = coordinator.nextSequence()
+      const seq1 = coordinator.nextSequence()
+
+      // Park seq1 — seq0 will never arrive.
+      const promise1 = coordinator.submit(seq1, async () => 'succeeded' as TerminalJobStatus)
+
+      // Advance past the timeout; seq1 must be force-resolved.
+      await vi.advanceTimersByTimeAsync(TEST_PARK_TIMEOUT_MS + 10)
+
+      const result1 = await promise1
+      expect(result1).toBe('output_failed_partial')
+
+      // After the timeout advanced committedUpTo past seq1, a new successor
+      // submitted at seq2 should commit immediately (not park).
+      const seq2 = coordinator.nextSequence()
+      const result2 = await coordinator.submit(seq2, async () => 'succeeded' as TerminalJobStatus)
+      expect(result2).toBe('succeeded')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels starvation timer when predecessor arrives before timeout', async () => {
+    // Happy path: seq1 parks, seq0 arrives before the timeout fires.
+    // seq1 must commit normally (not via forced timeout resolution).
+    vi.useFakeTimers()
+    try {
+      const coordinator = new SerialOutputCoordinator({ parkTimeoutMs: TEST_PARK_TIMEOUT_MS })
+
+      const seq0 = coordinator.nextSequence()
+      const seq1 = coordinator.nextSequence()
+
+      // Park seq1
+      const promise1 = coordinator.submit(seq1, async () => 'succeeded' as TerminalJobStatus)
+
+      // Advance to just before the timeout — seq1 still parked.
+      await vi.advanceTimersByTimeAsync(TEST_PARK_TIMEOUT_MS - 10)
+
+      // seq0 arrives in time — unblocks seq1 before the timer fires.
+      const result0 = await coordinator.submit(seq0, async () => 'succeeded' as TerminalJobStatus)
+      expect(result0).toBe('succeeded')
+
+      const result1 = await promise1
+      // seq1 must commit its own commitFn (not forced to output_failed_partial).
+      expect(result1).toBe('succeeded')
+
+      // Advance past where the timeout would have fired — must not corrupt state.
+      await vi.advanceTimersByTimeAsync(TEST_PARK_TIMEOUT_MS + 50)
+
+      const seq2 = coordinator.nextSequence()
+      const result2 = await coordinator.submit(seq2, async () => 'succeeded' as TerminalJobStatus)
+      expect(result2).toBe('succeeded')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drains successor chain after starvation timeout on intermediate entry', async () => {
+    // seq0 never arrives; seq1 and seq2 are both parked.
+    // When seq1 times out, committedUpTo advances to seq1, triggering seq2 to drain.
+    vi.useFakeTimers()
+    try {
+      const coordinator = new SerialOutputCoordinator({ parkTimeoutMs: TEST_PARK_TIMEOUT_MS })
+
+      const seq0 = coordinator.nextSequence()
+      const seq1 = coordinator.nextSequence()
+      const seq2 = coordinator.nextSequence()
+
+      // seq0 never arrives — park seq1 and seq2.
+      const promise1 = coordinator.submit(seq1, async () => 'succeeded' as TerminalJobStatus)
+      const promise2 = coordinator.submit(seq2, async () => 'succeeded' as TerminalJobStatus)
+
+      // Advance past timeout — seq1 times out and its drain should unblock seq2.
+      await vi.advanceTimersByTimeAsync(TEST_PARK_TIMEOUT_MS + 10)
+
+      const result1 = await promise1
+      expect(result1).toBe('output_failed_partial')
+
+      const result2 = await promise2
+      // seq2 commits its own commitFn because seq1's timeout triggered the drain.
+      expect(result2).toBe('succeeded')
+
+      // seq0 arriving late (after seq1 and seq2 already resolved) must not
+      // corrupt state; it has already been superseded.
+      void seq0 // suppress unused-variable lint
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/coordination/ordered-output-coordinator.ts
+++ b/src/main/coordination/ordered-output-coordinator.ts
@@ -8,8 +8,18 @@
 // - submit(seq, commitFn) resolves immediately if seq is next in line.
 // - Otherwise, the promise parks in a waiting map until predecessors complete.
 // - release(seq) marks a sequence as done without committing (for failures/skips).
+//
+// Starvation protection:
+// - Each parked entry has a configurable timeout (parkTimeoutMs).
+// - If the timeout fires before a predecessor completes/releases, the parked
+//   entry is force-resolved as output_failed_partial and committedUpTo advances
+//   past it, unblocking any subsequent parked entries.
 
 import type { TerminalJobStatus } from '../../shared/domain'
+
+// Default park timeout: 30 seconds. Long enough for normal STT/LLM latency,
+// short enough to avoid indefinite hangs when a predecessor job is lost.
+const DEFAULT_PARK_TIMEOUT_MS = 30_000
 
 export interface OrderedOutputCoordinator {
   /** Acquire next sequence number. Called at enqueue time. */
@@ -26,12 +36,19 @@ export interface OrderedOutputCoordinator {
 interface WaitingEntry {
   resolve: (status: TerminalJobStatus) => void
   commitFn: () => Promise<TerminalJobStatus>
+  // Timer handle cleared when the entry is committed normally; fires to force-release on starvation.
+  timeoutHandle: ReturnType<typeof setTimeout>
 }
 
 export class SerialOutputCoordinator implements OrderedOutputCoordinator {
   private nextSeq = 0
   private committedUpTo = -1
   private readonly waiting = new Map<number, WaitingEntry>()
+  private readonly parkTimeoutMs: number
+
+  constructor(options?: { parkTimeoutMs?: number }) {
+    this.parkTimeoutMs = options?.parkTimeoutMs ?? DEFAULT_PARK_TIMEOUT_MS
+  }
 
   nextSequence(): number {
     return this.nextSeq++
@@ -46,14 +63,31 @@ export class SerialOutputCoordinator implements OrderedOutputCoordinator {
       return this.commitAndDrain(sequenceNumber, commitFn)
     }
 
-    // Otherwise, park until predecessors complete
+    // Otherwise, park until predecessors complete.
+    // Start a starvation-protection timer so successors are never blocked forever
+    // if a predecessor is lost (never submitted or released).
     return new Promise<TerminalJobStatus>((resolve) => {
-      this.waiting.set(sequenceNumber, { resolve, commitFn })
+      const timeoutHandle = setTimeout(() => {
+        // Predecessor never arrived — force-resolve this entry as failed and
+        // advance committedUpTo so any further parked successors can drain.
+        if (this.waiting.has(sequenceNumber)) {
+          this.waiting.delete(sequenceNumber)
+          this.committedUpTo = sequenceNumber
+          resolve('output_failed_partial')
+          void this.drainWaiting()
+        }
+      }, this.parkTimeoutMs)
+
+      this.waiting.set(sequenceNumber, { resolve, commitFn, timeoutHandle })
     })
   }
 
   release(sequenceNumber: number): void {
-    this.waiting.delete(sequenceNumber)
+    const entry = this.waiting.get(sequenceNumber)
+    if (entry) {
+      clearTimeout(entry.timeoutHandle)
+      this.waiting.delete(sequenceNumber)
+    }
     if (sequenceNumber === this.committedUpTo + 1) {
       this.committedUpTo = sequenceNumber
       void this.drainWaiting()
@@ -79,6 +113,8 @@ export class SerialOutputCoordinator implements OrderedOutputCoordinator {
     while (this.waiting.has(this.committedUpTo + 1)) {
       const next = this.committedUpTo + 1
       const entry = this.waiting.get(next)!
+      // Cancel the starvation timer — predecessor arrived in time.
+      clearTimeout(entry.timeoutHandle)
       this.waiting.delete(next)
 
       let status: TerminalJobStatus


### PR DESCRIPTION
Implements the known gap noted in the ordered-output-coordinator todo:
if a predecessor sequence is never submitted or released, all parked
successors now resolve as output_failed_partial after a configurable
parkTimeoutMs (default 30 s) instead of waiting forever.

Changes:
- SerialOutputCoordinator accepts an optional { parkTimeoutMs } constructor
  option; defaults to DEFAULT_PARK_TIMEOUT_MS = 30_000.
- Each parked WaitingEntry stores a timeout handle that is cleared on
  normal drain (predecessor arrived in time) and fires to force-resolve
  the entry and advance committedUpTo when the predecessor never arrives.
- release() now clears the timeout handle for the released entry to
  prevent spurious timeout callbacks after normal release paths.
- Three new tests replace the it.todo placeholder, verified with
  vi.useFakeTimers/advanceTimersByTimeAsync:
  - times out parked entries when predecessor never completes
  - cancels starvation timer when predecessor arrives before timeout
  - drains successor chain after starvation timeout on intermediate entry

All 59 test files pass (344 tests; 4 skipped).

https://claude.ai/code/session_01AmKPUop9AKHFucqjdmn9yp