### PR TITLE
fix: validate transformation profile prompts before save (#122)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -37,7 +37,7 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 | P0 | Fix macOS paste-at-cursor failure | #121 | Fix | PR OPEN |
 | P0 | Preserve spoken language in STT | #120 | Fix | TODO |
 | P1 | Show message when stop/cancel pressed while idle | #124 | Fix | TODO |
-| P1 | Validate Transformation Profile prompts before saving | #122 | Fix | TODO |
+| P1 | Validate Transformation Profile prompts before saving | #122 | Fix | PR OPEN |
 | P2 | Add Playwright e2e recording test with fake audio | #95 | Test | TODO |
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
@@ -123,12 +123,12 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Block saving invalid prompts and show clear validation messages.
 - Granularity: Transformation Profile validation only.
 - Checklist:
-- [ ] Read prompt save flow and validation surface.
-- [ ] Enforce non-blank system prompt and user prompt.
-- [ ] Enforce `{{text}}` presence in user prompt.
-- [ ] Block save and show clear validation errors.
-- [ ] Add at least one test for invalid and valid prompt cases.
-- [ ] Update docs/help text for prompt requirements.
+- [x] Read prompt save flow and validation surface.
+- [x] Enforce non-blank system prompt and user prompt.
+- [x] Enforce `{{text}}` presence in user prompt.
+- [x] Block save and show clear validation errors.
+- [x] Add at least one test for invalid and valid prompt cases.
+- [x] Update docs/help text for prompt requirements.
 - Gate:
 - Invalid prompts cannot be saved and show actionable errors.
 - Valid prompts save normally; tests pass and docs updated.
@@ -136,6 +136,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Must ensure validation messaging is consistent with existing UX patterns.
 - Feasibility:
 - High. Validation is localized and easy to test.
+- Implementation Notes (2026-02-25):
+- Renderer save validation now blocks invalid prompt saves and shows inline errors for system/user prompts.
+- User prompt help text documents required `{{text}}` placeholder.
+- Save path normalizes legacy `{{input}}` to `{{text}}`; runtime formatter supports both placeholders for backward compatibility.
+- No manual user verification required; covered with renderer unit tests and prompt formatter tests.
 
 ---
 

--- a/src/main/services/transformation/prompt-format.test.ts
+++ b/src/main/services/transformation/prompt-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildPromptBlocks, INPUT_PLACEHOLDER } from './prompt-format'
+import { buildPromptBlocks, INPUT_PLACEHOLDER, LEGACY_INPUT_PLACEHOLDER } from './prompt-format'
 
 describe('buildPromptBlocks', () => {
   it('builds system+user prompt blocks with input placeholder replacement', () => {
@@ -20,5 +20,15 @@ describe('buildPromptBlocks', () => {
     })
 
     expect(blocks).toEqual(['raw input'])
+  })
+
+  it('supports legacy {{input}} placeholder for backward compatibility', () => {
+    const blocks = buildPromptBlocks({
+      sourceText: 'raw input',
+      systemPrompt: '',
+      userPrompt: `Legacy template: ${LEGACY_INPUT_PLACEHOLDER}`
+    })
+
+    expect(blocks).toEqual(['Legacy template: raw input'])
   })
 })

--- a/src/main/services/transformation/prompt-format.ts
+++ b/src/main/services/transformation/prompt-format.ts
@@ -4,7 +4,8 @@ export interface PromptFormatInput {
   userPrompt: string
 }
 
-export const INPUT_PLACEHOLDER = '{{input}}'
+export const INPUT_PLACEHOLDER = '{{text}}'
+export const LEGACY_INPUT_PLACEHOLDER = '{{input}}'
 
 const applyUserPromptTemplate = (sourceText: string, userPrompt: string): string => {
   const trimmedUserPrompt = userPrompt.trim()
@@ -12,8 +13,10 @@ const applyUserPromptTemplate = (sourceText: string, userPrompt: string): string
     return sourceText
   }
 
