### PR TITLE
Fix recording shortcut behavior after closing main window

### DIFF
--- a/docs/decisions/window-close-background-shortcuts.md
+++ b/docs/decisions/window-close-background-shortcuts.md
@@ -1,0 +1,21 @@
+<!-- Where: docs/decisions/window-close-background-shortcuts.md | What: decision for window-close lifecycle behavior with tray/global shortcuts | Why: clarify expected behavior across installed and dist runs -->
+
+# Decision: Keep App Alive After Main Window Close
+
+## Context
+- The app registers global shortcuts in the Electron main process.
+- Recording shortcuts are executed by dispatching commands from the main process to renderer windows.
+- Closing the main window destroyed the only renderer, so recording shortcuts could no longer complete after the window was closed.
+- Issue #150 reported this during manual testing by launching the app directly from `dist/`.
+
+## Decision
+- Treat the main window close button as "hide to background" during normal operation so the renderer remains alive for recording shortcut handling.
+- Allow real window close only during explicit app quit (`before-quit` marks quit intent first).
+- Global shortcuts remain active until the user explicitly quits the app (for example via the tray menu) or the process exits.
+- This expectation applies to both installed builds and manual `dist/` launches.
+
+## Consequences
+- Window close now behaves consistently with the documented background-shortcut user flow and preserves renderer-backed recording shortcuts.
+- Non-macOS `window-all-closed` behavior remains unchanged (app quits when all windows are actually closed).
+- `will-quit` remains the single place where global shortcuts are unregistered.
+- Users can still fully exit via explicit quit actions.

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -152,6 +152,10 @@ Steps:
 2. Upon login, the app launches automatically.
 3. Global shortcuts become active and ready for use in background even if window is closed.
 
+Notes:
+- Expected behavior is the same for installed builds and manual runs launched from `dist/`: closing the main window should hide it (background/tray mode) rather than destroying the renderer, so global shortcuts continue to work while the app process is still running.
+- Global shortcuts stop only after the app is explicitly quit (for example via the tray menu) or the process exits/crashes.
+
 ---
 
 ## Flow 7: Run Transformation on Selected Text

