### PR TITLE
feat(settings): remove active profile from user-facing UI (#127)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -495,6 +495,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - Update docs/help text and tests for removed `active` UI references.
 - Feasibility:
 - High once earlier behavior changes are landed.
+- Implementation Notes (2026-02-26):
+- Removed the user-facing `Active profile` selector/help text from Transformation settings and renamed `Remove Active Profile` to `Remove Profile`.
+- Manual Home transform and transform-on-selection flows now resolve `defaultPresetId` to match the only user-facing profile selection in Settings.
+- Settings default-profile selection now synchronizes `activePresetId` so the profile editor fields continue to edit the selected profile without exposing a separate `active` control.
+- Updated renderer/main tests and the `#127` decision record to reflect the final default-profile semantics.
 
 ### PR / Review Strategy for This Batch
 - Continue using one ticket per PR for implementation changes.

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -413,15 +413,16 @@ describe('CommandRouter', () => {
     expect(snapshot.profileId).toBe('default-id')
   })
 
-  it('runCompositeFromSelection enqueues selection snapshot with active preset', async () => {
+  it('runCompositeFromSelection enqueues selection snapshot with default preset when active/default differ', async () => {
     const transformQueue = { enqueue: vi.fn() }
     const settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
         activePresetId: 'active-id',
+        defaultPresetId: 'default-id',
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
-          { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'other-id', name: 'Other' }
+          { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' }
         ]
       }
     })
@@ -436,7 +437,7 @@ describe('CommandRouter', () => {
     expect(result.status).toBe('ok')
     const snapshot = transformQueue.enqueue.mock.calls[0][0] as TransformationRequestSnapshot
     expect(snapshot.textSource).toBe('selection')
-    expect(snapshot.profileId).toBe('active-id')
+    expect(snapshot.profileId).toBe('default-id')
     expect(snapshot.sourceText).toBe('selected text')
   })
 
@@ -452,12 +453,13 @@ describe('CommandRouter', () => {
     expect(transformQueue.enqueue).not.toHaveBeenCalled()
   })
 
-  it('binds active-profile snapshot per request when active preset changes between enqueues', async () => {
+  it('binds default-profile snapshot per request when default preset changes between manual clipboard enqueues', async () => {
     const transformQueue = { enqueue: vi.fn() }
     const settings: Settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
         activePresetId: 'a',
+        defaultPresetId: 'a',
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'a', name: 'A', model: 'gemini-2.5-flash' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'b', name: 'B', model: 'gemini-2.5-flash' }
@@ -473,7 +475,7 @@ describe('CommandRouter', () => {
     const router = new CommandRouter(deps)
 
     await router.runCompositeFromClipboard()
-    settings.transformation.activePresetId = 'b'
+    settings.transformation.defaultPresetId = 'b'
     await router.runCompositeFromClipboard()
 
     const first = transformQueue.enqueue.mock.calls[0][0] as TransformationRequestSnapshot

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -93,13 +93,13 @@ export class CommandRouter {
   }
 
   /**
-   * Run active-profile clipboard transformation.
-   * Used by existing IPC handler.
+   * Run default-profile clipboard transformation (manual Home transform action).
+   * Uses defaultPresetId: active profile concept is no longer user-facing (#127).
    * Kept async to preserve the existing Promise-based router surface.
    */
   async runCompositeFromClipboard(): Promise<CompositeTransformResult> {
     const settings = this.settingsService.getSettings()
-    const preset = this.resolveActivePreset(settings)
+    const preset = this.resolveDefaultPreset(settings)
     const clipboardText = this.readClipboardText()
     return this.enqueueTransformation({
       settings,
@@ -129,13 +129,13 @@ export class CommandRouter {
   }
 
   /**
-   * Run active-profile transformation against selected text.
-   * Used by runTransformationOnSelection hotkey semantics.
+   * Run default-profile transformation against selected text.
+   * Uses defaultPresetId: active profile concept is no longer user-facing (#127).
    * Kept async to preserve the existing Promise-based router surface.
    */
   async runCompositeFromSelection(selectionText: string): Promise<CompositeTransformResult> {
     const settings = this.settingsService.getSettings()
-    const preset = this.resolveActivePreset(settings)
+    const preset = this.resolveDefaultPreset(settings)
     return this.enqueueTransformation({
       settings,
       preset,
@@ -235,15 +235,6 @@ export class CommandRouter {
       systemPrompt: preset.systemPrompt,
       userPrompt: preset.userPrompt
     }
-  }
-
-  /** Resolve the active preset for transformation shortcuts. */
-  private resolveActivePreset(settings: Settings): TransformationPreset | null {
-    return (
-      settings.transformation.presets.find((p) => p.id === settings.transformation.activePresetId) ??
-      settings.transformation.presets[0] ??
-      null
-    )
   }
 
   /** Resolve the default preset for run-default transformation shortcuts. */

--- a/src/main/orchestrators/transformation-orchestrator.ts
+++ b/src/main/orchestrators/transformation-orchestrator.ts
@@ -43,9 +43,11 @@ export class TransformationOrchestrator {
     return (firstLine ?? '').trim()
   }
 
-  private resolveActivePreset(settings: Settings): TransformationPreset {
+  // Manual transforms now use the default preset (#127); this is the renamed
+  // replacement for the old active-preset resolver.
+  private resolveDefaultPreset(settings: Settings): TransformationPreset {
     const preset =
-      settings.transformation.presets.find((item) => item.id === settings.transformation.activePresetId) ??
+      settings.transformation.presets.find((item) => item.id === settings.transformation.defaultPresetId) ??
       settings.transformation.presets[0]
     if (!preset) {
       throw new Error('No transformation preset configured.')
@@ -55,7 +57,7 @@ export class TransformationOrchestrator {
 
   async runCompositeFromClipboard(): Promise<CompositeResult> {
     const settings = this.settingsService.getSettings()
-    const preset = this.resolveActivePreset(settings)
+    const preset = this.resolveDefaultPreset(settings)
     const clipboardText = this.readTopmostClipboardText()
     if (!clipboardText) {
       return { status: 'error', message: 'Clipboard is empty.' }

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -85,14 +85,14 @@ export interface AppShellCallbacks {
   onSelectTranscriptionProvider: (provider: Settings['transcription']['provider']) => void
   onSelectTranscriptionModel: (model: Settings['transcription']['model']) => void
   onToggleAutoRun: (checked: boolean) => void
-  onSelectActivePreset: (presetId: string) => void
+  // onSelectActivePreset removed: active profile is no longer user-facing (#127)
   onSelectDefaultPreset: (presetId: string) => void
   onChangeActivePresetDraft: (
     patch: Partial<Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>>
   ) => void
   onRunSelectedPreset: () => void
   onAddPreset: () => void
-  onRemovePreset: (activePresetId: string) => void
+  onRemovePreset: (presetId: string) => void
   onChangeTranscriptionBaseUrlDraft: (value: string) => void
   onChangeTransformationBaseUrlDraft: (value: string) => void
   onResetTranscriptionBaseUrlDraft: () => void
@@ -241,9 +241,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                 onToggleAutoRun={(checked: boolean) => {
                   callbacks.onToggleAutoRun(checked)
                 }}
-                onSelectActivePreset={(presetId: string) => {
-                  callbacks.onSelectActivePreset(presetId)
-                }}
                 onSelectDefaultPreset={(presetId: string) => {
                   callbacks.onSelectDefaultPreset(presetId)
                 }}
@@ -258,8 +255,8 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                 onAddPreset={() => {
                   callbacks.onAddPreset()
                 }}
-                onRemovePreset={(activePresetId: string) => {
-                  callbacks.onRemovePreset(activePresetId)
+                onRemovePreset={(presetId: string) => {
+                  callbacks.onRemovePreset(presetId)
                 }}
               />
               <SettingsEndpointOverridesReact


### PR DESCRIPTION
## Summary
- remove the user-facing Active profile selector/help text from Transformation settings and make Default profile the only visible selection
- align manual transform routing with `defaultPresetId` (home transform + transform-on-selection)
- enforce hidden `activePresetId` sync to the selected/default profile across boot/select/add/remove paths
- update decision/work-plan docs and expand regression tests for upgrade/invariant edge cases

## Validation
- pnpm vitest run src/main/core/command-router.test.ts src/main/orchestrators/transformation-orchestrator.test.ts src/renderer/settings-mutations.test.ts src/renderer/settings-transformation-react.test.tsx src/renderer/renderer-app.test.ts
- pnpm tsc --noEmit
- Claude CLI review (timeout 600s) — final pass: no regressions found

## Notes
- Boot-time normalization keeps `activePresetId` aligned in memory without forcing an immediate settings write; persisted settings are updated on the next settings save/autosave.

Closes #127
