### PR TITLE
docs(ui): clarify active vs default transformation profile semantics (#127)

### DIFF
--- a/docs/decisions/transformation-active-vs-default-profile.md
+++ b/docs/decisions/transformation-active-vs-default-profile.md
@@ -1,0 +1,50 @@
+<!--
+Where: docs/decisions/transformation-active-vs-default-profile.md
+What: Decision record for the meaning of active vs default transformation profiles.
+Why: Clarifies user-facing semantics in Settings and documents existing behavior used by shortcuts/capture flows.
+-->
+
+# Decision Record: Active vs Default Transformation Profile
+
+## Context
+
+The Transformation settings UI exposes both an `active` profile and a `default` profile. Issue `#127` raised that the difference is unclear, especially because some flows use a one-shot picked profile and some flows use the default profile.
+
+The codebase already implements distinct behaviors, but the settings UI did not explain them clearly.
+
+## Decision
+
+Keep both concepts and document them explicitly:
+
+- `Active profile`: the currently selected profile for manual transformation actions in the app UI and the starting selection in the pick-and-run profile picker.
+- `Default profile`: the profile used by default/automatic transformation flows (including capture/recording transformations and the Run Transform shortcut).
+
+These values are allowed to differ.
+
+## Behavioral Definition (Confirmed from Current Code)
+
+- Manual Home transform action (`runCompositeFromClipboard`): uses `activePresetId`.
+- Manual transform-on-selection action: uses `activePresetId`.
+- Pick-and-run transformation: uses a one-time picked profile and does **not** persist `activePresetId` or `defaultPresetId`.
+- Recording/capture transformation pipeline: uses `defaultPresetId`.
+- Run Transform shortcut (default transform hotkey): uses `defaultPresetId`.
+- App restart: both `activePresetId` and `defaultPresetId` persist via saved settings.
+
+## Rationale
+
+- Users may want to experiment with a profile manually (`active`) without changing the stable profile used by repeatable/default flows (`default`).
+- Keeping `default` separate avoids accidental changes to capture/automation behavior when browsing or editing profiles in Settings.
+- The existing code already follows this split; clarifying UI copy is lower risk than changing behavior.
+
+## UI Guidance
+
+The Settings UI should state:
+
+- `Active profile` is for manual transforms and picker starting selection.
+- `Default profile` is for capture/default shortcut flows and persists across restarts.
+- Changing `active` does not change `default`.
+
+## Consequences
+
+- No behavior change is required for `#127`; this is a documentation + UI clarification update.
+- This decision unblocks `#130` (default-profile change UX), which depends on consistent active/default semantics.

--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -41,10 +41,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 | P2 | Add Playwright e2e recording test with fake audio | #95 | Test | TODO |
 | P2 | Improve “change default config” behavior for 2 vs 3+ profiles | #130 | UX Change | TODO |
 | P3 | Per-provider Save buttons for API keys | #125 | UX Change | TODO |
-| P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | PR OPEN |
+| P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | DONE |
 | P3 | Remove IPC pong display from UI | #123 | UX Change | DONE |
 | P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | DONE |
-| P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | TODO |
+| P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | PR OPEN |
 | P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | TODO |
 
 ---
@@ -280,12 +280,12 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Define and communicate the relationship between active and default profiles.
 - Granularity: UX text and behavior alignment only.
 - Checklist:
-- [ ] Read current behavior and any related specs.
-- [ ] Create decision doc in `docs/decisions/` defining semantics.
-- [ ] Update UI copy/help text to reflect the decision.
-- [ ] Align behavior with the documented semantics if needed.
-- [ ] Add at least one test for the clarified behavior.
-- [ ] Update docs/help text.
+- [x] Read current behavior and any related specs.
+- [x] Create decision doc in `docs/decisions/` defining semantics.
+- [x] Update UI copy/help text to reflect the decision.
+- [x] Align behavior with the documented semantics if needed.
+- [x] Add at least one test for the clarified behavior.
+- [x] Update docs/help text.
 - Gate:
 - Decision recorded; UI text and behavior match the decision.
 - Tests pass and docs updated.
@@ -293,6 +293,10 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Product semantics are unclear; require explicit agreement.
 - Feasibility:
 - Medium. Depends on existing behavior alignment.
+- Implementation Notes (2026-02-25):
+- Added decision doc `docs/decisions/transformation-active-vs-default-profile.md` documenting active/default semantics and confirming existing behavior.
+- Added Settings help text clarifying active vs default profile usage and restart persistence.
+- Added/updated tests for clarified behavior and help text (`CommandRouter` capture uses default profile when active/default differ; transformation settings UI copy assertions).
 
 ### #128 - [P3] Clarify “Enable transformation” toggle vs auto-run default transformation
 - Type: Decision + UX Change

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -110,6 +110,31 @@ describe('CommandRouter', () => {
     expect(snapshot.transformationProfile!.provider).toBe('google')
   })
 
+  it('submitRecordedAudio uses default preset (not active preset) when they differ', () => {
+    const captureQueue = { enqueue: vi.fn() }
+    const settings = makeSettings({
+      transformation: {
+        ...DEFAULT_SETTINGS.transformation,
+        activePresetId: 'active-id',
+        defaultPresetId: 'default-id',
+        presets: [
+          { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
+          { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' }
+        ]
+      }
+    })
+    const deps = makeDeps({
+      captureQueue,
+      settingsService: { getSettings: () => settings }
+    })
+    const router = new CommandRouter(deps)
+
+    router.submitRecordedAudio({ data: new Uint8Array([1]), mimeType: 'audio/webm', capturedAt: '2026-02-17T00:00:00Z' })
+
+    const snapshot = captureQueue.enqueue.mock.calls[0][0] as CaptureRequestSnapshot
+    expect(snapshot.transformationProfile?.profileId).toBe('default-id')
+  })
+
   it('submitRecordedAudio sets transformationProfile to null when transformation is disabled', () => {
     const captureQueue = { enqueue: vi.fn() }
     const settings = makeSettings({

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -61,6 +61,8 @@ describe('SettingsTransformationReact', () => {
 
     expect(host.textContent).toContain('Active profile')
     expect(host.textContent).toContain('Default profile')
+    expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('manual Transform actions')
+    expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Run Transform shortcut')
     expect(host.textContent).toContain('Add Profile')
     expect(host.textContent).toContain('Remove Active Profile')
     expect(host.textContent).toContain('Run Selected Profile')
@@ -155,6 +157,8 @@ describe('SettingsTransformationReact', () => {
       )
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Profile name is required.')
+    expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('does not change the default profile')
+    expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Saved across app restarts')
     expect(host.querySelector('#settings-error-system-prompt')?.textContent).toContain('System prompt is required.')
     expect(host.querySelector('#settings-error-user-prompt')?.textContent).toContain('{{text}}')
   })

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -100,6 +100,9 @@ export const SettingsTransformationReact = ({
           ))}
         </select>
       </label>
+      <p className="muted" id="settings-help-active-profile">
+        Used for manual Transform actions and as the starting selection in Pick Transformation. Changing this does not change the default profile.
+      </p>
       <label className="text-row">
         <span>Default profile</span>
         <select
@@ -115,6 +118,9 @@ export const SettingsTransformationReact = ({
           ))}
         </select>
       </label>
+      <p className="muted" id="settings-help-default-profile">
+        Used for recording/capture transformations and the Run Transform shortcut. Saved across app restarts.
+      </p>
       <div className="settings-actions">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- define and document the intended meaning of active vs default transformation profiles
- add Settings help text so users can see the distinction in the UI
- add regression coverage for the clarified default-profile capture behavior

## Changes
- added decision doc: `docs/decisions/transformation-active-vs-default-profile.md`
- added transformation settings help text for `Active profile` and `Default profile`
- added `CommandRouter` test proving capture uses `defaultPresetId` when active/default differ
- updated transformation settings component tests for the new help text
- updated work-plan status/checklist for `#127` and marked `#126` done

## Tests
- `pnpm vitest run src/renderer/settings-transformation-react.test.tsx src/main/core/command-router.test.ts`

## Manual Verification
- not required (decision/doc + UI help text + unit-test coverage)
