### PR TITLE
fix(renderer): play recording cues when app is unfocused (#132)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -475,6 +475,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Timebox investigation and split fix into a separate PR if root cause expands.
 - Feasibility:
 - Unknown until investigation completes.
+- Implementation Notes (2026-02-26):
+- Root cause was a renderer-side `document.hasFocus()` guard that intentionally suppressed recording cue playback when the app window was not focused.
+- Removed the focus gate for recording start/stop/cancel cues so global shortcut recordings still produce audible feedback while another app is focused.
+- Added renderer unit regression coverage for background-focus `startRecording` cue playback.
+- Manual macOS packaged-build verification is still recommended to confirm no OS audio-session quirks remain.
 
 #### Step 6 - `#151` Picker Window Height / List Visibility
 - Goal: show 3-5 profiles before scrolling, based on count.

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -6,7 +6,7 @@ Why: Ensure stop/cancel commands show clear feedback instead of silent/success p
 
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS } from '../shared/domain'
 import { handleRecordingCommandDispatch, resetRecordingState, type NativeRecordingDeps } from './native-recording'
 
@@ -31,14 +31,53 @@ const createDeps = (): { deps: NativeRecordingDeps; state: NativeRecordingDeps['
   return { deps, state }
 }
 
+class FakeMediaRecorder {
+  static isTypeSupported = vi.fn(() => false)
+  mimeType = 'audio/webm'
+  private readonly listeners = new Map<string, Array<(event?: any) => void>>()
+
+  addEventListener(event: string, listener: (event?: any) => void): void {
+    const existing = this.listeners.get(event) ?? []
+    existing.push(listener)
+    this.listeners.set(event, existing)
+  }
+
+  start(): void {
+    // No-op for start-path tests.
+  }
+
+  stop(): void {
+    for (const listener of this.listeners.get('stop') ?? []) {
+      listener()
+    }
+  }
+}
+
 describe('handleRecordingCommandDispatch', () => {
   beforeEach(() => {
     resetRecordingState()
+    vi.clearAllMocks()
     ;(window as Window & { speechToTextApi: any }).speechToTextApi = {
       playSound: vi.fn(),
       getHistory: vi.fn(),
       submitRecordedAudio: vi.fn()
     }
+    Object.defineProperty(globalThis, 'MediaRecorder', {
+      value: FakeMediaRecorder,
+      configurable: true
+    })
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn(async () => ({
+          getTracks: () => []
+        }))
+      },
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it.each(['stopRecording', 'cancelRecording'] as const)(
@@ -57,4 +96,17 @@ describe('handleRecordingCommandDispatch', () => {
       expect(window.speechToTextApi.playSound).not.toHaveBeenCalled()
     }
   )
+
+  it('plays the start recording sound even when the app document is not focused (background hotkey)', async () => {
+    const { deps, state } = createDeps()
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+
+    await handleRecordingCommandDispatch(deps, { command: 'startRecording' })
+
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('recording_started')
+    expect(deps.addActivity).toHaveBeenCalledWith('Recording started.', 'success')
+    expect(deps.addToast).toHaveBeenCalledWith('Recording started.', 'success')
+    expect(deps.onStateChange).toHaveBeenCalledOnce()
+    expect(state.hasCommandError).toBe(false)
+  })
 })

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -64,11 +64,8 @@ const sleep = async (ms: number): Promise<void> =>
     setTimeout(resolve, ms)
   })
 
-// Play a sound only when the app window is focused (avoids sound on background hotkey triggers).
-const playSoundIfFocused = (event: Parameters<typeof window.speechToTextApi.playSound>[0]): void => {
-  if (!document.hasFocus()) {
-    return
-  }
+// Recording cues should play for global shortcuts even when another app is focused.
+const playRecordingCue = (event: Parameters<typeof window.speechToTextApi.playSound>[0]): void => {
   void window.speechToTextApi.playSound(event)
 }
 
@@ -345,7 +342,7 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       await startNativeRecording(deps, dispatch.preferredDeviceId)
       state.hasCommandError = false
       addActivity('Recording started.', 'success')
-      playSoundIfFocused('recording_started')
+      playRecordingCue('recording_started')
       addToast('Recording started.', 'success')
       onStateChange()
       return
@@ -359,7 +356,7 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       await stopNativeRecording(deps)
       state.hasCommandError = false
       addActivity('Recording captured and queued for transcription.', 'success')
-      playSoundIfFocused('recording_stopped')
+      playRecordingCue('recording_stopped')
       addToast('Recording stopped. Capture queued for transcription.', 'success')
       onStateChange()
       return
@@ -369,12 +366,12 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       if (isNativeRecording()) {
         await stopNativeRecording(deps)
         addActivity('Recording captured and queued for transcription.', 'success')
-        playSoundIfFocused('recording_stopped')
+        playRecordingCue('recording_stopped')
         addToast('Recording stopped. Capture queued for transcription.', 'success')
       } else {
         await startNativeRecording(deps, dispatch.preferredDeviceId)
         addActivity('Recording started.', 'success')
-        playSoundIfFocused('recording_started')
+        playRecordingCue('recording_started')
         addToast('Recording started.', 'success')
       }
       state.hasCommandError = false
@@ -390,7 +387,7 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       await cancelNativeRecording(deps)
       state.hasCommandError = false
       addActivity('Recording cancelled.', 'info')
-      playSoundIfFocused('recording_cancelled')
+      playRecordingCue('recording_cancelled')
       addToast('Recording cancelled.', 'info')
       onStateChange()
       return


### PR DESCRIPTION
## Summary\n- remove the renderer focus gate that muted recording cue sounds when global shortcuts were triggered from another app\n- add a renderer regression test for background-focus start recording cue playback\n- record the #132 root cause/fix in the work plan notes\n\n## Validation\n- pnpm vitest run src/renderer/native-recording.test.ts\n- pnpm tsc --noEmit\n- timeout 600s claude -p "Review the current git diff for bugs, regressions, or missing tests..." (no regressions found; minor coverage gap note only)\n\nCloses #132