### PR TITLE
chore(test): scope vitest discovery

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ pnpm test:coverage     # unit tests with coverage
 pnpm test:e2e          # end-to-end tests (playwright)
 ```
 
+Vitest excludes `.worktrees` and `.pnpm-store` from test discovery to avoid running tests from external worktrees or cached stores.
+
 ## CI E2E Strategy
 
 - Default CI e2e runs on macOS to match the runtime support target.

--- a/src/shared/vitest-config.test.ts
+++ b/src/shared/vitest-config.test.ts
@@ -1,0 +1,17 @@
+/*
+Where: src/shared/vitest-config.test.ts
+What: Vitest config coverage for exclude patterns.
+Why: Guard against accidental removal of worktree/pnpm-store exclusions that
+     would slow or break local test discovery.
+*/
+
+import { describe, expect, it } from 'vitest'
+import config from '../../vitest.config'
+
+describe('vitest config', () => {
+  it('excludes worktrees and pnpm store from test discovery', () => {
+    const excluded = Array.isArray(config.test?.exclude) ? config.test?.exclude : []
+    expect(excluded).toContain('**/.worktrees/**')
+    expect(excluded).toContain('**/.pnpm-store/**')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,21 @@
-import { defineConfig } from 'vitest/config'
+/*
+Where: vitest.config.ts
+What: Vitest configuration (plugins + test coverage/exclude settings).
+Why: Keep test discovery scoped to the repo by excluding generated or external
+     directories like worktrees and pnpm store.
+*/
+
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
   test: {
+    exclude: [
+      ...configDefaults.exclude,
+      '**/.worktrees/**',
+      '**/.pnpm-store/**'
+    ],
     coverage: {
       provider: 'v8',
       include: ['src/main/**/*.ts', 'src/shared/**/*.ts'],


### PR DESCRIPTION
## Summary
- exclude .worktrees and .pnpm-store from Vitest discovery
- add a regression test for the exclude list
- document Vitest exclusions in the test section

## Testing
- pnpm vitest run src/shared/vitest-config.test.ts