### PR TITLE
chore(ui): use profile terminology in transformation settings (#129)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -42,8 +42,8 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
 | P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | TODO |
-| P3 | Remove IPC pong display from UI | #123 | UX Change | PR OPEN |
-| P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | TODO |
+| P3 | Remove IPC pong display from UI | #123 | UX Change | DONE |
+| P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | PR OPEN |
 | P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | TODO |
 | P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | TODO |
 
@@ -254,10 +254,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Use consistent “profile” terminology in transformation settings UI.
 - Granularity: UI copy only.
 - Checklist:
-- [ ] Read all transformation settings UI copy locations.
-- [ ] Replace “config” with “profile” consistently.
-- [ ] Update tests/snapshots for copy changes.
-- [ ] Update docs/help text if referenced.
+- [x] Read all transformation settings UI copy locations.
+- [x] Replace “config” with “profile” consistently.
+- [x] Update tests/snapshots for copy changes.
+- [x] Update docs/help text if referenced.
 - Gate:
 - Transformation settings UI uses “profile” consistently.
 - Tests pass and docs updated.
@@ -265,6 +265,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Copy changes may require localization or snapshot updates.
 - Feasibility:
 - High. Localized text update.
+- Implementation Notes (2026-02-25):
+- Renamed transformation settings labels/buttons from “configuration” to “profile” (active/default/profile actions/name/model).
+- Updated related settings messages and validation text in the transformation settings flow (add/remove/required-name) to use “profile”.
+- Updated renderer tests to assert profile terminology and no remaining “Configuration” text in the transformation settings component.
 
 ### #127 - [P3] Clarify “Active config” vs “default” in Transformation settings
 - Type: Decision + UX Change

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -309,7 +309,7 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       }
     }
     onStateChange()
-    setSettingsSaveMessage('Configuration added. Save settings to persist.')
+    setSettingsSaveMessage('Profile added. Save settings to persist.')
   }
 
   const removeTransformationPreset = (activePresetId: string): void => {
@@ -318,7 +318,7 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     }
     const presets = state.settings.transformation.presets
     if (presets.length <= 1) {
-      setSettingsSaveMessage('At least one configuration is required.')
+      setSettingsSaveMessage('At least one profile is required.')
       return
     }
     const remaining = presets.filter((preset) => preset.id !== activePresetId)
@@ -335,7 +335,7 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       }
     }
     onStateChange()
-    setSettingsSaveMessage('Configuration removed. Save settings to persist.')
+    setSettingsSaveMessage('Profile removed. Save settings to persist.')
   }
 
   const saveSettingsFromState = async (): Promise<void> => {

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -59,6 +59,15 @@ describe('SettingsTransformationReact', () => {
       )
     })
 
+    expect(host.textContent).toContain('Active profile')
+    expect(host.textContent).toContain('Default profile')
+    expect(host.textContent).toContain('Add Profile')
+    expect(host.textContent).toContain('Remove Active Profile')
+    expect(host.textContent).toContain('Run Selected Profile')
+    expect(host.textContent).toContain('Profile name')
+    expect(host.textContent).toContain('Profile model')
+    expect(host.textContent).not.toContain('Configuration')
+
     await act(async () => {
       host.querySelector<HTMLInputElement>('#settings-transform-enabled')?.click()
     })
@@ -131,7 +140,7 @@ describe('SettingsTransformationReact', () => {
       root?.render(
         <SettingsTransformationReact
           settings={DEFAULT_SETTINGS}
-          presetNameError="Preset name is required."
+          presetNameError="Profile name is required."
           systemPromptError="System prompt is required."
           userPromptError="User prompt must include {{text}}."
           onToggleTransformEnabled={() => {}}
@@ -145,7 +154,7 @@ describe('SettingsTransformationReact', () => {
         />
       )
     })
-    expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Preset name is required.')
+    expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Profile name is required.')
     expect(host.querySelector('#settings-error-system-prompt')?.textContent).toContain('System prompt is required.')
     expect(host.querySelector('#settings-error-user-prompt')?.textContent).toContain('{{text}}')
   })

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -86,7 +86,7 @@ export const SettingsTransformationReact = ({
         <span>Enable transformation</span>
       </label>
       <label className="text-row">
-        <span>Active configuration</span>
+        <span>Active profile</span>
         <select
           id="settings-transform-active-preset"
           value={settings.transformation.activePresetId}
@@ -101,7 +101,7 @@ export const SettingsTransformationReact = ({
         </select>
       </label>
       <label className="text-row">
-        <span>Default configuration</span>
+        <span>Default profile</span>
         <select
           id="settings-transform-default-preset"
           value={settings.transformation.defaultPresetId}
@@ -121,25 +121,25 @@ export const SettingsTransformationReact = ({
           id="settings-preset-add"
           onClick={() => { onAddPreset() }}
         >
-          Add Configuration
+          Add Profile
         </button>
         <button
           type="button"
           id="settings-preset-remove"
           onClick={() => { onRemovePreset(settings.transformation.activePresetId) }}
         >
-          Remove Active Configuration
+          Remove Active Profile
         </button>
         <button
           type="button"
           id="settings-run-selected-preset"
           onClick={() => { onRunSelectedPreset() }}
         >
-          Run Selected Configuration
+          Run Selected Profile
         </button>
       </div>
       <label className="text-row">
-        <span>Configuration name</span>
+        <span>Profile name</span>
         <input
           id="settings-transform-preset-name"
           type="text"
@@ -153,7 +153,7 @@ export const SettingsTransformationReact = ({
       </label>
       <p className="field-error" id="settings-error-preset-name">{presetNameError}</p>
       <label className="text-row">
-        <span>Configuration model</span>
+        <span>Profile model</span>
         <select
           id="settings-transform-preset-model"
           value={presetModel}

--- a/src/renderer/settings-validation.test.ts
+++ b/src/renderer/settings-validation.test.ts
@@ -54,7 +54,7 @@ describe('validateSettingsFormInput', () => {
     })
 
     expect(result.errors.transcriptionBaseUrl).toContain('must be a valid URL')
-    expect(result.errors.presetName).toBe('Configuration name is required.')
+    expect(result.errors.presetName).toBe('Profile name is required.')
     expect(result.errors.startRecording).toContain('duplicated')
     expect(result.errors.stopRecording).toContain('duplicated')
   })

--- a/src/renderer/settings-validation.ts
+++ b/src/renderer/settings-validation.ts
@@ -128,7 +128,7 @@ export const validateSettingsFormInput = (input: SettingsValidationInput): Setti
 
   const presetName = input.presetNameRaw.trim()
   if (presetName.length === 0) {
-    errors.presetName = 'Configuration name is required.'
+    errors.presetName = 'Profile name is required.'
   }
 
   const systemPrompt = input.systemPromptRaw


### PR DESCRIPTION
## Summary
- rename transformation settings UI copy from "configuration" to "profile"
- keep scope to user-facing terminology in the transformation settings flow
- update tests and work-plan status

## Changes
- labels/buttons in `SettingsTransformationReact` now use `profile` terminology
- transformation settings save/validation messages now use `profile` terminology
- updated renderer tests to assert profile copy and absence of `Configuration` in the transformation settings component
- updated `docs/github-issues-work-plan.md` (`#129` progress, `#123` status to DONE)

## Tests
- `pnpm vitest run src/renderer/settings-transformation-react.test.tsx src/renderer/settings-validation.test.ts src/renderer/settings-mutations.test.ts src/renderer/renderer-app.test.ts`

## Manual Verification
- not required (UI copy-only change covered by renderer tests)
