### PR TITLE
fix(ui): size transformation picker for 3-5 visible profiles (#151)

### DIFF
--- a/src/main/services/profile-picker-service.test.ts
+++ b/src/main/services/profile-picker-service.test.ts
@@ -61,9 +61,19 @@ const createWindowHarness = () => {
 }
 
 describe('buildPickerWindowHeight', () => {
-  it('grows with preset count and clamps to max height', () => {
-    expect(buildPickerWindowHeight(1)).toBeGreaterThan(100)
-    expect(buildPickerWindowHeight(50)).toBeLessThanOrEqual(460)
+  it('adapts for small lists and clamps visible rows to five', () => {
+    const h1 = buildPickerWindowHeight(1)
+    const h2 = buildPickerWindowHeight(2)
+    const h3 = buildPickerWindowHeight(3)
+    const h4 = buildPickerWindowHeight(4)
+    const h5 = buildPickerWindowHeight(5)
+    const h6 = buildPickerWindowHeight(6)
+
+    expect(h2).toBeGreaterThan(h1)
+    expect(h3).toBeGreaterThan(h2)
+    expect(h4).toBeGreaterThan(h3)
+    expect(h5).toBeGreaterThan(h4)
+    expect(h6).toBe(h5)
   })
 })
 
@@ -101,8 +111,9 @@ describe('ProfilePickerService', () => {
 
   it('returns selected profile id when picker emits navigate result', async () => {
     const harness = createWindowHarness()
+    const create = vi.fn(() => harness.window)
     const service = new ProfilePickerService({
-      create: vi.fn(() => harness.window)
+      create
     })
 
     const pending = service.pickProfile([makePreset('a', 'Alpha'), makePreset('b', 'Beta')], 'a')
@@ -110,6 +121,12 @@ describe('ProfilePickerService', () => {
     harness.emitNavigate('picker://select/b')
 
     await expect(pending).resolves.toBe('b')
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useContentSize: true,
+        height: buildPickerWindowHeight(2)
+      })
+    )
     expect(harness.window.show).toHaveBeenCalledOnce()
     expect(harness.window.focus).toHaveBeenCalledOnce()
     expect(harness.window.close).toHaveBeenCalled()

--- a/src/main/services/profile-picker-service.ts
+++ b/src/main/services/profile-picker-service.ts
@@ -6,14 +6,18 @@ import type { TransformationPreset } from '../../shared/domain'
 
 const PICK_RESULT_URL_PREFIX = 'picker://select/'
 const WINDOW_WIDTH = 380
-const WINDOW_BASE_HEIGHT = 96
-const WINDOW_ITEM_HEIGHT = 38
-const WINDOW_MAX_HEIGHT = 460
+// Content-area sizing targets for picker HTML layout (excluding native title bar).
+// Each list item renders two lines (name + tag), so the row height is much larger
+// than a single-line button.
+const WINDOW_BASE_HEIGHT = 90
+const WINDOW_ITEM_HEIGHT = 52
+const WINDOW_MAX_VISIBLE_ITEMS = 5
 const PICKER_AUTO_CLOSE_TIMEOUT_MS = 60_000
 
 export interface PickerBrowserWindowOptions {
   width: number
   height: number
+  useContentSize?: boolean
   resizable: boolean
   maximizable: boolean
   minimizable: boolean
@@ -59,8 +63,8 @@ const escapeHtml = (value: string): string =>
 const escapeInlineScriptJson = (value: string): string => value.replaceAll('</script>', '<\\/script>')
 
 const buildPickerWindowHeight = (presetCount: number): number => {
-  const computed = WINDOW_BASE_HEIGHT + presetCount * WINDOW_ITEM_HEIGHT
-  return Math.min(WINDOW_MAX_HEIGHT, Math.max(computed, WINDOW_BASE_HEIGHT + WINDOW_ITEM_HEIGHT))
+  const visibleItemCount = Math.min(WINDOW_MAX_VISIBLE_ITEMS, Math.max(presetCount, 1))
+  return WINDOW_BASE_HEIGHT + visibleItemCount * WINDOW_ITEM_HEIGHT
 }
 
 const buildPickerHtml = (presets: readonly TransformationPreset[], currentActiveId: string): string => {
@@ -116,7 +120,7 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], currentActive
         list-style: none;
         margin: 0;
         padding: 0;
-        max-height: 300px;
+        max-height: ${WINDOW_MAX_VISIBLE_ITEMS * WINDOW_ITEM_HEIGHT}px;
         overflow-y: auto;
       }
       .item {
@@ -264,6 +268,7 @@ export class ProfilePickerService {
     const pickerWindow = this.windowFactory.create({
       width: WINDOW_WIDTH,
       height: buildPickerWindowHeight(presets.length),
+      useContentSize: true,
       resizable: false,
       maximizable: false,
       minimizable: false,


### PR DESCRIPTION
## Summary
- resize the pick-and-run transformation picker to fit the actual two-line row height
- clamp picker window height so it shows up to 5 profiles before scrolling
- use content-area sizing so window height tracks picker HTML layout instead of native frame height

## Tests
- pnpm vitest run src/main/services/profile-picker-service.test.ts
- pnpm tsc --noEmit

Closes #151
