### PR TITLE
Remove transformation enable setting

### DIFF
--- a/docs/decisions/transformation-enable-vs-auto-run.md
+++ b/docs/decisions/transformation-enable-vs-auto-run.md
@@ -1,40 +1,28 @@
 <!--
 Where: docs/decisions/transformation-enable-vs-auto-run.md
-What: Decision record defining semantics of the transformation enable toggle vs auto-run default transform.
-Why: Clarifies user-facing behavior and removes ambiguity in Settings about what each toggle controls.
+What: Decision record describing the removal of the transformation enable toggle and the remaining auto-run control.
+Why: Keeps settings semantics clear after simplifying transformation behavior to always-enabled manual execution.
 -->
 
-# Decision Record: `Enable transformation` vs `Auto-run default transform`
+# Decision Record: Remove `Enable transformation`, keep `Auto-run default transform`
 
 ## Context
 
-Issue `#128` identified confusion in the Transformation settings UI:
+The Transformation settings UI previously exposed two controls:
 
 - `Enable transformation`
 - `Auto-run default transform`
 
-Users could not tell which flows each toggle affects, and the codebase needed a clear rule for how they interact.
+This created ongoing confusion and unnecessary states. In practice, users mainly need to control automatic transformation on recording/capture flows, while manual transform actions should remain available whenever prerequisites (API key, preset) are satisfied.
 
 ## Decision
 
-Keep both toggles and define them as separate controls:
+Remove the `Enable transformation` setting from the UI and treat transformation as always enabled.
 
-- `Enable transformation`: master gate for all transformation execution.
-- `Auto-run default transform`: capture/recording-only automation flag for the default profile.
+- Manual transform actions and transform shortcuts are always allowed (subject to existing prerequisites such as API keys).
+- `Auto-run default transform` remains the only user-facing toggle and controls recording/capture automation only.
 
 ## Behavioral Semantics
-
-### `Enable transformation`
-
-When OFF:
-- Manual transform actions are blocked.
-- Transformation shortcuts are blocked.
-- Recording/capture jobs do not run transformation.
-- `Auto-run default transform` has no effect until transformation is enabled again.
-
-When ON:
-- Manual transform actions and transformation shortcuts are allowed (subject to API key and other existing checks).
-- Capture/recording transformation depends on the auto-run toggle.
 
 ### `Auto-run default transform`
 
@@ -43,24 +31,22 @@ When OFF:
 - Manual transform actions and transformation shortcuts still work.
 
 When ON:
-- Recording/capture jobs automatically run transformation using the default profile (when transformation is enabled).
+- Recording/capture jobs automatically run transformation using the default profile.
 
 ## Rationale
 
-- `Enable transformation` is the clear global off-switch for the feature.
-- `Auto-run default transform` is not a global enable flag; it controls whether capture flows automatically apply the default profile.
-- This separation supports common usage:
-  - manual transforms available, but no automatic transform on every recording
-  - a full feature off state without changing per-profile settings
+- The global transformation off-switch added complexity but little value.
+- Users already have a clear way to stop automatic transformation (`Auto-run default transform`).
+- Keeping manual transforms available avoids a hidden failure mode after users disable transformation and later forget why shortcuts stop working.
 
 ## Implementation Alignment
 
 This decision aligns behavior and UI by:
 
-- clarifying both toggles in Settings help text
-- ensuring capture snapshot binding and legacy processing orchestration skip transformation when auto-run is disabled
+- removing the `Enable transformation` control from Settings
+- using `Auto-run default transform` as the only automation toggle
 
 ## Consequences
 
