### PR TITLE
fix(picker): restore previous app focus after pick-and-run (#145)

### DIFF
--- a/docs/github-issues-work-plan.md
+++ b/docs/github-issues-work-plan.md
@@ -461,6 +461,11 @@ Why: Provide a detailed, reviewable execution plan with checklists and gates.
 - OS-level focus APIs can be timing-sensitive; avoid flaky tests by asserting orchestration calls and keeping manual validation explicit.
 - Feasibility:
 - Medium.
+- Implementation Notes (2026-02-26):
+- `ProfilePickerService` now captures the frontmost macOS app bundle id before showing the picker and restores it after picker close (selection/cancel/timeout) before resolving the picker promise.
+- Added `FrontmostAppFocusClient` to wrap best-effort `osascript` capture/activate commands and wired it through the main-process composition root.
+- Added unit coverage for focus snapshot/restore helper and picker restore behavior at the service boundary.
+- Manual macOS verification is still required for real-world focus behavior across target apps (e.g., Chrome/editor) and main-window open/closed states.
 
 #### Step 5 - `#132` Audio Cue Missing When Another App Is Focused (Investigation First)
 - Goal: determine whether this is a packaged-build bug, `dist/`-run limitation, or focus-dependent audio-session issue.

--- a/src/main/infrastructure/frontmost-app-focus-client.test.ts
+++ b/src/main/infrastructure/frontmost-app-focus-client.test.ts
@@ -1,0 +1,73 @@
+/*
+Where: src/main/infrastructure/frontmost-app-focus-client.test.ts
+What: Unit tests for frontmost app focus snapshot/restore AppleScript wrapper.
+Why: Keep profile picker focus-restore behavior deterministic at the command boundary.
+*/
+
+import { describe, expect, it, vi } from 'vitest'
+import { FrontmostAppFocusClient } from './frontmost-app-focus-client'
+
+describe('FrontmostAppFocusClient', () => {
+  it('returns null on non-macOS without invoking osascript', async () => {
+    const runCommand = vi.fn()
+    const client = new FrontmostAppFocusClient({
+      runCommand: runCommand as any,
+      platform: 'linux'
+    })
+
+    await expect(client.captureFrontmostBundleId()).resolves.toBeNull()
+    await expect(client.activateBundleId('com.google.Chrome')).resolves.toBeUndefined()
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it('captures and trims the frontmost app bundle id on macOS', async () => {
+    const runCommand = vi.fn(async () => ({ stdout: 'com.google.Chrome \n', stderr: '' }))
+    const client = new FrontmostAppFocusClient({
+      runCommand: runCommand as any,
+      platform: 'darwin'
+    })
+
+    await expect(client.captureFrontmostBundleId()).resolves.toBe('com.google.Chrome')
+    expect(runCommand).toHaveBeenCalledWith('osascript', [
+      '-e',
+      'tell application "System Events" to get bundle identifier of first application process whose frontmost is true'
+    ])
+  })
+
+  it('returns null when macOS frontmost-app capture returns empty stdout', async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '   \n', stderr: '' }))
+    const client = new FrontmostAppFocusClient({
+      runCommand: runCommand as any,
+      platform: 'darwin'
+    })
+
+    await expect(client.captureFrontmostBundleId()).resolves.toBeNull()
+    expect(runCommand).toHaveBeenCalledOnce()
+  })
+
+  it('activates a macOS app by bundle id via osascript', async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '', stderr: '' }))
+    const client = new FrontmostAppFocusClient({
+      runCommand: runCommand as any,
+      platform: 'darwin'
+    })
+
+    await client.activateBundleId('com.google.Chrome')
+
+    expect(runCommand).toHaveBeenCalledWith('osascript', [
+      '-e',
+      'tell application id "com.google.Chrome" to activate'
+    ])
+  })
+
+  it('skips activation when the macOS bundle id is empty after trim', async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '', stderr: '' }))
+    const client = new FrontmostAppFocusClient({
+      runCommand: runCommand as any,
+      platform: 'darwin'
+    })
+
+    await expect(client.activateBundleId('   ')).resolves.toBeUndefined()
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/infrastructure/frontmost-app-focus-client.ts
+++ b/src/main/infrastructure/frontmost-app-focus-client.ts
@@ -1,0 +1,48 @@
+/*
+Where: src/main/infrastructure/frontmost-app-focus-client.ts
+What: Best-effort macOS frontmost-app snapshot/restore helper for temporary UI flows.
+Why: Profile picker popups should return focus to the previously frontmost app after close.
+*/
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const escapeAppleScriptString = (value: string): string => value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+
+export class FrontmostAppFocusClient {
+  private readonly runCommand: typeof execFileAsync
+  private readonly platform: NodeJS.Platform
+
+  constructor(options?: { runCommand?: typeof execFileAsync; platform?: NodeJS.Platform }) {
+    this.runCommand = options?.runCommand ?? execFileAsync
+    this.platform = options?.platform ?? process.platform
+  }
+
+  async captureFrontmostBundleId(): Promise<string | null> {
+    if (this.platform !== 'darwin') {
+      return null
+    }
+
+    const { stdout } = await this.runCommand('osascript', [
+      '-e',
+      'tell application "System Events" to get bundle identifier of first application process whose frontmost is true'
+    ])
+    const bundleId = stdout.trim()
+    return bundleId.length > 0 ? bundleId : null
+  }
+
+  async activateBundleId(bundleId: string): Promise<void> {
+    const trimmedBundleId = bundleId.trim()
+    if (this.platform !== 'darwin' || trimmedBundleId.length === 0) {
+      return
+    }
+
+    await this.runCommand('osascript', [
+      '-e',
+      `tell application id "${escapeAppleScriptString(trimmedBundleId)}" to activate`
+    ])
+  }
+}
+

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -32,6 +32,7 @@ import { ElectronSoundService } from '../services/sound-service'
 import { SOUND_ASSET_PATHS } from '../infrastructure/sound-asset-paths'
 import { ClipboardClient } from '../infrastructure/clipboard-client'
 import { SelectionClient } from '../infrastructure/selection-client'
