### PR TITLE
docs(ui): clarify transformation enable vs auto-run semantics (#128)

### DIFF
--- a/docs/decisions/transformation-enable-vs-auto-run.md
+++ b/docs/decisions/transformation-enable-vs-auto-run.md
@@ -1,0 +1,66 @@
+<!--
+Where: docs/decisions/transformation-enable-vs-auto-run.md
+What: Decision record defining semantics of the transformation enable toggle vs auto-run default transform.
+Why: Clarifies user-facing behavior and removes ambiguity in Settings about what each toggle controls.
+-->
+
+# Decision Record: `Enable transformation` vs `Auto-run default transform`
+
+## Context
+
+Issue `#128` identified confusion in the Transformation settings UI:
+
+- `Enable transformation`
+- `Auto-run default transform`
+
+Users could not tell which flows each toggle affects, and the codebase needed a clear rule for how they interact.
+
+## Decision
+
+Keep both toggles and define them as separate controls:
+
+- `Enable transformation`: master gate for all transformation execution.
+- `Auto-run default transform`: capture/recording-only automation flag for the default profile.
+
+## Behavioral Semantics
+
+### `Enable transformation`
+
+When OFF:
+- Manual transform actions are blocked.
+- Transformation shortcuts are blocked.
+- Recording/capture jobs do not run transformation.
+- `Auto-run default transform` has no effect until transformation is enabled again.
+
+When ON:
+- Manual transform actions and transformation shortcuts are allowed (subject to API key and other existing checks).
+- Capture/recording transformation depends on the auto-run toggle.
+
+### `Auto-run default transform`
+
+When OFF:
+- Recording/capture jobs keep transcription output but skip automatic transformation.
+- Manual transform actions and transformation shortcuts still work.
+
+When ON:
+- Recording/capture jobs automatically run transformation using the default profile (when transformation is enabled).
+
+## Rationale
+
+- `Enable transformation` is the clear global off-switch for the feature.
+- `Auto-run default transform` is not a global enable flag; it controls whether capture flows automatically apply the default profile.
+- This separation supports common usage:
+  - manual transforms available, but no automatic transform on every recording
+  - a full feature off state without changing per-profile settings
+
+## Implementation Alignment
+
+This decision aligns behavior and UI by:
+
+- clarifying both toggles in Settings help text
+- ensuring capture snapshot binding and legacy processing orchestration skip transformation when auto-run is disabled
+
+## Consequences
+
+- `#128` is a decision + UX clarification with a small behavior alignment change.
+- Future toggle-related UX changes should reference this decision doc before changing semantics.

--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -44,8 +44,8 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 | P3 | Simplify Home transformation shortcut copy/status | #126 | UX Change | DONE |
 | P3 | Remove IPC pong display from UI | #123 | UX Change | DONE |
 | P3 | Rename “config” to “profile” in Transformation settings UI | #129 | UX Change | DONE |
-| P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | PR OPEN |
-| P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | TODO |
+| P3 | Clarify “Active config” vs “default” in Transformation settings | #127 | Decision + UX Change | DONE |
+| P3 | Clarify “Enable transformation” toggle vs auto-run default | #128 | Decision + UX Change | PR OPEN |
 
 ---
 
@@ -303,12 +303,12 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Goal: Define toggle interaction rules and ensure UI matches behavior.
 - Granularity: Toggle semantics and help text only.
 - Checklist:
-- [ ] Read current toggle behavior and settings dependencies.
-- [ ] Create decision doc in `docs/decisions/` defining interaction rules.
-- [ ] Update UI copy/help text to reflect the decision.
-- [ ] Align behavior with the documented semantics if needed.
-- [ ] Add at least one test for toggle combinations.
-- [ ] Update docs/help text.
+- [x] Read current toggle behavior and settings dependencies.
+- [x] Create decision doc in `docs/decisions/` defining interaction rules.
+- [x] Update UI copy/help text to reflect the decision.
+- [x] Align behavior with the documented semantics if needed.
+- [x] Add at least one test for toggle combinations.
+- [x] Update docs/help text.
 - Gate:
 - Decision recorded; UI text and behavior match the decision.
 - Tests pass and docs updated.
@@ -316,3 +316,8 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Ambiguous behavior could lead to user confusion if not carefully specified.
 - Feasibility:
 - Medium. Requires agreement on intended semantics.
+- Implementation Notes (2026-02-25):
+- Added decision doc `docs/decisions/transformation-enable-vs-auto-run.md` defining `Enable transformation` as the master gate and `Auto-run default transform` as capture/recording-only automation.
+- Added Settings help text under both toggles clarifying scope and interaction.
+- Aligned capture/processing behavior so auto-run-off skips automatic transformation (while manual transform flows remain gated only by `enabled`).
+- Added tests for capture snapshot binding and processing behavior when auto-run is disabled, plus UI help text assertions.

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -215,10 +215,11 @@ export class CommandRouter {
 
   /**
    * Resolve transformation profile for capture snapshot.
-   * Returns null when transformation is disabled, meaning the pipeline skips LLM.
+   * Returns null when transformation is disabled or auto-run is off,
+   * meaning the capture pipeline skips LLM transformation.
    */
   private resolveTransformationProfile(settings: Settings): TransformationProfileSnapshot | null {
-    if (!settings.transformation.enabled) {
+    if (!settings.transformation.enabled || !settings.transformation.autoRunDefaultTransform) {
       return null
     }
 

--- a/src/main/orchestrators/processing-orchestrator.ts
+++ b/src/main/orchestrators/processing-orchestrator.ts
@@ -115,7 +115,12 @@ export class ProcessingOrchestrator {
       failureDetail = await this.resolveTranscriptionFailureDetail(settings, error)
     }
 
-    if (terminalStatus === 'succeeded' && settings.transformation.enabled && transcriptText !== null) {
+    if (
+      terminalStatus === 'succeeded' &&
+      settings.transformation.enabled &&
+      settings.transformation.autoRunDefaultTransform &&
+      transcriptText !== null
+    ) {
       try {
         const transformationApiKey = this.secretStore.getApiKey('google')
         if (!transformationApiKey) {

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -61,6 +61,8 @@ describe('SettingsTransformationReact', () => {
 
     expect(host.textContent).toContain('Active profile')
     expect(host.textContent).toContain('Default profile')
+    expect(host.querySelector('#settings-help-transform-enabled')?.textContent).toContain('Master switch')
+    expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('recording/capture automatic transformation')
     expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('manual Transform actions')
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Run Transform shortcut')
     expect(host.textContent).toContain('Add Profile')
@@ -157,6 +159,8 @@ describe('SettingsTransformationReact', () => {
       )
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Profile name is required.')
+    expect(host.querySelector('#settings-help-transform-enabled')?.textContent).toContain('manual transforms')
+    expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('Manual transforms still work')
     expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('does not change the default profile')
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Saved across app restarts')
     expect(host.querySelector('#settings-error-system-prompt')?.textContent).toContain('System prompt is required.')

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -85,6 +85,9 @@ export const SettingsTransformationReact = ({
         />
         <span>Enable transformation</span>
       </label>
+      <p className="muted" id="settings-help-transform-enabled">
+        Master switch for all transformation execution (manual transforms, shortcuts, and recording/capture auto-run).
+      </p>
       <label className="text-row">
         <span>Active profile</span>
         <select
@@ -185,6 +188,9 @@ export const SettingsTransformationReact = ({
         />
         <span>Auto-run default transform</span>
       </label>
+      <p className="muted" id="settings-help-transform-auto-run">
+        Only affects recording/capture automatic transformation using the default profile. Manual transforms still work when this is off (if transformation is enabled).
+      </p>
       <label className="text-row">
         <span>System prompt</span>
         <textarea


### PR DESCRIPTION
## Summary
- define the behavior of `Enable transformation` vs `Auto-run default transform`
- add Settings help text clarifying what each toggle affects
- align capture/processing behavior so auto-run off skips automatic transformation

## Changes
- added decision doc: `docs/decisions/transformation-enable-vs-auto-run.md`
- added toggle help text in `SettingsTransformationReact`
- capture snapshot binding now skips transformation profile when auto-run is off
- legacy `ProcessingOrchestrator` now also skips auto-run transformation when auto-run is off
- added tests for capture/processing auto-run-disabled behavior and UI help text
- updated work-plan status/checklist for `#128` and marked `#127` done

## Tests
- `pnpm vitest run src/renderer/settings-transformation-react.test.tsx src/main/core/command-router.test.ts src/main/orchestrators/processing-orchestrator.test.ts`

## Manual Verification
- not required (decision+UI help text + unit-tested behavior alignment)