-- `#128` is a decision + UX clarification with a small behavior alignment change.
-- Future toggle-related UX changes should reference this decision doc before changing semantics.
+- The settings UI is simpler and avoids contradictory toggle states.
+- No backward-compatibility migration is kept for the removed `transformation.enabled` field.

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -155,10 +155,6 @@ export class CommandRouter {
     const normalizedText = options.sourceText.trim()
 
     const { settings, preset, textSource, emptyTextMessage } = options
-    if (!settings.transformation.enabled) {
-      return { status: 'error', message: 'Transformation is disabled in Settings.' }
-    }
-
     if (!preset) {
       return { status: 'error', message: 'No transformation preset configured.' }
     }
@@ -215,11 +211,11 @@ export class CommandRouter {
 
   /**
    * Resolve transformation profile for capture snapshot.
-   * Returns null when transformation is disabled or auto-run is off,
+   * Returns null when auto-run is off,
    * meaning the capture pipeline skips LLM transformation.
    */
   private resolveTransformationProfile(settings: Settings): TransformationProfileSnapshot | null {
-    if (!settings.transformation.enabled || !settings.transformation.autoRunDefaultTransform) {
+    if (!settings.transformation.autoRunDefaultTransform) {
       return null
     }
 

--- a/src/main/orchestrators/processing-orchestrator.test.ts
+++ b/src/main/orchestrators/processing-orchestrator.test.ts
@@ -33,14 +33,14 @@ const job: QueueJobRecord = {
 }
 
 describe('ProcessingOrchestrator', () => {
-  it('skips transformation when feature is disabled', async () => {
+  it('runs transformation when auto-run is on', async () => {
     const appendRecord = vi.fn()
-    const transform = vi.fn()
+    const transform = vi.fn(async () => ({ text: 'hello transformed', model: 'gemini-2.5-flash' as const }))
     const settings: Settings = {
       ...baseSettings,
       transformation: {
         ...baseSettings.transformation,
-        enabled: false
+        autoRunDefaultTransform: true
       }
     }
 
@@ -63,7 +63,7 @@ describe('ProcessingOrchestrator', () => {
 
     const result = await orchestrator.process(job)
     expect(result).toBe('succeeded')
-    expect(transform).not.toHaveBeenCalled()
+    expect(transform).toHaveBeenCalledOnce()
     expect(appendRecord).toHaveBeenCalledTimes(1)
   })
 
@@ -74,7 +74,6 @@ describe('ProcessingOrchestrator', () => {
       ...baseSettings,
       transformation: {
         ...baseSettings.transformation,
-        enabled: true,
         autoRunDefaultTransform: false
       }
     }

--- a/src/main/orchestrators/processing-orchestrator.ts
+++ b/src/main/orchestrators/processing-orchestrator.ts
@@ -117,7 +117,6 @@ export class ProcessingOrchestrator {
 
     if (
       terminalStatus === 'succeeded' &&
-      settings.transformation.enabled &&
       settings.transformation.autoRunDefaultTransform &&
       transcriptText !== null
     ) {

--- a/src/main/orchestrators/transformation-orchestrator.test.ts
+++ b/src/main/orchestrators/transformation-orchestrator.test.ts
@@ -21,25 +21,27 @@ const baseSettings: Settings = {
 }
 
 describe('TransformationOrchestrator', () => {
-  it('returns error when transformation is disabled', async () => {
+  it('runs clipboard transform even when auto-run is off', async () => {
+    const transform = vi.fn(async () => ({ text: 'transformed text', model: 'gemini-2.5-flash' as const }))
     const orchestrator = new TransformationOrchestrator({
       settingsService: {
         getSettings: () => ({
           ...baseSettings,
           transformation: {
             ...baseSettings.transformation,
-            enabled: false
+            autoRunDefaultTransform: false
           }
         })
       },
       clipboardClient: { readText: () => 'input text' },
       secretStore: { getApiKey: () => 'key' },
-      transformationService: { transform: vi.fn() } as any,
+      transformationService: { transform } as any,
       outputService: { applyOutputWithDetail: vi.fn(async () => ({ status: 'succeeded', message: null })) } as any
     })
 
     const result = await orchestrator.runCompositeFromClipboard()
-    expect(result).toEqual({ status: 'error', message: 'Transformation is disabled in Settings.' })
+    expect(result).toEqual({ status: 'ok', message: 'transformed text' })
+    expect(transform).toHaveBeenCalledOnce()
   })
 
   it('returns error when clipboard is empty', async () => {

--- a/src/main/orchestrators/transformation-orchestrator.ts
+++ b/src/main/orchestrators/transformation-orchestrator.ts
@@ -55,9 +55,6 @@ export class TransformationOrchestrator {
 
   async runCompositeFromClipboard(): Promise<CompositeResult> {
     const settings = this.settingsService.getSettings()
-    if (!settings.transformation.enabled) {
-      return { status: 'error', message: 'Transformation is disabled in Settings.' }
-    }
     const preset = this.resolveActivePreset(settings)
     const clipboardText = this.readTopmostClipboardText()
     if (!clipboardText) {

--- a/src/main/services/settings-service.test.ts
+++ b/src/main/services/settings-service.test.ts
@@ -22,10 +22,10 @@ describe('SettingsService', () => {
   it('returns a clone instead of mutable internal state', () => {
     const service = new SettingsService(createMockStore())
     const settings = service.getSettings()
-    settings.transformation.enabled = false
+    settings.recording.device = 'Mutated Device'
 
     const reloaded = service.getSettings()
-    expect(reloaded.transformation.enabled).toBe(DEFAULT_SETTINGS.transformation.enabled)
+    expect(reloaded.recording.device).toBe(DEFAULT_SETTINGS.recording.device)
   })
 
   it('stores updated settings and reads them back', () => {
@@ -45,6 +45,20 @@ describe('SettingsService', () => {
     // Same store, new service instance — proves data comes from store, not instance state
     const serviceB = new SettingsService(store)
     expect(serviceB.getSettings().recording.device).toBe('Built-in Microphone')
+  })
+
+  it('strips removed transformation.enabled key when saving', () => {
+    const store = createMockStore()
+    const service = new SettingsService(store)
+    const next = structuredClone(service.getSettings()) as Settings & {
+      transformation: Settings['transformation'] & { enabled?: boolean }
+    }
+    next.transformation.enabled = false
+
+    const saved = service.setSettings(next as Settings)
+
+    expect('enabled' in (saved.transformation as Record<string, unknown>)).toBe(false)
+    expect('enabled' in (store.get('settings').transformation as Record<string, unknown>)).toBe(false)
   })
 
   it('rejects invalid settings payloads', () => {

--- a/src/main/services/settings-service.ts
+++ b/src/main/services/settings-service.ts
@@ -3,7 +3,8 @@
 // Why: Settings survive app restarts (replaces previous in-memory-only storage).
 
 import Store from 'electron-store'
-import { DEFAULT_SETTINGS, type Settings, validateSettings } from '../../shared/domain'
+import * as v from 'valibot'
+import { DEFAULT_SETTINGS, SettingsSchema, type Settings, validateSettings } from '../../shared/domain'
 
 export type SettingsStoreSchema = { settings: Settings }
 
@@ -34,7 +35,9 @@ export class SettingsService {
       throw new Error(`Invalid settings: ${errors.map((e) => `${e.field}: ${e.message}`).join('; ')}`)
     }
 
-    this.store.set('settings', structuredClone(nextSettings))
+    // Persist the schema-parsed output so removed/unknown keys are stripped.
+    const parsedSettings = v.parse(SettingsSchema, nextSettings)
+    this.store.set('settings', structuredClone(parsedSettings))
     return this.getSettings()
   }
 }

--- a/src/main/test-support/settings-fixtures.ts
+++ b/src/main/test-support/settings-fixtures.ts
@@ -8,11 +8,11 @@ import type { Settings } from '../../shared/domain'
 /** Minimal valid settings using all defaults. */
 export const SETTINGS_MINIMAL: Settings = buildSettings()
 
-/** Transformation disabled — processing skips LLM step. */
-export const SETTINGS_TRANSFORM_DISABLED: Settings = buildSettings({
+/** Auto-run transformation disabled — processing skips LLM step. */
+export const SETTINGS_TRANSFORM_AUTO_RUN_DISABLED: Settings = buildSettings({
   transformation: {
     ...buildSettings().transformation,
-    enabled: false
+    autoRunDefaultTransform: false
   }
 })
 

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -84,7 +84,6 @@ export interface AppShellCallbacks {
   onSelectRecordingDevice: (deviceId: string) => void
   onSelectTranscriptionProvider: (provider: Settings['transcription']['provider']) => void
   onSelectTranscriptionModel: (model: Settings['transcription']['model']) => void
-  onToggleTransformEnabled: (checked: boolean) => void
   onToggleAutoRun: (checked: boolean) => void
   onSelectActivePreset: (presetId: string) => void
   onSelectDefaultPreset: (presetId: string) => void
@@ -239,9 +238,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                 presetNameError={uiState.settingsValidationErrors.presetName ?? ''}
                 systemPromptError={uiState.settingsValidationErrors.systemPrompt ?? ''}
                 userPromptError={uiState.settingsValidationErrors.userPrompt ?? ''}
-                onToggleTransformEnabled={(checked: boolean) => {
-                  callbacks.onToggleTransformEnabled(checked)
-                }}
                 onToggleAutoRun={(checked: boolean) => {
                   callbacks.onToggleAutoRun(checked)
                 }}

--- a/src/renderer/blocked-control.test.ts
+++ b/src/renderer/blocked-control.test.ts
@@ -31,22 +31,13 @@ describe('resolveRecordingBlockedMessage', () => {
 })
 
 describe('resolveTransformBlockedMessage', () => {
-  it('returns disablement guidance when transformation is turned off', () => {
-    const result = resolveTransformBlockedMessage(
-      {
-        ...DEFAULT_SETTINGS,
-        transformation: {
-          ...DEFAULT_SETTINGS.transformation,
-          enabled: false
-        }
-      },
-      { groq: true, elevenlabs: true, google: true }
-    )
-    expect(result).toEqual({
-      reason: 'Transformation is blocked because it is disabled.',
-      nextStep: 'Open Settings > Transformation and enable transformation.',
-      deepLinkTarget: 'settings'
+  it('returns null when Google key is present', () => {
+    const result = resolveTransformBlockedMessage(DEFAULT_SETTINGS, {
+      groq: true,
+      elevenlabs: true,
+      google: true
     })
+    expect(result).toBeNull()
   })
 
   it('returns missing-key guidance when google key is not present', () => {

--- a/src/renderer/blocked-control.ts
+++ b/src/renderer/blocked-control.ts
@@ -37,13 +37,6 @@ export const resolveTransformBlockedMessage = (
   settings: Settings,
   apiKeyStatus: ApiKeyStatusSnapshot
 ): BlockedControlMessage | null => {
-  if (!settings.transformation.enabled) {
-    return {
-      reason: 'Transformation is blocked because it is disabled.',
-      nextStep: 'Open Settings > Transformation and enable transformation.',
-      deepLinkTarget: 'settings'
-    }
-  }
   if (!apiKeyStatus.google) {
     return {
       reason: 'Transformation is blocked because the Google API key is missing.',

--- a/src/renderer/home-react.test.tsx
+++ b/src/renderer/home-react.test.tsx
@@ -25,11 +25,7 @@ const readyStatus: ApiKeyStatusSnapshot = {
 }
 
 const readySettings: Settings = {
-  ...DEFAULT_SETTINGS,
-  transformation: {
-    ...DEFAULT_SETTINGS.transformation,
-    enabled: true
-  }
+  ...DEFAULT_SETTINGS
 }
 
 let root: Root | null = null
@@ -87,8 +83,7 @@ describe('HomeReact', () => {
     root.render(
       <HomeReact
         settings={{
-          ...readySettings,
-          transformation: { ...readySettings.transformation, enabled: false }
+          ...readySettings
         }}
         apiKeyStatus={{
           groq: false,

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -410,12 +410,6 @@ const rerenderShellFromState = (): void => {
         transcription: { ...current.transcription, model }
       }))
     },
-    onToggleTransformEnabled: (checked) => {
-      applyNonSecretAutosavePatch((current) => ({
-        ...current,
-        transformation: { ...current.transformation, enabled: checked }
-      }))
-    },
     onToggleAutoRun: (checked) => {
       applyNonSecretAutosavePatch((current) => ({
         ...current,

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -31,7 +31,6 @@ describe('SettingsTransformationReact', () => {
     document.body.append(host)
     root = createRoot(host)
 
-    const onToggleTransformEnabled = vi.fn()
     const onToggleAutoRun = vi.fn()
     const onSelectActivePreset = vi.fn()
     const onSelectDefaultPreset = vi.fn()
@@ -47,7 +46,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError=""
           systemPromptError=""
           userPromptError=""
-          onToggleTransformEnabled={onToggleTransformEnabled}
           onToggleAutoRun={onToggleAutoRun}
           onSelectActivePreset={onSelectActivePreset}
           onSelectDefaultPreset={onSelectDefaultPreset}
@@ -61,7 +59,6 @@ describe('SettingsTransformationReact', () => {
 
     expect(host.textContent).toContain('Active profile')
     expect(host.textContent).toContain('Default profile')
-    expect(host.querySelector('#settings-help-transform-enabled')?.textContent).toContain('Master switch')
     expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('recording/capture automatic transformation')
     expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('manual Transform actions')
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Run Transform shortcut')
@@ -72,10 +69,8 @@ describe('SettingsTransformationReact', () => {
     expect(host.textContent).toContain('Profile model')
     expect(host.textContent).not.toContain('Configuration')
 
-    await act(async () => {
-      host.querySelector<HTMLInputElement>('#settings-transform-enabled')?.click()
-    })
-    expect(onToggleTransformEnabled).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('#settings-transform-enabled')).toBeNull()
+    expect(host.querySelector('#settings-help-transform-enabled')).toBeNull()
 
     await act(async () => {
       host.querySelector<HTMLInputElement>('#settings-transform-auto-run')?.click()
@@ -126,7 +121,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError=""
           systemPromptError=""
           userPromptError=""
-          onToggleTransformEnabled={() => {}}
           onToggleAutoRun={() => {}}
           onSelectActivePreset={() => {}}
           onSelectDefaultPreset={() => {}}
@@ -147,7 +141,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError="Profile name is required."
           systemPromptError="System prompt is required."
           userPromptError="User prompt must include {{text}}."
-          onToggleTransformEnabled={() => {}}
           onToggleAutoRun={() => {}}
           onSelectActivePreset={() => {}}
           onSelectDefaultPreset={() => {}}
@@ -159,7 +152,7 @@ describe('SettingsTransformationReact', () => {
       )
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Profile name is required.')
-    expect(host.querySelector('#settings-help-transform-enabled')?.textContent).toContain('manual transforms')
+    expect(host.querySelector('#settings-help-transform-enabled')).toBeNull()
     expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('Manual transforms still work')
     expect(host.querySelector('#settings-help-active-profile')?.textContent).toContain('does not change the default profile')
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Saved across app restarts')

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -14,7 +14,6 @@ interface SettingsTransformationReactProps {
   presetNameError: string
   systemPromptError: string
   userPromptError: string
-  onToggleTransformEnabled: (checked: boolean) => void
   onToggleAutoRun: (checked: boolean) => void
   onSelectActivePreset: (presetId: string) => void
   onSelectDefaultPreset: (presetId: string) => void
@@ -31,7 +30,6 @@ export const SettingsTransformationReact = ({
   presetNameError,
   systemPromptError,
   userPromptError,
-  onToggleTransformEnabled,
   onToggleAutoRun,
   onSelectActivePreset,
   onSelectDefaultPreset,
@@ -44,7 +42,6 @@ export const SettingsTransformationReact = ({
     settings.transformation.presets.find((preset) => preset.id === settings.transformation.activePresetId) ??
     settings.transformation.presets[0]
 
-  const [enabled, setEnabled] = useState(settings.transformation.enabled)
   const [autoRun, setAutoRun] = useState(settings.transformation.autoRunDefaultTransform)
   const [presetName, setPresetName] = useState(activePreset?.name ?? 'Default')
   const [presetModel, setPresetModel] = useState(activePreset?.model ?? 'gemini-2.5-flash')
@@ -52,14 +49,12 @@ export const SettingsTransformationReact = ({
   const [userPrompt, setUserPrompt] = useState(activePreset?.userPrompt ?? '')
 
   useEffect(() => {
-    setEnabled(settings.transformation.enabled)
     setAutoRun(settings.transformation.autoRunDefaultTransform)
     setPresetName(activePreset?.name ?? 'Default')
     setPresetModel(activePreset?.model ?? 'gemini-2.5-flash')
     setSystemPrompt(activePreset?.systemPrompt ?? '')
     setUserPrompt(activePreset?.userPrompt ?? '')
   }, [
-    settings.transformation.enabled,
     settings.transformation.autoRunDefaultTransform,
     settings.transformation.activePresetId,
     settings.transformation.defaultPresetId,
@@ -72,22 +67,6 @@ export const SettingsTransformationReact = ({
   return (
     <div>
       <h3>Transformation</h3>
-      <label className="toggle-row">
-        <input
-          type="checkbox"
-          id="settings-transform-enabled"
-          checked={enabled}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => {
-            const checked = event.target.checked
-            setEnabled(checked)
-            onToggleTransformEnabled(checked)
-          }}
-        />
-        <span>Enable transformation</span>
-      </label>
-      <p className="muted" id="settings-help-transform-enabled">
-        Master switch for all transformation execution (manual transforms, shortcuts, and recording/capture auto-run).
-      </p>
       <label className="text-row">
         <span>Active profile</span>
         <select
@@ -189,7 +168,7 @@ export const SettingsTransformationReact = ({
         <span>Auto-run default transform</span>
       </label>
       <p className="muted" id="settings-help-transform-auto-run">
-        Only affects recording/capture automatic transformation using the default profile. Manual transforms still work when this is off (if transformation is enabled).
+        Only affects recording/capture automatic transformation using the default profile. Manual transforms still work when this is off.
       </p>
       <label className="text-row">
         <span>System prompt</span>

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -25,7 +25,7 @@ export const ShellChromeReact = ({ settings, currentPage, onNavigate }: ShellChr
       <h1>Speech-to-Text v1</h1>
       <div className="hero-meta">
         <span className="chip">STT {settings.transcription.provider} / {settings.transcription.model}</span>
-        <span className="chip">Transform {settings.transformation.enabled ? 'Enabled' : 'Disabled'}</span>
+        <span className="chip">Transform Auto-run {settings.transformation.autoRunDefaultTransform ? 'On' : 'Off'}</span>
       </div>
     </section>
     <nav className="top-nav card" aria-label="Primary">

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -130,7 +130,6 @@ export const SettingsSchema = v.object({
   }),
   transformation: v.pipe(
     v.object({
-      enabled: v.boolean(),
       activePresetId: v.string(),
       defaultPresetId: v.string(),
       baseUrlOverrides: v.object({
@@ -203,7 +202,6 @@ export const DEFAULT_SETTINGS: Settings = {
     networkRetries: 2
   },
   transformation: {
-    enabled: true,
     activePresetId: 'default',
     defaultPresetId: 'default',
     baseUrlOverrides: {


### PR DESCRIPTION
## Summary
- remove the Settings UI toggle for `Enable transformation` and make manual transformation paths always available
- use only `Auto-run default transform` for capture/recording automation gating
- remove `transformation.enabled` from the settings schema/defaults (no backward-compat migration), and strip unknown/removed keys on save
- update unit tests and e2e tests to the new settings contract and UI selectors

## Testing
- `pnpm typecheck`
- `pnpm vitest run src/main/services/settings-service.test.ts src/main/core/command-router.test.ts src/main/orchestrators/transformation-orchestrator.test.ts src/main/orchestrators/processing-orchestrator.test.ts src/renderer/settings-transformation-react.test.tsx src/renderer/blocked-control.test.ts src/renderer/home-react.test.tsx`
- `pnpm exec playwright test e2e/electron-ui.e2e.ts --list` (parse/list check only)

## Notes
- No backward-compatibility migration is kept for removed `transformation.enabled`.
- Old persisted `transformation.enabled` keys are stripped on the next successful settings save.