+import { FrontmostAppFocusClient } from '../infrastructure/frontmost-app-focus-client'
 import { SerialOutputCoordinator } from '../coordination/ordered-output-coordinator'
 import { CaptureQueue } from '../queues/capture-queue'
 import { TransformQueue } from '../queues/transform-queue'
@@ -58,8 +59,13 @@ const soundService = new ElectronSoundService({
 })
 const clipboardClient = new ClipboardClient()
 const selectionClient = new SelectionClient({ clipboard: clipboardClient })
+const frontmostAppFocusClient = new FrontmostAppFocusClient()
 const profilePickerService = new ProfilePickerService({
-  create: (options) => new BrowserWindow(options)
+  create: (options) => new BrowserWindow(options),
+  focusBridge: {
+    captureFrontmostAppId: () => frontmostAppFocusClient.captureFrontmostBundleId(),
+    restoreFrontmostAppId: (appId) => frontmostAppFocusClient.activateBundleId(appId)
+  }
 })
 const apiKeyConnectionService = new ApiKeyConnectionService()
 


### PR DESCRIPTION
## Summary
- capture the frontmost macOS app before showing the pick-and-run profile picker and restore it after the picker closes
- add a small `FrontmostAppFocusClient` AppleScript wrapper and wire it into the main-process picker service
- add picker/focus client regression tests (including best-effort capture/restore failure paths) and update the work plan notes

## Validation
- pnpm vitest run src/main/infrastructure/frontmost-app-focus-client.test.ts src/main/services/profile-picker-service.test.ts src/main/services/hotkey-service.test.ts
- pnpm tsc --noEmit
- Claude CLI review (timeout 600s) — no functional regressions found

## Notes
- Manual macOS verification is still required for real focus behavior across apps (Chrome/editor) and main-window open/closed states.
- `pickProfile()` is now `async`, so duplicate calls still share a single active picker session but no longer return the same Promise object by reference.

Closes #145
