### PR TITLE
fix: show message for idle stop/cancel recording (#124)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -36,8 +36,8 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 |---|---|---|---|---|
 | P0 | Fix macOS paste-at-cursor failure | #121 | Fix | PR OPEN |
 | P0 | Preserve spoken language in STT | #120 | Fix | TODO |
-| P1 | Show message when stop/cancel pressed while idle | #124 | Fix | TODO |
-| P1 | Validate Transformation Profile prompts before saving | #122 | Fix | PR OPEN |
+| P1 | Show message when stop/cancel pressed while idle | #124 | Fix | PR OPEN |
+| P1 | Validate Transformation Profile prompts before saving | #122 | Fix | DONE |
 | P2 | Add Playwright e2e recording test with fake audio | #95 | Test | TODO |
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
@@ -105,11 +105,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Provide clear feedback when stop/cancel is pressed without an active recording.
 - Granularity: Stop/cancel handlers only.
 - Checklist:
-- [ ] Read stop/cancel handlers and recording state logic.
-- [ ] Add idle-state guard with user-facing message.
-- [ ] Ensure no state changes occur in idle path.
-- [ ] Add at least one test for idle stop/cancel behavior.
-- [ ] Update docs/help text if referenced.
+- [x] Read stop/cancel handlers and recording state logic.
+- [x] Add idle-state guard with user-facing message.
+- [x] Ensure no state changes occur in idle path.
+- [x] Add at least one test for idle stop/cancel behavior.
+- [x] Update docs/help text if referenced.
 - Gate:
 - Idle stop/cancel shows clear message and does not change state.
 - Tests pass and docs updated.
@@ -117,6 +117,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Must avoid double messaging when stop/cancel races with auto-stop.
 - Feasibility:
 - High. Limited scope and predictable changes.
+- Implementation Notes (2026-02-25):
+- Renderer recording command dispatch now guards idle `stopRecording` / `cancelRecording` and shows `Recording is not in progress.` instead of silent/success-like completion messages from the handler.
+- Idle guard returns before recorder-state mutations, sound playback, or `onStateChange`.
+- Added renderer unit tests for both idle stop and idle cancel paths.
 
 ### #122 - [P1] Validate Transformation Profile prompts before saving
 - Type: Fix

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -1,0 +1,60 @@
+/*
+Where: src/renderer/native-recording.test.ts
+What: Unit tests for renderer-native recording command dispatch idle guards.
+Why: Ensure stop/cancel commands show clear feedback instead of silent/success paths when no recording is active.
+*/
+
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS } from '../shared/domain'
+import { handleRecordingCommandDispatch, resetRecordingState, type NativeRecordingDeps } from './native-recording'
+
+const createDeps = (): { deps: NativeRecordingDeps; state: NativeRecordingDeps['state'] } => {
+  const state: NativeRecordingDeps['state'] = {
+    settings: structuredClone(DEFAULT_SETTINGS),
+    apiKeyStatus: { groq: true, elevenlabs: true, google: true },
+    audioInputSources: [],
+    audioSourceHint: '',
+    hasCommandError: true,
+    pendingActionId: 'recording:stopRecording'
+  }
+
+  const deps: NativeRecordingDeps = {
+    state,
+    addActivity: vi.fn(),
+    addToast: vi.fn(),
+    logError: vi.fn(),
+    onStateChange: vi.fn()
+  }
+
+  return { deps, state }
+}
+
+describe('handleRecordingCommandDispatch', () => {
+  beforeEach(() => {
+    resetRecordingState()
+    ;(window as Window & { speechToTextApi: any }).speechToTextApi = {
+      playSound: vi.fn(),
+      getHistory: vi.fn(),
+      submitRecordedAudio: vi.fn()
+    }
+  })
+
+  it.each(['stopRecording', 'cancelRecording'] as const)(
+    'shows an idle message and keeps state unchanged for %s when no recording is active',
+    async (command) => {
+      const { deps, state } = createDeps()
+      const beforeState = structuredClone(state)
+
+      await handleRecordingCommandDispatch(deps, { command })
+
+      expect(deps.addActivity).toHaveBeenCalledWith('Recording is not in progress.', 'info')
+      expect(deps.addToast).toHaveBeenCalledWith('Recording is not in progress.', 'info')
+      expect(deps.onStateChange).not.toHaveBeenCalled()
+      expect(deps.logError).not.toHaveBeenCalled()
+      expect(state).toEqual(beforeState)
+      expect(window.speechToTextApi.playSound).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -332,6 +332,11 @@ export const cancelNativeRecording = async (deps: NativeRecordingDeps): Promise<
   await stopNativeRecording(deps)
 }
 
+const notifyIdleRecordingCommand = (deps: NativeRecordingDeps): void => {
+  deps.addActivity('Recording is not in progress.', 'info')
+  deps.addToast('Recording is not in progress.', 'info')
+}
+
 export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, dispatch: RecordingCommandDispatch): Promise<void> => {
   const { state, addActivity, addToast, logError, onStateChange } = deps
   const command = dispatch.command
@@ -347,6 +352,10 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
     }
 
     if (command === 'stopRecording') {
+      if (!isNativeRecording()) {
+        notifyIdleRecordingCommand(deps)
+        return
+      }
       await stopNativeRecording(deps)
       state.hasCommandError = false
       addActivity('Recording captured and queued for transcription.', 'success')
@@ -374,6 +383,10 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
     }
 
     if (command === 'cancelRecording') {
+      if (!isNativeRecording()) {
+        notifyIdleRecordingCommand(deps)
+        return
+      }
       await cancelNativeRecording(deps)
       state.hasCommandError = false
       addActivity('Recording cancelled.', 'info')


### PR DESCRIPTION
## Summary
- show a clear info message when `stopRecording` or `cancelRecording` is triggered while no recording is active
- avoid recorder-state mutations and success/cancel side effects in the idle handler path
- add renderer unit coverage for both idle commands

## Changes
- add idle guard checks in `handleRecordingCommandDispatch()` for `stopRecording` and `cancelRecording`
- route both idle commands to a shared info message: `Recording is not in progress.`
- return before sound playback, `onStateChange`, or recorder-state mutations in idle path
- update work-plan status/checklist for `#124` and mark `#122` as done

## Tests
- `pnpm vitest run src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts`

## Manual Verification
- not required for this ticket (renderer unit-tested behavior)