-  if (trimmedUserPrompt.includes(INPUT_PLACEHOLDER)) {
-    return trimmedUserPrompt.replaceAll(INPUT_PLACEHOLDER, sourceText)
+  if (trimmedUserPrompt.includes(INPUT_PLACEHOLDER) || trimmedUserPrompt.includes(LEGACY_INPUT_PLACEHOLDER)) {
+    return trimmedUserPrompt
+      .replaceAll(LEGACY_INPUT_PLACEHOLDER, INPUT_PLACEHOLDER)
+      .replaceAll(INPUT_PLACEHOLDER, sourceText)
   }
 
   return `${trimmedUserPrompt}\n\n${sourceText}`

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -233,6 +233,8 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               <SettingsTransformationReact
                 settings={uiState.settings}
                 presetNameError={uiState.settingsValidationErrors.presetName ?? ''}
+                systemPromptError={uiState.settingsValidationErrors.systemPrompt ?? ''}
+                userPromptError={uiState.settingsValidationErrors.userPrompt ?? ''}
                 onToggleTransformEnabled={(checked: boolean) => {
                   callbacks.onToggleTransformEnabled(checked)
                 }}

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -58,6 +58,17 @@ interface IpcHarness {
 }
 
 const buildIpcHarness = (): IpcHarness => {
+  const defaultSettings = structuredClone(DEFAULT_SETTINGS)
+  defaultSettings.transformation.presets = defaultSettings.transformation.presets.map((preset, index) =>
+    index === 0
+      ? {
+          ...preset,
+          systemPrompt: 'You are a careful editor.',
+          userPrompt: 'Rewrite: {{text}}'
+        }
+      : preset
+  )
+
   let apiKeyStatus = {
     groq: true,
     elevenlabs: true,
@@ -71,7 +82,7 @@ const buildIpcHarness = (): IpcHarness => {
 
   const api: IpcApi = {
     ping: async () => 'pong',
-    getSettings: async () => structuredClone(DEFAULT_SETTINGS),
+    getSettings: async () => structuredClone(defaultSettings),
     setSettings: setSettingsSpy,
     getApiKeyStatus: async () => apiKeyStatus,
     setApiKey: async () => {},

--- a/src/renderer/settings-mutations.test.ts
+++ b/src/renderer/settings-mutations.test.ts
@@ -1,0 +1,113 @@
+/*
+Where: src/renderer/settings-mutations.test.ts
+What: Unit tests for renderer settings save mutations.
+Why: Ensure prompt validation blocks invalid profile saves and normalizes legacy placeholders.
+*/
+
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS, type Settings } from '../shared/domain'
+import type { ApiKeyProvider } from '../shared/ipc'
+import { createSettingsMutations, type SettingsMutableState } from './settings-mutations'
+
+const createState = (settings: Settings): SettingsMutableState => ({
+  settings,
+  persistedSettings: structuredClone(settings),
+  settingsValidationErrors: {},
+  apiKeyStatus: { groq: false, elevenlabs: false, google: false },
+  apiKeySaveStatus: { groq: '', elevenlabs: '', google: '' },
+  apiKeyTestStatus: { groq: '', elevenlabs: '', google: '' },
+  apiKeysSaveMessage: '',
+  audioInputSources: []
+})
+
+const withActivePreset = (
+  settings: Settings,
+  patch: Partial<Settings['transformation']['presets'][number]>
+): Settings => {
+  const activeId = settings.transformation.activePresetId
+  return {
+    ...settings,
+    transformation: {
+      ...settings.transformation,
+      presets: settings.transformation.presets.map((preset) => (preset.id === activeId ? { ...preset, ...patch } : preset))
+    }
+  }
+}
+
+describe('createSettingsMutations.saveSettingsFromState', () => {
+  beforeEach(() => {
+    const noopAsync = async () => {}
+    ;(window as Window & { speechToTextApi: any }).speechToTextApi = {
+      setSettings: vi.fn(async (settings: Settings) => settings),
+      setApiKey: vi.fn(noopAsync),
+      testApiKeyConnection: vi.fn(async () => ({ provider: 'google' as ApiKeyProvider, status: 'success', message: 'ok' })),
+      getApiKeyStatus: vi.fn(async () => ({ groq: false, elevenlabs: false, google: false }))
+    }
+  })
+
+  it('blocks save and surfaces prompt validation errors for invalid transformation profile prompts', async () => {
+    const settings = withActivePreset(structuredClone(DEFAULT_SETTINGS), {
+      systemPrompt: '   ',
+      userPrompt: 'Rewrite clearly without placeholder'
+    })
+    const state = createState(settings)
+    const setSettingsSaveMessage = vi.fn()
+    const setSettingsValidationErrors = vi.fn()
+    const addToast = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage,
+      setSettingsValidationErrors,
+      addActivity: vi.fn(),
+      addToast,
+      logError: vi.fn()
+    })
+
+    await mutations.saveSettingsFromState()
+
+    expect(window.speechToTextApi.setSettings).not.toHaveBeenCalled()
+    expect(setSettingsValidationErrors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: 'System prompt is required.',
+        userPrompt: expect.stringContaining('{{text}}')
+      })
+    )
+    expect(setSettingsSaveMessage).toHaveBeenCalledWith('Fix the highlighted validation errors before saving.')
+    expect(addToast).toHaveBeenCalledWith('Settings validation failed. Fix highlighted fields.', 'error')
+  })
+
+  it('saves valid prompts and normalizes legacy {{input}} placeholder to {{text}}', async () => {
+    const settings = withActivePreset(structuredClone(DEFAULT_SETTINGS), {
+      systemPrompt: 'You are a careful editor.',
+      userPrompt: 'Rewrite: {{input}}'
+    })
+    const state = createState(settings)
+    const setSettingsSaveMessage = vi.fn()
+    const setSettingsValidationErrors = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage,
+      setSettingsValidationErrors,
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.saveSettingsFromState()
+
+    expect(window.speechToTextApi.setSettings).toHaveBeenCalledOnce()
+    const savedSettings = vi.mocked(window.speechToTextApi.setSettings).mock.calls[0]?.[0] as Settings
+    const savedPreset = savedSettings.transformation.presets.find((preset) => preset.id === savedSettings.transformation.activePresetId)
+    expect(savedPreset?.userPrompt).toBe('Rewrite: {{text}}')
+    expect(setSettingsValidationErrors).toHaveBeenCalledWith({})
+    expect(setSettingsSaveMessage).toHaveBeenCalledWith('Settings saved.')
+  })
+})

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -349,6 +349,8 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       transcriptionBaseUrlRaw: state.settings.transcription.baseUrlOverrides[state.settings.transcription.provider] ?? '',
       transformationBaseUrlRaw: state.settings.transformation.baseUrlOverrides[activePreset.provider] ?? '',
       presetNameRaw: activePreset.name,
