### PR TITLE
chore(ui): simplify home transform shortcut copy/status (#126)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -41,9 +41,9 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 | P2 | Add Playwright e2e recording test with fake audio | #95 | Test | TODO |
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
-| P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | TODO |
+| P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | PR OPEN |
 | P3 | Remove IPC pong display from UI | #123 | UX Change | DONE |
-| P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | PR OPEN |
+| P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | DONE |
 | P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | TODO |
 | P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | TODO |
 
@@ -216,10 +216,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Update copy and remove status per issue request.
 - Granularity: Home shortcut UI copy only.
 - Checklist:
-- [ ] Read Home shortcut UI copy usage.
-- [ ] Replace copy per issue request and remove status display.
-- [ ] Update tests/snapshots for new copy.
-- [ ] Update docs/help text if referenced.
+- [x] Read Home shortcut UI copy usage.
+- [x] Replace copy per issue request and remove status display.
+- [x] Update tests/snapshots for new copy.
+- [x] Update docs/help text if referenced.
 - Gate:
 - Updated copy and status removal are visible in UI.
 - Tests pass and docs updated.
@@ -227,6 +227,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Minor: Copy changes could conflict with localization rules if any exist.
 - Feasibility:
 - High. Localized UI copy changes.
+- Implementation Notes (2026-02-25):
+- Home transformation shortcut panel now uses simplified copy: `Run transformation on clipboard text`.
+- Removed the `lastTransformSummary` line from the Home transformation shortcut panel display.
+- Renamed the transform action button label from `Run Composite Transform` to `Transform` (busy label unchanged).
+- Updated Home renderer tests for new copy and removed status text.
 
 ### #123 - [P3] Remove IPC pong display from the UI
 - Type: UX Change

--- a/src/renderer/home-react.test.tsx
+++ b/src/renderer/home-react.test.tsx
@@ -64,13 +64,16 @@ describe('HomeReact', () => {
     const status = host.querySelector<HTMLElement>('[role="status"]')
     const buttons = [...host.querySelectorAll<HTMLButtonElement>('button.command-button')]
     const startButton = buttons.find((button) => button.textContent === 'Starting...')
-    const transformButton = buttons.find((button) => button.textContent === 'Run Composite Transform')
+    const transformButton = buttons.find((button) => button.textContent === 'Transform')
 
     expect(status?.textContent).toBe('Busy')
     expect(status?.classList.contains('is-busy')).toBe(true)
     expect(startButton?.textContent).toBe('Starting...')
     expect(startButton?.disabled).toBe(false)
     expect(transformButton?.disabled).toBe(true)
+    expect(host.textContent).toContain('Run transformation on clipboard text')
+    expect(host.textContent).not.toContain('Flow 5: pick-and-run transform on clipboard text in one action.')
+    expect(host.textContent).not.toContain('Last transform:')
   })
 
   it('fires command callbacks for Home actions and blocked deep-link', async () => {
@@ -105,7 +108,7 @@ describe('HomeReact', () => {
 
     const commandButtons = [...host.querySelectorAll<HTMLButtonElement>('button.command-button')]
     const startButton = commandButtons.find((button) => button.textContent === 'Start')
-    const transformButton = commandButtons.find((button) => button.textContent === 'Run Composite Transform')
+    const transformButton = commandButtons.find((button) => button.textContent === 'Transform')
     startButton?.click()
     transformButton?.click()
     const inlineLinks = host.querySelectorAll<HTMLButtonElement>('.inline-link')

--- a/src/renderer/home-react.tsx
+++ b/src/renderer/home-react.tsx
@@ -48,7 +48,6 @@ const resolveCommandButtonState = (
 export const HomeReact = ({
   settings,
   apiKeyStatus,
-  lastTransformSummary,
   pendingActionId,
   hasCommandError,
   isRecording,
@@ -68,7 +67,7 @@ export const HomeReact = ({
     pendingActionId,
     'transform:composite',
     transformBlocked !== null,
-    'Run Composite Transform',
+    'Transform',
     'Transforming...'
   )
 
@@ -136,8 +135,7 @@ export const HomeReact = ({
         style={{ '--delay': '160ms' } as StaggerStyle}
       >
         <h2>Transform Shortcut</h2>
-        <p className="muted">Flow 5: pick-and-run transform on clipboard text in one action.</p>
-        <p className="muted">{lastTransformSummary}</p>
+        <p className="muted">Run transformation on clipboard text</p>
         {transformBlocked ? (
           <>
             <p className="inline-error">{transformBlocked.reason}</p>


### PR DESCRIPTION
## Summary
- simplify Home transform shortcut copy
- remove the last-transform status line from the Home shortcut panel
- shorten the transform button label

## Changes
- replaced `Flow 5: pick-and-run transform on clipboard text in one action.` with `Run transformation on clipboard text`
- removed the `lastTransformSummary` line from the Home transform shortcut panel display
- renamed button text from `Run Composite Transform` to `Transform` (kept `Transforming...` busy label)
- updated Home renderer tests and work-plan status for `#126` / `#129`

## Tests
- `pnpm vitest run src/renderer/home-react.test.tsx src/renderer/renderer-app.test.ts`

## Manual Verification
- not required (UI copy/display-only change covered by renderer tests)