--- a/src/main/core/app-lifecycle.test.ts
+++ b/src/main/core/app-lifecycle.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Where: src/main/core/app-lifecycle.test.ts
+ * What:  Tests for AppLifecycle window-close and quit-cleanup behavior.
+ * Why:   Prevent regressions where closing the main window exits the process and kills global shortcuts.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type AppListener = (...args: unknown[]) => void
+
+const mocks = vi.hoisted(() => {
+  const appListeners = new Map<string, AppListener>()
+  const requestSingleInstanceLock = vi.fn<() => boolean>()
+  const quit = vi.fn()
+  const on = vi.fn((event: string, listener: AppListener) => {
+    appListeners.set(event, listener)
+  })
+  const whenReady = vi.fn<() => Promise<void>>()
+  const setLoginItemSettings = vi.fn()
+  const getAllWindows = vi.fn(() => [])
+
+  const registerIpcHandlers = vi.fn()
+  const unregisterGlobalHotkeys = vi.fn()
+
+  const createMainWindow = vi.fn()
+  const ensureTray = vi.fn()
+  const showMainWindow = vi.fn()
+  const markQuitting = vi.fn()
+
+  return {
+    appListeners,
+    requestSingleInstanceLock,
+    quit,
+    on,
+    whenReady,
+    setLoginItemSettings,
+    getAllWindows,
+    registerIpcHandlers,
+    unregisterGlobalHotkeys,
+    createMainWindow,
+    ensureTray,
+    showMainWindow,
+    markQuitting
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    requestSingleInstanceLock: mocks.requestSingleInstanceLock,
+    quit: mocks.quit,
+    on: mocks.on,
+    whenReady: mocks.whenReady,
+    setLoginItemSettings: mocks.setLoginItemSettings
+  },
+  BrowserWindow: {
+    getAllWindows: mocks.getAllWindows
+  }
+}))
+
+vi.mock('../ipc/register-handlers', () => ({
+  registerIpcHandlers: mocks.registerIpcHandlers,
+  unregisterGlobalHotkeys: mocks.unregisterGlobalHotkeys
+}))
+
+vi.mock('./window-manager', () => ({
+  WindowManager: vi.fn().mockImplementation(() => ({
+    createMainWindow: mocks.createMainWindow,
+    ensureTray: mocks.ensureTray,
+    showMainWindow: mocks.showMainWindow,
+    markQuitting: mocks.markQuitting
+  }))
+}))
+
+import { AppLifecycle } from './app-lifecycle'
+
+describe('AppLifecycle', () => {
+  beforeEach(() => {
+    mocks.appListeners.clear()
+    vi.clearAllMocks()
+    mocks.requestSingleInstanceLock.mockReturnValue(true)
+    mocks.whenReady.mockResolvedValue(undefined)
+    mocks.getAllWindows.mockReturnValue([])
+  })
+
+  it('preserves platform window-all-closed behavior', async () => {
+    const lifecycle = new AppLifecycle()
+
+    lifecycle.initialize()
+    await Promise.resolve()
+
+    expect(mocks.registerIpcHandlers).toHaveBeenCalledOnce()
+    expect(mocks.createMainWindow).toHaveBeenCalledOnce()
+    expect(mocks.ensureTray).toHaveBeenCalledOnce()
+
+    const onWindowAllClosed = mocks.appListeners.get('window-all-closed')
+    expect(onWindowAllClosed).toBeTypeOf('function')
+
+    onWindowAllClosed?.()
+
+    if (process.platform === 'darwin') {
+      expect(mocks.quit).not.toHaveBeenCalled()
+    } else {
+      expect(mocks.quit).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('marks the window manager as quitting before app quit closes windows', () => {
+    const lifecycle = new AppLifecycle()
+
+    lifecycle.initialize()
+
+    const onBeforeQuit = mocks.appListeners.get('before-quit')
+    expect(onBeforeQuit).toBeTypeOf('function')
+
+    onBeforeQuit?.()
+
+    expect(mocks.markQuitting).toHaveBeenCalledOnce()
+  })
+
+  it('unregisters global hotkeys on will-quit', () => {
+    const lifecycle = new AppLifecycle()
+
+    lifecycle.initialize()
+
+    const onWillQuit = mocks.appListeners.get('will-quit')
+    expect(onWillQuit).toBeTypeOf('function')
+
+    onWillQuit?.()
+
+    expect(mocks.unregisterGlobalHotkeys).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/core/app-lifecycle.ts
+++ b/src/main/core/app-lifecycle.ts
@@ -1,3 +1,9 @@
+/**
+ * Where: src/main/core/app-lifecycle.ts
+ * What:  Main-process app lifecycle wiring (single instance, window/tray boot, quit cleanup).
+ * Why:   Keep background tray + global shortcuts active when the main window is closed.
+ */
+
 import { app, BrowserWindow } from 'electron'
 import { registerIpcHandlers, unregisterGlobalHotkeys } from '../ipc/register-handlers'
 import { WindowManager } from './window-manager'
@@ -33,6 +39,10 @@ export class AppLifecycle {
       if (process.platform !== 'darwin') {
         app.quit()
       }
+    })
+
+    app.on('before-quit', () => {
+      this.windowManager.markQuitting()
     })
 
     app.on('will-quit', () => {

--- a/src/main/core/window-manager.test.ts
+++ b/src/main/core/window-manager.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Where: src/main/core/window-manager.test.ts
+ * What:  Tests WindowManager tray/background close behavior.
+ * Why:   Guard against destroying the renderer on window close, which breaks recording shortcuts.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type WindowListener = (...args: any[]) => void
+
+const mocks = vi.hoisted(() => {
+  const windowListeners = new Map<string, WindowListener>()
+  const hide = vi.fn()
+  const loadURL = vi.fn()
+  const loadFile = vi.fn()
+  const isMinimized = vi.fn(() => false)
+  const restore = vi.fn()
+  const show = vi.fn()
+  const focus = vi.fn()
+  const on = vi.fn((event: string, listener: WindowListener) => {
+    windowListeners.set(event, listener)
+  })
+
+  const browserWindowInstance = {
+    on,
+    hide,
+    loadURL,
+    loadFile,
+    isMinimized,
+    restore,
+    show,
+    focus
+  }
+  const BrowserWindow = vi.fn(() => browserWindowInstance)
+
+  const trayOn = vi.fn()
+  const traySetToolTip = vi.fn()
+  const traySetContextMenu = vi.fn()
+  const Tray = vi.fn(() => ({
+    setToolTip: traySetToolTip,
+    setContextMenu: traySetContextMenu,
+    on: trayOn
+  }))
+
+  const appDockHide = vi.fn()
+  const appDockShow = vi.fn()
+
+  return {
+    windowListeners,
+    hide,
+    loadURL,
+    loadFile,
+    isMinimized,
+    restore,
+    show,
+    focus,
+    on,
+    BrowserWindow,
+    trayOn,
+    traySetToolTip,
+    traySetContextMenu,
+    Tray,
+    Menu: { buildFromTemplate: vi.fn(() => ({ template: true })) },
+    nativeImage: { createEmpty: vi.fn(() => ({})) },
+    app: { dock: { hide: appDockHide, show: appDockShow } },
+    appDockHide,
+    appDockShow
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: mocks.BrowserWindow,
+  Tray: mocks.Tray,
+  Menu: mocks.Menu,
+  nativeImage: mocks.nativeImage,
+  app: mocks.app
+}))
+
+import { WindowManager } from './window-manager'
+
+describe('WindowManager', () => {
+  beforeEach(() => {
+    mocks.windowListeners.clear()
+    vi.clearAllMocks()
+    delete process.env.ELECTRON_RENDERER_URL
+  })
+
+  it('hides the main window instead of closing it when user closes the window', () => {
+    const manager = new WindowManager()
+    manager.createMainWindow()
+
+    const onClose = mocks.windowListeners.get('close')
+    expect(onClose).toBeTypeOf('function')
+
+    const preventDefault = vi.fn()
+    onClose?.({ preventDefault })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.hide).toHaveBeenCalledOnce()
+  })
+
+  it('allows the window to close during explicit app quit', () => {
+    const manager = new WindowManager()
+    manager.createMainWindow()
+    manager.markQuitting()
+
+    const onClose = mocks.windowListeners.get('close')
+    expect(onClose).toBeTypeOf('function')
+
+    const preventDefault = vi.fn()
+    onClose?.({ preventDefault })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(mocks.hide).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- hide the main window on user close instead of destroying the renderer
- mark quit intent on `before-quit` so explicit quit can still close the window
- add lifecycle/window-manager regression tests and document expected behavior for installed and `dist/` runs

## Testing
- `pnpm vitest run src/main/core/app-lifecycle.test.ts src/main/core/window-manager.test.ts`

Fixes #150