+      systemPromptRaw: activePreset.systemPrompt,
+      userPromptRaw: activePreset.userPrompt,
       shortcuts: {
         startRecording: shortcutDraft.startRecording,
         stopRecording: shortcutDraft.stopRecording,
@@ -369,7 +371,9 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
 
     const updatedActivePreset = {
       ...activePreset,
-      name: formValidation.normalized.presetName
+      name: formValidation.normalized.presetName,
+      systemPrompt: formValidation.normalized.systemPrompt,
+      userPrompt: formValidation.normalized.userPrompt
     }
     const updatedPresets = state.settings.transformation.presets.map((preset) =>
       preset.id === updatedActivePreset.id ? updatedActivePreset : preset

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -45,6 +45,8 @@ describe('SettingsTransformationReact', () => {
         <SettingsTransformationReact
           settings={DEFAULT_SETTINGS}
           presetNameError=""
+          systemPromptError=""
+          userPromptError=""
           onToggleTransformEnabled={onToggleTransformEnabled}
           onToggleAutoRun={onToggleAutoRun}
           onSelectActivePreset={onSelectActivePreset}
@@ -109,6 +111,8 @@ describe('SettingsTransformationReact', () => {
         <SettingsTransformationReact
           settings={DEFAULT_SETTINGS}
           presetNameError=""
+          systemPromptError=""
+          userPromptError=""
           onToggleTransformEnabled={() => {}}
           onToggleAutoRun={() => {}}
           onSelectActivePreset={() => {}}
@@ -121,12 +125,15 @@ describe('SettingsTransformationReact', () => {
       )
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toBe('')
+    expect(host.querySelector('#settings-help-user-prompt')?.textContent).toContain('{{text}}')
 
     await act(async () => {
       root?.render(
         <SettingsTransformationReact
           settings={DEFAULT_SETTINGS}
           presetNameError="Preset name is required."
+          systemPromptError="System prompt is required."
+          userPromptError="User prompt must include {{text}}."
           onToggleTransformEnabled={() => {}}
           onToggleAutoRun={() => {}}
           onSelectActivePreset={() => {}}
@@ -139,5 +146,7 @@ describe('SettingsTransformationReact', () => {
       )
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Preset name is required.')
+    expect(host.querySelector('#settings-error-system-prompt')?.textContent).toContain('System prompt is required.')
+    expect(host.querySelector('#settings-error-user-prompt')?.textContent).toContain('{{text}}')
   })
 })

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -12,6 +12,8 @@ import type { Settings } from '../shared/domain'
 interface SettingsTransformationReactProps {
   settings: Settings
   presetNameError: string
+  systemPromptError: string
+  userPromptError: string
   onToggleTransformEnabled: (checked: boolean) => void
   onToggleAutoRun: (checked: boolean) => void
   onSelectActivePreset: (presetId: string) => void
@@ -27,6 +29,8 @@ interface SettingsTransformationReactProps {
 export const SettingsTransformationReact = ({
   settings,
   presetNameError,
+  systemPromptError,
+  userPromptError,
   onToggleTransformEnabled,
   onToggleAutoRun,
   onSelectActivePreset,
@@ -188,6 +192,7 @@ export const SettingsTransformationReact = ({
           }}
         />
       </label>
+      <p className="field-error" id="settings-error-system-prompt">{systemPromptError}</p>
       <label className="text-row">
         <span>User prompt</span>
         <textarea
@@ -201,6 +206,8 @@ export const SettingsTransformationReact = ({
           }}
         />
       </label>
+      <p className="muted" id="settings-help-user-prompt">Required. Include {'{{text}}'} where the transcript should be inserted.</p>
+      <p className="field-error" id="settings-error-user-prompt">{userPromptError}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- block settings saves when the active transformation profile has invalid prompts
- require non-blank system/user prompts and a `{{text}}` placeholder in the user prompt
- show inline prompt validation messages and user-prompt help text
- normalize legacy `{{input}}` to `{{text}}` on save and support both placeholders at runtime for backward compatibility

## Changes
- add `systemPrompt` / `userPrompt` checks to renderer settings form validation
- wire prompt validation errors into the transformation settings UI
- block `saveSettingsFromState()` before IPC `setSettings()` when prompt validation fails
- support canonical `{{text}}` placeholder in prompt formatting (legacy `{{input}}` still works)
- update work-plan status/checklist for `#122`

## Tests
- `pnpm vitest run src/renderer/settings-validation.test.ts src/renderer/settings-transformation-react.test.tsx src/renderer/settings-mutations.test.ts src/main/services/transformation/prompt-format.test.ts`
- `pnpm vitest run src/renderer/renderer-app.test.ts`

## Manual Verification
- not required for this ticket (renderer/main unit coverage only)
