### PR TITLE
chore(ui): remove IPC pong display from UI (#123)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -36,13 +36,13 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 |---|---|---|---|---|
 | P0 | Fix macOS paste-at-cursor failure | #121 | Fix | PR OPEN |
 | P0 | Preserve spoken language in STT | #120 | Fix | TODO |
-| P1 | Show message when stop/cancel pressed while idle | #124 | Fix | PR OPEN |
+| P1 | Show message when stop/cancel pressed while idle | #124 | Fix | DONE |
 | P1 | Validate Transformation Profile prompts before saving | #122 | Fix | DONE |
 | P2 | Add Playwright e2e recording test with fake audio | #95 | Test | TODO |
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
 | P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | TODO |
-| P3 | Remove IPC pong display from UI | #123 | UX Change | TODO |
+| P3 | Remove IPC pong display from UI | #123 | UX Change | PR OPEN |
 | P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | TODO |
 | P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | TODO |
 | P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | TODO |
@@ -233,10 +233,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Remove pong indicator from user-facing UI.
 - Granularity: UI display only; do not remove internal diagnostics unless required.
 - Checklist:
-- [ ] Read pong UI rendering path.
-- [ ] Remove UI element without affecting internal diagnostics.
-- [ ] Update tests/snapshots as needed.
-- [ ] Update docs/help text if referenced.
+- [x] Read pong UI rendering path.
+- [x] Remove UI element without affecting internal diagnostics.
+- [x] Update tests/snapshots as needed.
+- [x] Update docs/help text if referenced.
 - Gate:
 - Pong display removed from UI and no regressions.
 - Tests pass and docs updated.
@@ -244,6 +244,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Ensure removal does not break any dev-only diagnostics.
 - Feasibility:
 - High. Simple UI removal.
+- Implementation Notes (2026-02-25):
+- Removed the `IPC pong` chip from `ShellChromeReact` hero metadata.
+- Kept renderer ping state + IPC ping wiring intact to avoid changing internal initialization diagnostics.
+- Updated component test to assert pong text is no longer rendered.
 
 ### #129 - [P3] Rename “config” to “profile” in Transformation settings UI
 - Type: UX Change

--- a/src/renderer/shell-chrome-react.test.tsx
+++ b/src/renderer/shell-chrome-react.test.tsx
@@ -43,6 +43,7 @@ describe('ShellChromeReact', () => {
     await flush()
 
     expect(host.querySelector('h1')?.textContent).toBe('Speech-to-Text v1')
+    expect(host.textContent).not.toContain('IPC pong')
     expect(host.textContent).toContain(`STT ${DEFAULT_SETTINGS.transcription.provider} / ${DEFAULT_SETTINGS.transcription.model}`)
     expect(host.querySelectorAll<HTMLButtonElement>('[data-route-tab]').length).toBe(2)
 

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -18,13 +18,12 @@ interface ShellChromeReactProps {
   onNavigate: (page: AppPage) => void
 }
 
-export const ShellChromeReact = ({ ping, settings, currentPage, onNavigate }: ShellChromeReactProps) => (
+export const ShellChromeReact = ({ settings, currentPage, onNavigate }: ShellChromeReactProps) => (
   <>
     <section className="hero card" data-stagger="" style={{ '--delay': '40ms' } as CSSProperties}>
       <p className="eyebrow">Speech-to-Text Control Room</p>
       <h1>Speech-to-Text v1</h1>
       <div className="hero-meta">
-        <span className="chip chip-good">IPC {ping}</span>
         <span className="chip">STT {settings.transcription.provider} / {settings.transcription.model}</span>
         <span className="chip">Transform {settings.transformation.enabled ? 'Enabled' : 'Disabled'}</span>
       </div>


### PR DESCRIPTION
## Summary
- remove the user-visible `IPC pong` chip from the shell header
- keep internal ping state and IPC ping initialization wiring unchanged
- update component coverage and work-plan status

## Changes
- removed `IPC {ping}` chip rendering from `ShellChromeReact`
- preserved `ping` prop plumbing so internal diagnostics/state setup remain intact
- updated shell chrome component test to assert `IPC pong` is not shown
- updated `docs/github-issues-work-plan.md` (`#123` progress, `#124` status to DONE)

## Tests
- `pnpm vitest run src/renderer/shell-chrome-react.test.tsx src/renderer/renderer-app.test.ts`

## Manual Verification
- not required (UI-only change covered by renderer tests)
