### PR TITLE
feat(sound): map recording UI events to dedicated MP3 audio cues

### DIFF
--- a/src/main/infrastructure/sound-asset-paths.ts
+++ b/src/main/infrastructure/sound-asset-paths.ts
@@ -1,0 +1,44 @@
+// src/main/infrastructure/sound-asset-paths.ts
+// What: Canonical path resolver for bundled runtime sound asset files.
+// Why:  Centralises dev/prod path resolution so SoundService (issue #96)
+//       and tests can import paths from one authoritative source (issue #94).
+//       In dev mode the files live at <project-root>/resources/sounds/;
+//       in a packaged build they are included via electron-builder "files".
+
+import { app } from 'electron'
+import { join } from 'node:path'
+
+// Resolve the root of the resources/sounds directory.
+// app.isPackaged is false during `electron-vite dev`, true in distributed builds.
+const soundsDir = (): string =>
+  join(app.isPackaged ? app.getAppPath() : process.cwd(), 'resources', 'sounds')
+
+/**
+ * Absolute paths to each bundled MP3 sound asset, keyed by recording event.
+ * Evaluated lazily via getters so the module can be imported before `app` is
+ * fully ready without throwing.
+ *
+ * Audio event → file mapping (decision #96):
+ *   recording_started       → zapsplat_household_alarm_clock_button_press_12967.mp3
+ *   recording_stopped       → sound_ex_machina_Button_Blip.mp3
+ *   recording_cancelled     → zapsplat_multimedia_click_button_short_sharp_73510.mp3
+ *   transformation_succeeded→ zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3
+ *   transformation_failed   → zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3
+ */
+export const SOUND_ASSET_PATHS = {
+  get recordingStarted() {
+    return join(soundsDir(), 'zapsplat_household_alarm_clock_button_press_12967.mp3')
+  },
+  get recordingStopped() {
+    return join(soundsDir(), 'sound_ex_machina_Button_Blip.mp3')
+  },
+  get recordingCancelled() {
+    return join(soundsDir(), 'zapsplat_multimedia_click_button_short_sharp_73510.mp3')
+  },
+  get transformationSucceeded() {
+    return join(soundsDir(), 'zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3')
+  },
+  get transformationFailed() {
+    return join(soundsDir(), 'zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3')
+  }
+} as const

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -29,6 +29,7 @@ import { TransformationService } from '../services/transformation-service'
 import { OutputService } from '../services/output-service'
 import { NetworkCompatibilityService } from '../services/network-compatibility-service'
 import { ElectronSoundService } from '../services/sound-service'
+import { SOUND_ASSET_PATHS } from '../infrastructure/sound-asset-paths'
 import { ClipboardClient } from '../infrastructure/clipboard-client'
 import { SelectionClient } from '../infrastructure/selection-client'
 import { SerialOutputCoordinator } from '../coordination/ordered-output-coordinator'
@@ -48,7 +49,13 @@ const transcriptionService = new TranscriptionService()
 const transformationService = new TransformationService()
 const outputService = new OutputService()
 const networkCompatibilityService = new NetworkCompatibilityService()
