### PR TITLE
fix(output): prevent double output when auto-transform is enabled (#148)

### DIFF
--- a/docs/decisions/output-selected-text-source-precedence.md
+++ b/docs/decisions/output-selected-text-source-precedence.md
@@ -1,0 +1,49 @@
+<!--
+Where: docs/decisions/output-selected-text-source-precedence.md
+What: Decision record for fixing capture double-output by adding an explicit selected output text source.
+Why: #148 needs a single output text source in capture flows without breaking standalone transform shortcut output behavior.
+-->
+
+# Decision Record: Explicit Output Text Source Selection for Capture Output
+
+## Context
+
+Issue `#148` reports duplicate output when capture auto-transform is enabled and both transcript and transformed outputs are configured to paste/copy.
+
+The existing settings model stores two separate output rules:
+
+- `output.transcript`
+- `output.transformed`
+
+Capture pipelines applied both rules in the same run, which could paste raw STT text and transformed text back-to-back.
+
+## Decision
+
+Add an explicit `output.selectedTextSource` field (`transcript` | `transformed`) and use it to choose exactly one capture output source.
+
+- Capture pipelines now apply only one output text source per run.
+- Settings Output UI is simplified to:
+  - `Output text` (single select)
+  - `Output destinations` (shared copy/paste checkboxes)
+- UI edits synchronize transcript/transformed destination rules so transform shortcuts keep using the same destination settings.
+
+## Rationale
+
+- Fixes the P0 duplicate-output bug at the runtime decision point.
+- Matches the requested UX model (single source + shared destinations).
+- Preserves standalone transform shortcut behavior by keeping the existing `output.transformed` rule in the schema and syncing it from the UI.
+- Keeps the change small and reversible versus a full output-settings schema redesign.
+
+## Migration
+
+Existing settings missing `output.selectedTextSource` are backfilled on load.
+
+- Derivation rule: prefer `transformed` when the transformed output rule has any enabled destination; otherwise use `transcript`.
+
+This prevents legacy overlapping configs from continuing the double-output behavior after upgrade.
+
+## Consequences
+
+- Capture jobs no longer emit both transcript and transformed output in the same successful run.
+- Hidden divergence in legacy transcript/transformed destination rules can persist until the user edits the Output settings (the UI re-synchronizes them on change).
+- Transformation-failure capture behavior still falls back to transcript output (existing behavior preserved).

--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -34,6 +34,7 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 
 | Priority | Ticket | Issue | Type | Status |
 |---|---|---|---|---|
+| P0 | Prevent double output when auto-transform + transformed paste are enabled | #148 | Fix + UX | DONE |
 | P0 | Fix macOS paste-at-cursor failure | #121 | Fix | PR OPEN |
 | P0 | Preserve spoken language in STT | #120 | Fix | PR OPEN |
 | P1 | Show message when stop/cancel pressed while idle | #124 | Fix | DONE |
@@ -50,6 +51,34 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 ---
 
 ## P0 Tickets
+
+### #148 - [P0] Prevent double output when auto-transform and transformed paste are enabled
+- Type: Fix + UX Change
+- Goal: Deliver only one selected output text per capture job (raw or transformed) and replace conflicting output toggles with a single source selector plus shared destinations.
+- Granularity: Capture output selection/preference logic and Settings Output UI only.
+- Checklist:
+- [x] Read capture pipeline / legacy orchestrator output paths and Settings Output UI.
+- [x] Verify controlled checkbox/radio React patterns against current docs (Context7).
+- [x] Add explicit output text source selection in settings (`transcript` vs `transformed`).
+- [x] Backfill missing selection on load for existing settings via migration.
+- [x] Enforce single-source output delivery in capture pipelines (no transcript + transformed double-delivery).
+- [x] Replace overlapping output toggles with single `Output text` selector and shared `Output destinations`.
+- [x] Preserve standalone transform shortcut output behavior while updating Settings Output UI.
+- [x] Add regression tests for capture pipeline, legacy orchestrator, Settings Output UI, and settings migration.
+- [ ] Run manual macOS verification for paste-at-cursor with auto-transform ON and transformed output selected.
+- Gate:
+- Capture jobs emit only one output text source per run (selected transformed on success; transcript fallback when transformed result is unavailable).
+- Settings Output UI no longer presents overlapping transcript/transformed destination toggles.
+- Tests pass and docs/decision record are updated.
+- Risks/Uncertainty:
+- Legacy installs may still have divergent transcript/transformed destination rules until users revisit the Output settings screen; UI now re-synchronizes them on edit.
+- Transform-failure fallback remains transcript output (current behavior) when transformed output is selected but transformation fails.
+- Feasibility:
+- Medium. Small runtime/UI patch with cross-cutting settings-schema/test updates.
+- Implementation Notes (2026-02-26):
+- Added `output.selectedTextSource` to settings and one-time migration derivation with transformed precedence for legacy matrix configs.
+- Capture pipelines now apply a single selected output rule instead of independently applying transcript and transformed outputs.
+- Settings Output UI now uses `Raw dictation` / `Transformed text` single-select plus shared `Copy to clipboard` / `Paste at cursor` destinations.
 
 ### #121 - [P0] Paste at cursor fails silently on macOS
 - Type: Fix

--- a/src/main/routing/mode-router.test.ts
+++ b/src/main/routing/mode-router.test.ts
@@ -24,6 +24,7 @@ describe('ModeRouter', () => {
       temperature: 0,
       transformationProfile: null,
       output: {
+        selectedTextSource: 'transcript',
         transcript: { copyToClipboard: true, pasteAtCursor: false },
         transformed: { copyToClipboard: true, pasteAtCursor: false }
       }
@@ -54,6 +55,7 @@ describe('ModeRouter', () => {
         userPrompt: 'Rewrite: {{input}}'
       },
       output: {
+        selectedTextSource: 'transformed',
         transcript: { copyToClipboard: false, pasteAtCursor: true },
         transformed: { copyToClipboard: true, pasteAtCursor: true }
       }
@@ -123,6 +125,7 @@ describe('ModeRouter', () => {
       temperature: 0,
       transformationProfile: null,
       output: {
+        selectedTextSource: 'transcript',
         transcript: { copyToClipboard: true, pasteAtCursor: false },
         transformed: { copyToClipboard: true, pasteAtCursor: false }
       }

--- a/src/main/routing/snapshot-immutability.test.ts
+++ b/src/main/routing/snapshot-immutability.test.ts
@@ -26,6 +26,7 @@ const makeCaptureSnapshot = () =>
       userPrompt: 'usr'
     },
     output: {
+      selectedTextSource: 'transcript',
       transcript: { copyToClipboard: true, pasteAtCursor: false },
       transformed: { copyToClipboard: true, pasteAtCursor: false }
     }

--- a/src/main/services/settings-service.test.ts
+++ b/src/main/services/settings-service.test.ts
@@ -184,6 +184,35 @@ describe('SettingsService', () => {
     )
   })
 
+  it('migrates missing output.selectedTextSource using transformed precedence', () => {
+    const legacySettings = structuredClone(DEFAULT_SETTINGS) as any
+    delete legacySettings.output.selectedTextSource
+    legacySettings.output.transcript = { copyToClipboard: true, pasteAtCursor: true }
+    legacySettings.output.transformed = { copyToClipboard: true, pasteAtCursor: true }
+
+    const data = { settings: legacySettings }
+    const set = vi.fn((key: 'settings', value: Settings) => {
+      data[key] = value
+    })
+    const store = {
+      get: () => data.settings,
+      set
+    } as any
+
+    const service = new SettingsService(store)
+    const loaded = service.getSettings()
+
+    expect(loaded.output.selectedTextSource).toBe('transformed')
+    expect(set).toHaveBeenCalledWith(
+      'settings',
+      expect.objectContaining({
+        output: expect.objectContaining({
+          selectedTextSource: 'transformed'
+        })
+      })
+    )
+  })
+
   it('preserves legacy scalar override values during one-time map migration', () => {
     const legacySettings = structuredClone(DEFAULT_SETTINGS) as any
     delete legacySettings.transcription.baseUrlOverrides

--- a/src/main/test-support/factories.ts
+++ b/src/main/test-support/factories.ts
@@ -49,6 +49,7 @@ export const buildCaptureRequestSnapshot = (
     temperature: overrides?.temperature ?? 0,
     transformationProfile: overrides?.transformationProfile ?? null,
     output: overrides?.output ?? {
+      selectedTextSource: 'transformed',
       transcript: { copyToClipboard: true, pasteAtCursor: false },
       transformed: { copyToClipboard: true, pasteAtCursor: false }
     }

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -7,7 +7,7 @@ Why: Extracted from renderer-app.tsx (Phase 6) to separate the render tree from 
 */
 
 import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { DEFAULT_SETTINGS, type Settings } from '../shared/domain'
+import { DEFAULT_SETTINGS, type OutputTextSource, type Settings } from '../shared/domain'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot, AudioInputSource, RecordingCommand } from '../shared/ipc'
 import type { ActivityItem } from './activity-feed'
 import { HomeReact } from './home-react'
@@ -98,10 +98,10 @@ export interface AppShellCallbacks {
   onResetTranscriptionBaseUrlDraft: () => void
   onResetTransformationBaseUrlDraft: () => void
   onChangeShortcutDraft: (key: ShortcutKey, value: string) => void
-  onToggleTranscriptCopy: (checked: boolean) => void
-  onToggleTranscriptPaste: (checked: boolean) => void
-  onToggleTransformedCopy: (checked: boolean) => void
-  onToggleTransformedPaste: (checked: boolean) => void
+  onChangeOutputSelection: (
+    selection: OutputTextSource,
+    destinations: { copyToClipboard: boolean; pasteAtCursor: boolean }
+  ) => void
   onRestoreDefaults: () => Promise<void>
   onSave: () => Promise<void>
   onDismissToast: (toastId: number) => void
@@ -309,17 +309,8 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
             </section>
             <SettingsOutputReact
               settings={uiState.settings}
-              onToggleTranscriptCopy={(checked: boolean) => {
-                callbacks.onToggleTranscriptCopy(checked)
-              }}
-              onToggleTranscriptPaste={(checked: boolean) => {
-                callbacks.onToggleTranscriptPaste(checked)
-              }}
-              onToggleTransformedCopy={(checked: boolean) => {
-                callbacks.onToggleTransformedCopy(checked)
-              }}
-              onToggleTransformedPaste={(checked: boolean) => {
-                callbacks.onToggleTransformedPaste(checked)
+              onChangeOutputSelection={(selection, destinations) => {
+                callbacks.onChangeOutputSelection(selection, destinations)
               }}
               onRestoreDefaults={async () => {
                 await callbacks.onRestoreDefaults()

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -12,8 +12,9 @@ Phase 6 splits (tsx-migration-completion-work-plan.md):
 This file is now the thin orchestration layer: boot, state, autosave, and render wiring.
 */
 
-import { type Settings } from '../shared/domain'
+import { type OutputTextSource, type Settings } from '../shared/domain'
 import { logStructured } from '../shared/error-logging'
+import { buildOutputSettingsFromSelection } from '../shared/output-selection'
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type {
@@ -435,28 +436,10 @@ const rerenderShellFromState = (): void => {
       setSettingsValidationErrors({ ...state.settingsValidationErrors, transformationBaseUrl: '' })
     },
     onChangeShortcutDraft: mutations.patchShortcutDraft,
-    onToggleTranscriptCopy: (checked) => {
+    onChangeOutputSelection: (selection: OutputTextSource, destinations) => {
       applyNonSecretAutosavePatch((current) => ({
         ...current,
-        output: { ...current.output, transcript: { ...current.output.transcript, copyToClipboard: checked } }
-      }))
-    },
-    onToggleTranscriptPaste: (checked) => {
-      applyNonSecretAutosavePatch((current) => ({
-        ...current,
-        output: { ...current.output, transcript: { ...current.output.transcript, pasteAtCursor: checked } }
-      }))
-    },
-    onToggleTransformedCopy: (checked) => {
-      applyNonSecretAutosavePatch((current) => ({
-        ...current,
-        output: { ...current.output, transformed: { ...current.output.transformed, copyToClipboard: checked } }
-      }))
-    },
-    onToggleTransformedPaste: (checked) => {
-      applyNonSecretAutosavePatch((current) => ({
-        ...current,
-        output: { ...current.output, transformed: { ...current.output.transformed, pasteAtCursor: checked } }
+        output: buildOutputSettingsFromSelection(current.output, selection, destinations)
       }))
     },
     onRestoreDefaults: mutations.restoreOutputAndShortcutsDefaults,

--- a/src/renderer/settings-output-react.test.tsx
+++ b/src/renderer/settings-output-react.test.tsx
@@ -31,14 +31,7 @@ describe('SettingsOutputReact', () => {
     document.body.append(host)
     root = createRoot(host)
 
-    const onToggleTranscriptCopy = vi.fn()
-    const onToggleTranscriptPaste = vi.fn()
-    const onToggleTransformedCopy = vi.fn()
-    const onToggleTransformedPaste = vi.fn()
-    const expectedTranscriptCopy = !DEFAULT_SETTINGS.output.transcript.copyToClipboard
-    const expectedTranscriptPaste = !DEFAULT_SETTINGS.output.transcript.pasteAtCursor
-    const expectedTransformedCopy = !DEFAULT_SETTINGS.output.transformed.copyToClipboard
-    const expectedTransformedPaste = !DEFAULT_SETTINGS.output.transformed.pasteAtCursor
+    const onChangeOutputSelection = vi.fn()
     let resolveRestore: (() => void) | null = null
     const onRestoreDefaults = vi.fn(
       () =>
@@ -51,38 +44,38 @@ describe('SettingsOutputReact', () => {
       root?.render(
         <SettingsOutputReact
           settings={DEFAULT_SETTINGS}
-          onToggleTranscriptCopy={onToggleTranscriptCopy}
-          onToggleTranscriptPaste={onToggleTranscriptPaste}
-          onToggleTransformedCopy={onToggleTransformedCopy}
-          onToggleTransformedPaste={onToggleTransformedPaste}
+          onChangeOutputSelection={onChangeOutputSelection}
           onRestoreDefaults={onRestoreDefaults}
         />
       )
     })
 
-    const transcriptCopy = host.querySelector<HTMLInputElement>('#settings-transcript-copy')
+    const transcriptText = host.querySelector<HTMLInputElement>('#settings-output-text-transcript')
     await act(async () => {
-      transcriptCopy?.click()
+      transcriptText?.click()
     })
-    expect(onToggleTranscriptCopy).toHaveBeenCalledWith(expectedTranscriptCopy)
+    expect(onChangeOutputSelection).toHaveBeenLastCalledWith('transcript', {
+      copyToClipboard: DEFAULT_SETTINGS.output.transcript.copyToClipboard,
+      pasteAtCursor: DEFAULT_SETTINGS.output.transcript.pasteAtCursor
+    })
 
-    const transcriptPaste = host.querySelector<HTMLInputElement>('#settings-transcript-paste')
+    const pasteOutput = host.querySelector<HTMLInputElement>('#settings-output-paste')
     await act(async () => {
-      transcriptPaste?.click()
+      pasteOutput?.click()
     })
-    expect(onToggleTranscriptPaste).toHaveBeenCalledWith(expectedTranscriptPaste)
+    expect(onChangeOutputSelection).toHaveBeenLastCalledWith('transcript', {
+      copyToClipboard: DEFAULT_SETTINGS.output.transcript.copyToClipboard,
+      pasteAtCursor: true
+    })
 
-    const transformedCopy = host.querySelector<HTMLInputElement>('#settings-transformed-copy')
+    const copyOutput = host.querySelector<HTMLInputElement>('#settings-output-copy')
     await act(async () => {
-      transformedCopy?.click()
+      copyOutput?.click()
     })
-    expect(onToggleTransformedCopy).toHaveBeenCalledWith(expectedTransformedCopy)
-
-    const transformedPaste = host.querySelector<HTMLInputElement>('#settings-transformed-paste')
-    await act(async () => {
-      transformedPaste?.click()
+    expect(onChangeOutputSelection).toHaveBeenLastCalledWith('transcript', {
+      copyToClipboard: false,
+      pasteAtCursor: true
     })
-    expect(onToggleTransformedPaste).toHaveBeenCalledWith(expectedTransformedPaste)
 
     const restoreButton = host.querySelector<HTMLButtonElement>('#settings-restore-defaults')
     await act(async () => {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -83,7 +83,11 @@ export const OutputRuleSchema = v.object({
 })
 export type OutputRule = v.InferOutput<typeof OutputRuleSchema>
 
+export const OutputTextSourceSchema = v.picklist(['transcript', 'transformed'])
+export type OutputTextSource = v.InferOutput<typeof OutputTextSourceSchema>
+
 export const OutputSettingsSchema = v.object({
+  selectedTextSource: OutputTextSourceSchema,
   transcript: OutputRuleSchema,
   transformed: OutputRuleSchema
 })
@@ -221,6 +225,7 @@ export const DEFAULT_SETTINGS: Settings = {
     autoRunDefaultTransform: false
   },
   output: {
+    selectedTextSource: 'transformed',
     transcript: {
       copyToClipboard: true,
       pasteAtCursor: false

--- a/src/shared/output-selection.ts
+++ b/src/shared/output-selection.ts
@@ -1,0 +1,54 @@
+// Where: Shared module (main + renderer).
+// What: Helpers for output-source precedence and output-settings UI mapping.
+// Why: #148 requires a single selected output text source for capture flows while
+// preserving existing transcript/transformed output rules used by other paths.
+
+import type { OutputRule, OutputSettings, OutputTextSource } from './domain'
+
+export interface CaptureOutputSelection {
+  source: OutputTextSource
+  rule: Readonly<OutputRule>
+}
+
+export const hasAnyOutputDestination = (rule: Readonly<OutputRule>): boolean =>
+  rule.copyToClipboard || rule.pasteAtCursor
+
+/**
+ * Derive the selected output text source for legacy settings that predate the explicit field.
+ * Transformed wins to prevent duplicate transcript+transform delivery in capture flows.
+ */
+export const deriveLegacySelectedTextSource = (output: Pick<OutputSettings, 'transcript' | 'transformed'>): OutputTextSource =>
+  hasAnyOutputDestination(output.transformed) ? 'transformed' : 'transcript'
+
+/**
+ * Capture-flow precedence for #148:
+ * - Use the selected transformed output when a transformed result exists.
+ * - Otherwise fall back to transcript output (preserves existing transform-failure fallback behavior).
+ */
+export const selectCaptureOutput = (
+  output: Readonly<OutputSettings>,
+  hasTransformedText: boolean
+): CaptureOutputSelection => {
+  if (output.selectedTextSource === 'transformed' && hasTransformedText) {
+    return { source: 'transformed', rule: output.transformed }
+  }
+  return { source: 'transcript', rule: output.transcript }
+}
+
+/**
+ * Settings UI uses a single destination matrix shared by the selected text source. To keep
+ * transform shortcuts working, both transcript/transformed rules are synchronized.
+ */
+export const buildOutputSettingsFromSelection = (
+  output: Readonly<OutputSettings>,
+  selection: OutputTextSource,
+  destinations: Readonly<OutputRule>
+): OutputSettings => ({
+  ...output,
+  selectedTextSource: selection,
+  transcript: { ...destinations },
+  transformed: { ...destinations }
+})
+
+export const getSelectedOutputDestinations = (output: Readonly<OutputSettings>): Readonly<OutputRule> =>
+  output.selectedTextSource === 'transformed' ? output.transformed : output.transcript


### PR DESCRIPTION
## Summary
- prevent capture jobs from outputting both raw transcript and transformed text in the same run
- add explicit output text source selection (`transcript` vs `transformed`) with settings migration
- simplify Output settings UI to single source selection plus shared destinations

## Tests
- `pnpm vitest run src/renderer/settings-output-react.test.tsx src/main/orchestrators/capture-pipeline.test.ts src/main/orchestrators/processing-orchestrator.test.ts src/main/services/settings-service.test.ts src/main/routing/mode-router.test.ts src/main/routing/snapshot-immutability.test.ts`
- `pnpm tsc --noEmit`

Closes #148