-const soundService = new ElectronSoundService()
+const soundService = new ElectronSoundService({
+  recording_started: SOUND_ASSET_PATHS.recordingStarted,
+  recording_stopped: SOUND_ASSET_PATHS.recordingStopped,
+  recording_cancelled: SOUND_ASSET_PATHS.recordingCancelled,
+  transformation_succeeded: SOUND_ASSET_PATHS.transformationSucceeded,
+  transformation_failed: SOUND_ASSET_PATHS.transformationFailed
+})
 const clipboardClient = new ClipboardClient()
 const selectionClient = new SelectionClient({ clipboard: clipboardClient })
 const profilePickerService = new ProfilePickerService({

--- a/src/main/services/sound-service.test.ts
+++ b/src/main/services/sound-service.test.ts
@@ -1,7 +1,9 @@
 // src/main/services/sound-service.test.ts
-// Verifies SoundService contracts: no-op and concrete beep patterns.
+// What: Unit tests for SoundService contract — no-op and concrete file-playback.
+// Why:  Verifies each SoundEvent triggers playback of the correct dedicated MP3
+//       asset (issue #96) without actually spawning a child process.
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SoundEvent } from '../../shared/ipc'
 import { ElectronSoundService, NoopSoundService } from './sound-service'
 
@@ -13,6 +15,16 @@ const ALL_EVENTS: SoundEvent[] = [
   'transformation_failed'
 ]
 
+// Stable test file-path stubs — decoupled from SOUND_ASSET_PATHS (which requires
+// a live Electron `app` object). Mirrors the real event→file mapping from issue #96.
+const STUB_PATHS: Record<SoundEvent, string> = {
+  recording_started: '/stub/sounds/recording_started.mp3',
+  recording_stopped: '/stub/sounds/recording_stopped.mp3',
+  recording_cancelled: '/stub/sounds/recording_cancelled.mp3',
+  transformation_succeeded: '/stub/sounds/transformation_succeeded.mp3',
+  transformation_failed: '/stub/sounds/transformation_failed.mp3'
+}
+
 describe('NoopSoundService', () => {
   it('accepts all sound events without throwing', () => {
     const service = new NoopSoundService()
@@ -23,18 +35,36 @@ describe('NoopSoundService', () => {
 })
 
 describe('ElectronSoundService', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it.each(ALL_EVENTS)('plays exactly one beep for %s', (event) => {
-    vi.useFakeTimers()
-    const beep = vi.fn()
-    const service = new ElectronSoundService(beep)
+  it.each(ALL_EVENTS)('plays the correct file for %s', (event) => {
+    const playFile = vi.fn()
+    const service = new ElectronSoundService(STUB_PATHS, playFile)
 
     service.play(event)
-    vi.runAllTimers()
 
-    expect(beep).toHaveBeenCalledTimes(1)
+    expect(playFile).toHaveBeenCalledOnce()
+    expect(playFile).toHaveBeenCalledWith(STUB_PATHS[event])
+  })
+
+  it('does not call playFile for an unknown event (defensive)', () => {
+    const playFile = vi.fn()
+    // Force an unknown event via cast to test the guard branch.
+    const service = new ElectronSoundService(
+      { ...STUB_PATHS, recording_started: '' },
+      playFile
+    )
+
+    // Empty string path → guard returns early
+    service.play('recording_started')
+
+    expect(playFile).not.toHaveBeenCalled()
+  })
+
+  it('swallows errors thrown by playFile to protect the pipeline', () => {
+    const playFile = vi.fn(() => {
+      throw new Error('audio backend failure')
+    })
+    const service = new ElectronSoundService(STUB_PATHS, playFile)
+
+    expect(() => service.play('recording_started')).not.toThrow()
   })
 })

--- a/src/main/services/sound-service.ts
+++ b/src/main/services/sound-service.ts
@@ -1,50 +1,67 @@
 // src/main/services/sound-service.ts
-// Interface and concrete implementation for sound notifications.
-// Phase 6: use Electron shell.beep() with exactly one beep per event.
+// What: Interface and concrete implementations for sound event notifications.
+// Why:  Each recording/transformation event plays a dedicated MP3 asset so users
+//       get distinct audio feedback (issue #96).  The concrete implementation
+//       delegates to `afplay` (macOS built-in, no extra dependency) via
+//       child_process.spawn so audio is non-blocking and never crashes the pipeline.
+//       filePaths and playFile are injectable for hermetic unit tests — callers
+//       (register-handlers.ts) supply SOUND_ASSET_PATHS at the wiring point.
 
-import { shell } from 'electron'
+import { spawn } from 'node:child_process'
 import type { SoundEvent } from '../../shared/ipc'
 
 export interface SoundService {
   play(event: SoundEvent): void
 }
 
-/** No-op implementation — does not produce any audio. */
+/** No-op implementation — does not produce any audio. Used in stubs and tests. */
 export class NoopSoundService implements SoundService {
   play(_event: SoundEvent): void {
-    // No-op. Concrete implementation in Phase 6.
+    // intentional no-op
   }
 }
 
-const SOUND_EVENT_DELAYS_MS: Record<SoundEvent, readonly number[]> = {
-  recording_started: [0],
-  recording_stopped: [0],
-  recording_cancelled: [0],
-  transformation_succeeded: [0],
-  transformation_failed: [0]
+// Mapping from SoundEvent to the resolved absolute file path.
+// Supplied by the caller so this module stays free of `electron` imports.
+export type SoundEventFilePaths = Record<SoundEvent, string>
+
+/**
+ * Play a file path using macOS `afplay`.
+ * Spawns detached + unref'd so it does not block the Electron event loop.
+ * Any launch failure is swallowed — audio is best-effort.
+ */
+const afplay = (filePath: string): void => {
+  try {
+    const child = spawn('afplay', [filePath], { detached: true, stdio: 'ignore' })
+    child.unref()
+  } catch {
+    // Do not let audio issues break command/queue processing.
+  }
 }
 
 /**
- * Concrete sound service backed by Electron's system beep.
- * Patterns are intentionally short to avoid blocking input handling.
+ * Concrete sound service that plays the designated MP3 for each SoundEvent.
+ *
+ * Constructor arguments are injectable for testing:
+ *   - `filePaths`: explicit event→path map (provided by register-handlers via SOUND_ASSET_PATHS)
+ *   - `playFile`:  audio backend (defaults to `afplay` via child_process.spawn)
  */
 export class ElectronSoundService implements SoundService {
-  private readonly beep: () => void
+  private readonly filePaths: SoundEventFilePaths
+  private readonly playFile: (path: string) => void
 
-  constructor(beep?: () => void) {
-    this.beep = beep ?? (() => shell.beep())
+  constructor(filePaths: SoundEventFilePaths, playFile?: (path: string) => void) {
+    this.filePaths = filePaths
+    this.playFile = playFile ?? afplay
   }
 
   play(event: SoundEvent): void {
-    const pattern = SOUND_EVENT_DELAYS_MS[event] ?? [0]
-    for (const delayMs of pattern) {
-      setTimeout(() => {
-        try {
-          this.beep()
-        } catch {
-          // Do not let audio issues break command/queue processing.
-        }
-      }, delayMs)
+    const path = this.filePaths[event]
+    if (!path) return
+    try {
+      this.playFile(path)
+    } catch {
+      // Do not let audio issues break command/queue processing.
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace `shell.beep()` with per-event MP3 playback via macOS `afplay` (spawned detached, never blocks the pipeline)
- Add `src/main/infrastructure/sound-asset-paths.ts` as single source of truth for resolved asset paths (lazy getters, safe to import before `app.whenReady`)
- Wire paths in `register-handlers.ts` keeping `ElectronSoundService` free of `electron` imports for hermetic testing

**Event → asset mapping (issue #96):**
| Event | File |
|---|---|
| `recording_started` | `zapsplat_household_alarm_clock_button_press_12967.mp3` |
| `recording_stopped` | `sound_ex_machina_Button_Blip.mp3` |
| `recording_cancelled` | `zapsplat_multimedia_click_button_short_sharp_73510.mp3` |
| `transformation_succeeded` | `zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3` |
| `transformation_failed` | `zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3` |

Closes #96. Depends on #118 (feat/reorganize-audio-assets) for the physical MP3 files in `resources/sounds/`.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] 3 new unit tests: per-event file path assertion, empty-path guard, error-swallowing
- [x] All 285 main-process tests pass (39 test files, 3 more than before)
- [x] No duplicate/overlapping audio — each event maps to exactly one file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)