### PR TITLE
feat(ui): Precision Audio Interface redesign — greenfield renderer overhaul

### DIFF
--- a/docs/decisions/ui-redesign-spec-greenfield.md
+++ b/docs/decisions/ui-redesign-spec-greenfield.md
@@ -1,0 +1,496 @@
+# UI Redesign Spec — Precision Audio Interface (Greenfield)
+
+**Status:** Proposed
+**Date:** 2026-02-26
+**Authors:** Design + Engineering
+**Scope:** Full renderer redesign — no backward-compatibility UI constraints
+**Related files:** `src/renderer/styles.css`, `src/renderer/home-react.tsx`, `src/renderer/shell-chrome-react.tsx`, `src/renderer/app-shell-react.tsx`
+
+---
+
+## 1. Design Direction
+
+### Concept: Precision Audio Interface
+
+The app is a voice-first productivity tool. The design should feel like high-quality hardware — a mixing desk or studio monitor — not a generic SaaS dashboard. Every visual decision should reinforce the primary interaction: **capturing your voice and transforming it into precise text**.
+
+**Four words that should describe the experience:**
+`Focused · Tactile · Responsive · Trustworthy`
+
+### Anti-patterns to eliminate
+
+| Current pattern | Why it fails | Replacement |
+|---|---|---|
+| Four equal recording buttons | Decision fatigue at the most critical moment | Single adaptive orb button |
+| Hero card + separate nav card | Wastes vertical space, two redundant containers | Unified compact header bar |
+| Long flat settings scroll | Cognitive overload; all sections fight for attention | Collapsible accordion sections |
+| Top-right toasts | Banner blindness; errors go unnoticed | Bottom-center, slide-up, accent stripe |
+| Generic orange accent | Indistinct; common AI app color | Jewel-tone amber + teal pair |
+| Status as small pill, same size as other elements | Visual hierarchy collapse | Status as dominant element when recording |
+
+---
+
+## 2. Design Tokens
+
+### 2.1 Color System
+
+All tokens defined as CSS custom properties on `:root`.
+
+#### Surfaces (3-level elevation model)
+
+| Token | Value | Usage |
+|---|---|---|
+| `--bg` | `#060d1a` | App background |
+| `--bg-elev` | `#0b1626` | Elevated surface (cards) |
+| `--bg-raised` | `#111f33` | Raised surface (modals, popovers) |
+| `--bg-input` | `rgb(4 10 22 / 55%)` | Form inputs |
+
+#### Ink (text hierarchy)
+
+| Token | Value | Usage |
+|---|---|---|
+| `--ink` | `#deeeff` | Primary text |
+| `--ink-2` | `#7f98b8` | Secondary / muted text |
+| `--ink-3` | `#384f6a` | Tertiary / dividers |
+
+#### Brand
+
+Two-color brand identity: **amber gold** as primary action, **teal** as feedback/secondary.
+
+| Token | Value | Rationale |
+|---|---|---|
+| `--amber` | `#e8a23a` | Primary CTA, buttons. Jewel-tone gold vs. generic orange |
+| `--amber-dim` | `rgb(232 162 58 / 16%)` | Button fill, chip backgrounds |
+| `--amber-glow` | `rgb(232 162 58 / 30%)` | Button box-shadow |
+| `--teal` | `#0dcfbf` | Focus rings, nav active, section labels, shortcut badges |
+| `--teal-dim` | `rgb(13 207 191 / 12%)` | Busy-state button fill |
+| `--teal-glow` | `rgb(13 207 191 / 28%)` | Focus glow |
+
+#### Semantic
+
+| Token | Value | Usage |
+|---|---|---|
+| `--good` | `#22d9a0` | Recording active, success toasts, completion dots |
+| `--good-dim` | `rgb(34 217 160 / 18%)` | Orb idle fill, waveform background |
+| `--good-glow` | `rgb(34 217 160 / 35%)` | Orb active shadow |
+| `--bad` | `#f06060` | Errors, stop-orb state, cancel button |
+| `--bad-dim` | `rgb(240 96 96 / 18%)` | Error backgrounds |
+
+#### Future: Light theme tokens
+
+Greenfield requirement — app should ship with a light theme as an alternate token set. Light mode mirror:
+
+```css
+[data-theme="light"] {
+  --bg: #f4f7fb;
+  --bg-elev: #ffffff;
+  --bg-raised: #eef2f8;
+  --bg-input: rgb(240 245 255 / 80%);
+  --ink: #0f1d30;
+  --ink-2: #4a6080;
+  --ink-3: #a0b4cc;
+  --border: rgb(180 200 220 / 60%);
+  --border-hi: rgb(140 165 195 / 80%);
+  /* brand colors remain the same — they read well on both backgrounds */
+}
+```
+
+### 2.2 Spacing — 8px Grid
+
+All spacing values are multiples of 4px, with 8px as the base unit. No `0.7rem` or `1.25rem` ad-hoc values in new code.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--sp1` | `4px` | Tight gaps (icon–label) |
+| `--sp2` | `8px` | Chip/badge padding, list gaps |
+| `--sp3` | `12px` | Default internal padding |
+| `--sp4` | `16px` | Card padding, section gaps |
+| `--sp5` | `20px` | Comfortable card padding |
+| `--sp6` | `24px` | Large section spacing |
+| `--sp8` | `32px` | Between major sections |
+| `--sp10` | `40px` | Page vertical rhythm |
+| `--sp12` | `48px` | Hero-level spacing |
+
+### 2.3 Typography
+
+Three typeface roles, all system-based (no network font loading required for offline Electron):
+
+| Role | Stack | Usage |
+|---|---|---|
+| **Serif** | `"Iowan Old Style", "Palatino Linotype", Georgia, serif` | App name, page hero titles |
+| **Sans** | `-apple-system, BlinkMacSystemFont, "Avenir Next", "Segoe UI", system-ui, sans-serif` | All UI body text |
+| **Mono** | `"SF Mono", "Cascadia Code", "Fira Code", ui-monospace, monospace` | Shortcut keys, status badges, section labels, version strings |
+
+Type scale:
+
+| Class / Element | Size | Weight | Role |
+|---|---|---|---|
+| `h1` / `.app-header-title` | `clamp(1.1rem, 2vw, 1.35rem)` | 700 | App name in header |
+| `h2` | `1.0rem` | 700 | Card section titles |
+| `h3` / `.section-label` | `0.65rem` + `letter-spacing: 0.14em` + uppercase | 700, mono | Section category labels |
+| Body | `0.88rem` | 400 | Form fields, descriptions |
+| `.status-dot` | `0.67rem` + mono | 700 | Recording state badge |
+| `.shortcut-combo` | `0.70rem` + mono | 400 | Key bindings |
+| `.chip` | `0.70rem` | 400 | Status chips |
+
+### 2.4 Radius Scale
+
+| Token | Value | Usage |
+|---|---|---|
+| `--r-sm` | `8px` | Shortcut combo badges, small chips |
+| `--r-md` | `12px` | Buttons, inputs, form rows |
+| `--r-lg` | `18px` | Cards (`--card-radius`) |
+| `--r-xl` | `28px` | Modal overlays (future) |
+| `--r-full` | `999px` | Pills, nav tabs, status dots |
+
+### 2.5 Shadow
+
+| Token | Value | Usage |
+|---|---|---|
+| `--shadow` | `0 20px 60px rgb(2 4 16 / 55%)` | Cards |
+| `--shadow-sm` | `0 4px 16px rgb(2 4 16 / 35%)` | App header, small surfaces |
+| `--shadow-amber` | `0 12px 40px var(--amber-glow)` | Primary button hover |
+| `--shadow-teal` | `0 12px 40px var(--teal-glow)` | Focus state glow |
+| `--shadow-good` | `0 12px 40px var(--good-glow)` | Recording orb hover |
+
+---
+
+## 3. Layout Architecture
+
+### 3.1 App Chrome
+
+Replace the legacy two-card header (hero card + nav card) with a single `.app-header` bar.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Speech-to-Text  v1  │  groq / whisper-large-v3  │  Auto-run   │  Home  Settings  │
+└─────────────────────────────────────────────────────────────────┘
+                                                  ↑ teal top border accent
+```
+
+- Brand (serif title + mono version) left-anchored
+- Status chips (provider, auto-run state) fill the center — hidden at `<760px`
+- Navigation tabs right-anchored, pill-shaped
+- Single `border-top` teal accent line (low-key brand signal)
+- `backdrop-filter: blur(8px)` — glass layer sits above background glow
+
+### 3.2 Home Page
+
+Two-column grid at `>1020px`, stacks to 1 column below. Column sizing: `1fr 1fr`.
+
+```
+┌─────────────────────┐  ┌─────────────────────┐
+│   Recording Card    │  │   Transform Card    │
+│                     │  │                     │
+│  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒     │  │  Run AI transform   │
+│   ●  waveform  ●    │  │  on clipboard text  │
+│     [ ● START ]     │  │                     │
+│    Start  Stop      │  │  [ Transform        │
+│         [Cancel]    │  │    Clipboard ]      │
+│                     │  │                     │
+└─────────────────────┘  └─────────────────────┘
+```
+
+**Greenfield addition (not yet implemented):**
+
+A third card below the two primary cards — **Activity Feed** — showing the last 5 transcription/transform results with timestamps, status, and preview text. This satisfies the peak-end rule: users see what the app produced before they close it.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Recent Activity                          [Clear all]    │
+│  ── 14:32  Transcribed  "Call John about the meeting…"   │
+│  ── 14:28  Transformed  "Rewrite as bullet points…"      │
+│  ── 14:20  Transcribed  "The quarterly report needs…"    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Settings Page
+
+Two-column grid: `2fr 1fr`. Left column: accordion card. Right column: shortcuts reference panel.
+
+Settings sections (in priority order for first-run setup):
+
+1. **API Keys** — required to use any feature; completion dot turns green when ≥1 key saved
+2. **Recording & Transcription** — device, method, provider, model
+3. **Transformation** — presets, prompts, auto-run, endpoint overrides
+4. **Keyboard Shortcuts** — editable bindings; completion dot always green (defaults exist)
+5. **Output & Save** — text source, destinations, save button
+
+Greenfield addition: **Setup Progress Ring** — a small SVG arc in the Settings heading that fills as sections are completed (`n/5`). Leverages goal-gradient effect — users accelerate when near done.
+
+```
+┌─────────────────────────────────┐
+│  Settings   ⊙ 2 / 5 configured  │
+│  ▼ API Keys            ● done   │
+│  ▼ Recording           ● done   │
+│  ▸ Transformation      ○ —      │
+│  ▸ Keyboard Shortcuts  ○ —      │
+│  ▸ Output & Save       ● done   │
+└─────────────────────────────────┘
+```
+
+---
+
+## 4. Component Specifications
+
+### 4.1 Recording Orb
+
+The single most important element in the app. Design rationale: users' primary mental model is "press to record, press to stop" — this is exactly what a circular toggle represents in hardware (tape deck, studio mic).
+
+**States:**
+
+| State | Background | Border | Glow | Icon | Label |
+|---|---|---|---|---|---|
+| Idle | `good-dim` 20% | `good` 28% | `good-dim` shadow | `●` | START |
+| Recording | `bad-dim` 20% | `bad` 35% | `bad-dim` shadow | `■` | STOP |
+| Busy | `teal-dim` | `teal` 35% | `teal-dim` shadow | `⟳` | — |
+| Blocked | — | `ink-3` | none | `●` | disabled |
+
+**Pulse ring:** A second layer (`record-orb-ring`) outside the button, `inset: -12px`, animates `scale(1) → scale(1.08)` at 2s infinite while recording. Communicates ongoing audio capture without requiring user attention.
+
+**Waveform:** 12 vertical bars above the orb. Each bar has `--bar-i: 0–11` driving staggered `animation-delay`. Idle: `height: 4px`, `opacity: 0.25`. Active: animated `height: 4px → 30px` alternating.
+
+> **Greenfield enhancement:** Connect waveform amplitude to real `AudioContext.createAnalyser()` data instead of CSS animation. This requires the `native-recording.ts` module to expose a readable stream or IPC message with raw amplitude values. The waveform then reflects actual microphone input, making it a functional level meter not just a decorative animation.
+
+**Secondary actions:** Start / Stop / Cancel rendered as `.btn-ghost` / `.btn-cancel` in a flex row below the orb. Cancel is conditionally rendered — visible only while `isRecording === true`. This eliminates the 4-button decision problem while preserving explicit command access for power users.
+
+### 4.2 Transform Card
+
+Secondary to recording but equal in layout column weight. Keep visual weight lower by:
+- No orb — just a standard full-width button
+- Smaller `h2` label (same size, but no large graphical element draws the eye here first)
+- Soft divider (`border-top: 1px solid --border`) between the two home cards at `<1020px`
+
+**Greenfield enhancement:** Show last transform result summary beneath the button:
+
+```
+[ Transform Clipboard ]
+────────────────────────
+Last: "Meeting notes → 5 bullet points"   14:32 · 1.2s
+```
+
+This creates a **labor illusion** effect — showing that work happened builds confidence in the transformation quality.
+
+### 4.3 Settings Accordion
+
+**Trigger (section header):**
+- Full-width `<button>` that resets default button styling
+- Left: 7px completion dot (gray → green via `transition`)
+- Center: section title
+- Right: `▾` chevron rotates 180° on open via `transform: rotate(180deg)`
+- Hover: subtle `background` lightening only — no border or shadow changes
+
+**Body (section content):**
+- `border-top: 1px solid --border` separates header from content
+- `background: rgb(6 12 26 / 55%)` — slightly darker than the card, creates depth
+- Padding: `--sp4` all sides
+
+**Animation (not yet implemented — greenfield target):**
+Replace the conditional render (`{isOpen && ...}`) with a CSS `grid-template-rows: 0fr → 1fr` transition for smooth open/close. Requires an inner wrapper `<div style="overflow: hidden">`.
+
+```css
+/* Target animation */
+.settings-section-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 260ms ease;
+}
+.settings-section-body[data-open="true"] {
+  grid-template-rows: 1fr;
+}
+.settings-section-body > div { overflow: hidden; }
+```
+
+### 4.4 Toast System
+
+**Position:** Bottom-center. Fixed, `left: 50%; transform: translateX(-50%)`. `flex-direction: column-reverse` so newest toast appears on top.
+
+**Entry animation:** `toast-rise` — `translateY(14px) scale(0.96) → translateY(0) scale(1)` over 220ms with spring easing.
+
+**Left accent stripe:** `border-left: 3px solid` in the tone color (green / red / teal). No full background tint — keeps the toast readable on any background.
+
+**Greenfield enhancement — dismiss progress bar:**
+
+```
+[✓  Saved settings successfully            ✕]
+[░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ ] ← 6s countdown bar
+```
+
+A `width: 100% → 0%` transition on a 3px bottom bar communicates time-until-dismiss. Reduces the cognitive cost of "did I read that in time?".
+
+### 4.5 Navigation Tabs
+
+Pill-shaped buttons (`border-radius: --r-full`) in a flex row within the app header.
+
+| State | Style |
+|---|---|
+| Default | Transparent background, `--ink-2` text, `--border` border |
+| Hover | `rgb(255 255 255 / 5%)` background, `--border-hi` border, `--ink` text |
+| Active | `--teal-dim` background, `rgb(13 207 191 / 45%)` border, `--teal` text |
+
+No underline, no bold weight change on active — the background+border+color change is sufficient signal.
+
+### 4.6 Status Dot
+
+Mono uppercase pill displayed next to recording card `h2`. States:
+
+| State | Color | Animation |
+|---|---|---|
+| Idle | `--ink-3` | None |
+| Recording | `--good` | `dot-blink` 1.1s infinite on `::before` |
+| Busy | `--amber` | None |
+| Error | `--bad` | None |
+
+The `::before` circle uses `currentColor` so it always matches the text — no separate token needed.
+
+---
+
+## 5. Interaction Patterns
+
+### 5.1 Stagger Entrance
+
+All main panels use `[data-stagger]` with `--delay` CSS custom property:
+
+| Element | Delay |
+|---|---|
+| App header | 40ms |
+| Recording card | 100ms |
+| Transform card | 160ms |
+| Settings card | 220ms |
+
+Animation: `translateY(8px) opacity(0) → translateY(0) opacity(1)` over 540ms with `cubic-bezier(0.2, 0.65, 0.2, 1)`.
+
+### 5.2 Button Physics
+
+All buttons use `cubic-bezier(0.34, 1.56, 0.64, 1)` (spring physics) for the orb and `ease` for standard buttons. This creates distinct tactile identity:
+- Orb: bouncy, physical → matches "pressing a hardware button"
+- Standard buttons: smooth, digital → matches form-filling expectations
+
+### 5.3 Keyboard Navigation
+
+All interactive elements are fully keyboard accessible:
+- `Tab` / `Shift+Tab` for focus traversal
+- `Space` / `Enter` to activate buttons
+- `focus-visible` outline: `2px solid --teal` with `2px offset` — consistent everywhere
+- Accordion headers: `aria-expanded`, `aria-controls` attributes set correctly
+
+### 5.4 Focus States (greenfield requirement)
+
+Do not suppress `:focus` — only suppress `:focus:not(:focus-visible)` for pointer interactions. Current implementation correctly uses `:focus-visible` everywhere.
+
+---
+
+## 6. Greenfield Features (Not Yet Implemented)
+
+These are design targets for future iterations, in priority order:
+
+### P0 — High impact, relatively contained
+
+| Feature | Rationale | Technical approach |
+|---|---|---|
+| **Real waveform amplitude** | Functional feedback, not just decorative | `AudioContext.createAnalyser()` → IPC amplitude messages → waveform bar heights |
+| **Toast countdown bar** | Reduces "did I miss it" anxiety | `width` CSS transition on `::after` pseudo-element |
+| **Smooth accordion animation** | Polished open/close | `grid-template-rows: 0fr → 1fr` CSS transition |
+| **Last transform result display** | Labor illusion, confirms work happened | Passed as `lastTransformSummary` prop (already exists in state) |
+
+### P1 — High impact, larger scope
+
+| Feature | Rationale | Technical approach |
+|---|---|---|
+| **Command palette (⌘K)** | Power user shortcut to any action | New `CommandPalette` overlay component, global keydown listener |
+| **Activity feed card** | Peak-end rule, history visibility | New `ActivityFeedReact` component, last N items from IPC events |
+| **Setup progress ring** | Goal-gradient effect for first-run | SVG arc, computed from `apiKeysDone + recordingDone + ...` |
+| **Full-screen recording mode** | Immersive focus during recording | CSS class toggle on `<body>`, hides nav and non-recording UI |
+
+### P2 — Quality of life
+
+| Feature | Rationale | Technical approach |
+|---|---|---|
+| **Light theme** | Accessibility, user preference | `[data-theme="light"]` token overrides in CSS |
+| **Compact mode** | Small window / secondary screen use | `@media (max-height: 500px)` breakpoint |
+| **Preset quick-switch chips** | One-tap preset change without entering settings | Chip row on home page, triggers `onSelectDefaultPreset` |
+| **Onboarding overlay** | First-run users don't know what to configure | Step-by-step overlay using existing accordion sections |
+
+---
+
+## 7. Accessibility Requirements
+
+Minimum bar for all new components:
+
+- **WCAG 2.1 AA contrast** on all text/background pairs
+- **`aria-live` regions** for: recording status, toast layer, save status
+- **`aria-expanded`/`aria-controls`** on all accordion headers
+- **`aria-label`** on icon-only buttons (orb button uses `aria-label="Start recording (toggle)"`)
+- **`role="status"`** on recording status dot; `role="alert"` on error toasts
+- **No `outline: none`** — always `focus-visible` outlines
+- **Reduced motion support:**
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .waveform--active span,
+  .record-orb-ring--recording,
+  [data-stagger],
+  .toast-item {
+    animation: none;
+    transition-duration: 0ms;
+  }
+  [data-stagger] { opacity: 1; transform: none; }
+}
+```
+
+---
+
+## 8. Implementation Phases
+
+### Phase A — Completed in this PR
+
+- [x] New CSS design token system (`styles.css` rewrite)
+- [x] Compact unified app header (`shell-chrome-react.tsx`)
+- [x] Recording orb + waveform bars + adaptive secondary actions (`home-react.tsx`)
+- [x] Settings accordion with completion dots (`app-shell-react.tsx`)
+- [x] Bottom-center toast with slide-up animation
+- [x] Three-tier button system (default / ghost / cancel)
+- [x] Monospace labels for technical elements
+
+### Phase B — Next iteration
+
+- [ ] Real waveform amplitude via AudioContext IPC
+- [ ] Toast countdown bar
+- [ ] Smooth accordion CSS animation (`grid-template-rows`)
+- [ ] Last transform result displayed on home card
+- [ ] `prefers-reduced-motion` CSS block
+
+### Phase C — Future
+
+- [ ] Command palette (⌘K)
+- [ ] Activity feed card
+- [ ] Setup progress ring
+- [ ] Light theme token set
+- [ ] Full-screen recording mode
+
+---
+
+## 9. Decision Log
+
+### Why amber + teal instead of the original orange + cyan?
+
+The original `#f2a65a` (orange) and `#7dd3fc` (light blue) are common in AI app templates. They read as "default Tailwind palette" to experienced developers. The replacement pair:
+
+- `--amber #e8a23a` — more saturated, jewel-toned, reads as deliberate
+- `--teal #0dcfbf` — cooler and more distinctive than `#7dd3fc`; also provides better contrast on dark backgrounds at small sizes (status dots, shortcut combos)
+
+Both pairs pass WCAG AA at their use sizes.
+
+### Why hide the original `.hero` and `.top-nav` in CSS rather than deleting them?
+
+The `.hero` and `.top-nav` class names are used in `shell-chrome-react.tsx` which is being replaced. Setting `display: none` in CSS lets the old markup co-exist during the transition without breaking anything. Once `shell-chrome-react.tsx` is fully migrated, these classes can be removed from both the CSS and the TSX.
+
+→ **Done:** `shell-chrome-react.tsx` has been fully migrated to `.app-header`. The `.hero` / `.top-nav` CSS rules are safe to delete in a cleanup PR.
+
+### Why is the orb button `toggleRecording` and not `startRecording`?
+
+`toggleRecording` is the most resilient mapping for a single button: if the app state is somehow desynced (recording started from a different trigger), pressing toggle will always move to the opposite state. `startRecording` called while already recording is a no-op or error. The secondary row provides explicit `start` / `stop` for power users who want deterministic commands.
+
+### Why put Cancel in a conditional render vs. always showing it disabled?
+
+A disabled Cancel button while idle creates noise in the button row and adds a target users will accidentally tap. Hiding it entirely when idle reduces the visual weight of the secondary row to just Start + Stop — a cleaner affordance. The Cancel action is still reachable via keyboard shortcut at any time.

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -1,9 +1,9 @@
 /*
 Where: src/renderer/shell-chrome-react.tsx
-What: React-rendered shell chrome (hero + top navigation).
-Why: Reduce legacy template rendering and keep navigation click ownership in React.
-     Migrated from .ts (createElement) to .tsx (JSX) as the proof-of-concept for the
-     project-wide TSX migration (see docs/decisions/tsx-migration.md).
+What: Compact unified app header — brand, status chips, and navigation tabs in one bar.
+Why: Replaces the original two-card layout (hero card + nav card) with a single horizontal
+     header. This reduces vertical space, improves visual hierarchy, and puts navigation
+     inline with the brand — a more conventional, scannable app chrome pattern.
 */
 
 import type { CSSProperties } from 'react'
@@ -18,35 +18,53 @@ interface ShellChromeReactProps {
   onNavigate: (page: AppPage) => void
 }
 
-export const ShellChromeReact = ({ settings, currentPage, onNavigate }: ShellChromeReactProps) => (
-  <>
-    <section className="hero card" data-stagger="" style={{ '--delay': '40ms' } as CSSProperties}>
-      <p className="eyebrow">Speech-to-Text Control Room</p>
-      <h1>Speech-to-Text v1</h1>
-      <div className="hero-meta">
-        <span className="chip">STT {settings.transcription.provider} / {settings.transcription.model}</span>
-        <span className="chip">Transform Auto-run {settings.transformation.autoRunDefaultTransform ? 'On' : 'Off'}</span>
+export const ShellChromeReact = ({ settings, currentPage, onNavigate }: ShellChromeReactProps) => {
+  const autoRunLabel = settings.transformation.autoRunDefaultTransform ? 'Auto-run On' : 'Auto-run Off'
+  const autoRunActive = settings.transformation.autoRunDefaultTransform
+
+  return (
+    <header
+      className="app-header"
+      data-stagger=""
+      style={{ '--delay': '40ms' } as CSSProperties}
+    >
+      {/* Brand */}
+      <div className="app-header-brand">
+        <h1 className="app-header-title">Speech-to-Text</h1>
+        <span className="app-header-version">v1</span>
       </div>
-    </section>
-    <nav className="top-nav card" aria-label="Primary">
-      <button
-        type="button"
-        className={`nav-tab${currentPage === 'home' ? ' is-active' : ''}`}
-        data-route-tab="home"
-        aria-pressed={currentPage === 'home' ? 'true' : 'false'}
-        onClick={() => { onNavigate('home') }}
-      >
-        Home
-      </button>
-      <button
-        type="button"
-        className={`nav-tab${currentPage === 'settings' ? ' is-active' : ''}`}
-        data-route-tab="settings"
-        aria-pressed={currentPage === 'settings' ? 'true' : 'false'}
-        onClick={() => { onNavigate('settings') }}
-      >
-        Settings
-      </button>
-    </nav>
-  </>
-)
+
+      {/* Status chips — hidden on small screens via CSS */}
+      <div className="app-header-meta">
+        <span className="chip">
+          {settings.transcription.provider} / {settings.transcription.model}
+        </span>
+        <span className={`chip${autoRunActive ? ' chip-good' : ''}`}>
+          {autoRunLabel}
+        </span>
+      </div>
+
+      {/* Page navigation */}
+      <nav className="app-header-nav" aria-label="Primary">
+        <button
+          type="button"
+          className={`nav-tab${currentPage === 'home' ? ' is-active' : ''}`}
+          data-route-tab="home"
+          aria-pressed={currentPage === 'home' ? 'true' : 'false'}
+          onClick={() => { onNavigate('home') }}
+        >
+          Home
+        </button>
+        <button
+          type="button"
+          className={`nav-tab${currentPage === 'settings' ? ' is-active' : ''}`}
+          data-route-tab="settings"
+          aria-pressed={currentPage === 'settings' ? 'true' : 'false'}
+          onClick={() => { onNavigate('settings') }}
+        >
+          Settings
+        </button>
+      </nav>
+    </header>
+  )
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,113 +1,109 @@
+/*
+Where: src/renderer/styles.css
+What: Global design system — surfaces, typography, components, animations.
+Why: Precision Audio Interface aesthetic — dark, focused, purposeful. Every element
+     serves the recording workflow. New in this revision: recording orb, waveform bars,
+     settings accordion, bottom-center toasts, 8px spacing grid, and three-tier button system.
+*/
+
+/* ============================================================
+   Design Tokens
+   ============================================================ */
 :root {
-  --bg: #0b1220;
-  --bg-elev: #121d30;
-  --ink: #ecf2ff;
-  --muted: #98a8c3;
-  --line: #314865;
-  --accent: #f2a65a;
-  --accent-2: #7dd3fc;
-  --good: #34d399;
-  --bad: #f87171;
-  --card-radius: 18px;
-  --shadow: 0 22px 60px rgb(2 6 23 / 45%);
+  /* Surfaces */
+  --bg: #060d1a;
+  --bg-elev: #0b1626;
+  --bg-raised: #111f33;
+  --bg-input: rgb(4 10 22 / 55%);
+
+  /* Ink */
+  --ink: #deeeff;
+  --ink-2: #7f98b8;
+  --ink-3: #384f6a;
+  --muted: #7f98b8; /* legacy alias */
+
+  /* Brand — Amber gold primary, Teal secondary */
+  --amber: #e8a23a;
+  --amber-dim: rgb(232 162 58 / 16%);
+  --amber-glow: rgb(232 162 58 / 30%);
+  --teal: #0dcfbf;
+  --teal-dim: rgb(13 207 191 / 12%);
+  --teal-glow: rgb(13 207 191 / 28%);
+
+  /* Semantic */
+  --good: #22d9a0;
+  --good-dim: rgb(34 217 160 / 18%);
+  --good-glow: rgb(34 217 160 / 35%);
+  --bad: #f06060;
+  --bad-dim: rgb(240 96 96 / 18%);
+
+  /* Legacy compat aliases */
+  --accent: var(--amber);
+  --accent-2: var(--teal);
+  --line: rgb(48 72 108 / 55%);
+
+  /* Borders */
+  --border: rgb(48 72 108 / 55%);
+  --border-hi: rgb(70 100 140 / 70%);
+
+  /* Radius */
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 18px;
+  --r-xl: 28px;
+  --r-full: 999px;
+  --card-radius: var(--r-lg); /* legacy */
+
+  /* Shadow */
+  --shadow: 0 20px 60px rgb(2 4 16 / 55%);
+  --shadow-sm: 0 4px 16px rgb(2 4 16 / 35%);
+  --shadow-amber: 0 12px 40px var(--amber-glow);
+  --shadow-teal: 0 12px 40px var(--teal-glow);
+  --shadow-good: 0 12px 40px var(--good-glow);
+
+  /* Spacing — strict 8px grid */
+  --sp1: 4px;
+  --sp2: 8px;
+  --sp3: 12px;
+  --sp4: 16px;
+  --sp5: 20px;
+  --sp6: 24px;
+  --sp8: 32px;
+  --sp10: 40px;
+  --sp12: 48px;
 }
 
-* {
-  box-sizing: border-box;
-}
+/* ============================================================
+   Reset & Base
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; }
 
-html,
-body,
-#app {
+html, body, #app {
   min-height: 100%;
   margin: 0;
 }
 
 body {
-  font-family: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Avenir Next", "Segoe UI", system-ui, sans-serif;
   color: var(--ink);
+  /* Atmospheric background: dual radial glows + deep gradient */
   background:
-    radial-gradient(circle at 18% 10%, rgb(125 211 252 / 22%) 0, transparent 40%),
-    radial-gradient(circle at 84% 2%, rgb(242 166 90 / 20%) 0, transparent 34%),
-    repeating-linear-gradient(125deg, rgb(255 255 255 / 0.04) 0 2px, transparent 2px 12px),
-    linear-gradient(158deg, #08101c 0%, #0b1220 44%, #101b2f 100%);
+    radial-gradient(ellipse 900px 500px at 10% 0%, rgb(13 207 191 / 7%) 0%, transparent 55%),
+    radial-gradient(ellipse 700px 450px at 92% 8%, rgb(232 162 58 / 9%) 0%, transparent 50%),
+    radial-gradient(ellipse 1400px 700px at 50% 110%, rgb(8 18 40 / 100%) 0%, transparent 100%),
+    linear-gradient(168deg, #060f1e 0%, #060d1a 48%, #07101f 100%);
+  background-attachment: fixed;
 }
 
+/* ============================================================
+   Layout Shell
+   ============================================================ */
 .shell {
   width: min(1260px, 100% - 2rem);
-  margin: 1.2rem auto 2rem;
+  margin: 0 auto var(--sp8);
   display: grid;
-  gap: 1rem;
-}
-
-.toast-layer {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 40;
-  display: grid;
-  gap: 0.55rem;
-  width: min(360px, calc(100vw - 2rem));
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  pointer-events: none;
-}
-
-.toast-item {
-  pointer-events: auto;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: start;
-  gap: 0.6rem;
-  border-radius: 12px;
-  border: 1px solid var(--line);
-  background: linear-gradient(155deg, rgb(16 26 43 / 95%) 0%, rgb(8 14 28 / 96%) 100%);
-  box-shadow: 0 16px 30px rgb(2 6 23 / 45%);
-  padding: 0.62rem 0.68rem;
-}
-
-.toast-success {
-  border-color: color-mix(in oklab, var(--good), var(--line) 45%);
-}
-
-.toast-error {
-  border-color: color-mix(in oklab, var(--bad), var(--line) 40%);
-}
-
-.toast-info {
-  border-color: color-mix(in oklab, var(--accent-2), var(--line) 50%);
-}
-
-.toast-message {
-  margin: 0;
-  font-size: 0.86rem;
-  line-height: 1.35;
-}
-
-.toast-dismiss {
-  border-radius: 9px;
-  padding: 0.3rem 0.5rem;
-  font-size: 0.74rem;
-}
-
-.top-nav {
-  display: flex;
-  gap: 0.6rem;
-  padding: 0.65rem;
-}
-
-.nav-tab {
-  border-radius: 999px;
-  padding: 0.42rem 0.9rem;
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.nav-tab.is-active {
-  border-color: color-mix(in oklab, var(--accent-2), var(--line) 40%);
-  background: linear-gradient(135deg, rgb(125 211 252 / 22%) 0%, rgb(15 23 42 / 70%) 100%);
+  gap: var(--sp3);
+  padding-top: var(--sp4);
 }
 
 .shell-failure {
@@ -115,131 +111,577 @@ body {
   min-height: 100vh;
 }
 
+/* ============================================================
+   Cards
+   ============================================================ */
 .card {
-  border: 1px solid var(--line);
-  border-radius: var(--card-radius);
-  background: linear-gradient(140deg, rgb(20 30 48 / 92%) 0%, rgb(11 18 32 / 96%) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: linear-gradient(155deg, rgb(14 24 44 / 90%) 0%, rgb(8 14 30 / 94%) 100%);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(6px);
-  padding: 1rem 1.1rem;
+  backdrop-filter: blur(8px);
+  padding: var(--sp5);
 }
 
-.hero {
-  display: grid;
-  gap: 0.5rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: auto -140px -140px auto;
-  width: 280px;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgb(125 211 252 / 45%) 0%, transparent 70%);
-  pointer-events: none;
-}
-
-.eyebrow {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.72rem;
-  color: var(--accent-2);
-}
-
-h1,
-h2 {
-  font-family: "Iowan Old Style", "Palatino Linotype", serif;
-  letter-spacing: 0.02em;
-  margin: 0;
-}
+/* ============================================================
+   Typography
+   ============================================================ */
+h1, h2, h3 { margin: 0; }
 
 h1 {
-  font-size: clamp(2.1rem, 3vw, 2.9rem);
+  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
 }
 
 h2 {
-  font-size: 1.4rem;
+  font-size: 1.0rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
-.panel-head {
+/* Mono uppercase label — used for section headings and status tags */
+.section-label {
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--teal);
+  font-family: "SF Mono", "Cascadia Code", ui-monospace, monospace;
+}
+
+/* Legacy eyebrow class */
+.eyebrow {
+  margin: 0;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--teal);
+}
+
+/* ============================================================
+   App Header (replaces separate hero + top-nav cards)
+   ============================================================ */
+.app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.8rem;
-}
-
-.status-dot {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  padding: 0.2rem 0.52rem;
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.status-dot::before {
-  content: "";
-  width: 0.5rem;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  background: var(--muted);
-}
-
-.status-dot.is-idle {
-  color: var(--muted);
-}
-
-.status-dot.is-idle::before {
-  background: var(--muted);
-}
-
-.status-dot.is-recording {
-  color: var(--good);
-}
-
-.status-dot.is-recording::before {
-  background: var(--good);
-}
-
-.status-dot.is-busy {
-  color: var(--accent);
-}
-
-.status-dot.is-busy::before {
-  background: var(--accent);
-}
-
-.hero-meta {
-  display: flex;
+  padding: var(--sp3) var(--sp5);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: linear-gradient(135deg, rgb(14 24 44 / 88%) 0%, rgb(8 14 30 / 92%) 100%);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-sm);
+  gap: var(--sp4);
   flex-wrap: wrap;
-  gap: 0.5rem;
+  /* Subtle teal accent line at top */
+  border-top-color: rgb(13 207 191 / 28%);
 }
 
-.chip {
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 0.28rem 0.66rem;
+.app-header-brand {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp2);
+  flex-shrink: 0;
+}
+
+.app-header-title {
+  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.app-header-version {
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  font-family: "SF Mono", ui-monospace, monospace;
+  letter-spacing: 0.06em;
+  align-self: center;
+}
+
+.app-header-meta {
+  display: flex;
+  gap: var(--sp2);
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.app-header-nav {
+  display: flex;
+  gap: var(--sp2);
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   Legacy Hero / Nav (hidden — replaced by app-header)
+   ============================================================ */
+.hero {
+  display: none;
+}
+
+.top-nav {
+  display: none;
+}
+
+/* ============================================================
+   Navigation Tabs
+   ============================================================ */
+.nav-tab {
+  border-radius: var(--r-full);
+  padding: 5px 16px;
   font-size: 0.78rem;
-  color: var(--muted);
-  background: rgb(2 6 23 / 45%);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: all 180ms ease;
+}
+
+.nav-tab:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: var(--border-hi);
+  transform: none;
+  background: rgb(255 255 255 / 5%);
+  box-shadow: none;
+}
+
+.nav-tab.is-active {
+  border-color: rgb(13 207 191 / 45%);
+  background: var(--teal-dim);
+  color: var(--teal);
+}
+
+/* ============================================================
+   Chips / Badges
+   ============================================================ */
+.chip {
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  padding: 3px 10px;
+  font-size: 0.7rem;
+  color: var(--ink-2);
+  background: rgb(5 12 28 / 50%);
+  letter-spacing: 0.03em;
+  white-space: nowrap;
 }
 
 .chip-good {
   color: var(--good);
-  border-color: color-mix(in oklab, var(--good), var(--line) 55%);
+  border-color: rgb(34 217 160 / 30%);
+  background: var(--good-dim);
 }
 
+.chip-amber {
+  color: var(--amber);
+  border-color: var(--amber-dim);
+  background: var(--amber-dim);
+}
+
+/* ============================================================
+   Hero meta (compat for existing chip rows)
+   ============================================================ */
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp2);
+}
+
+/* ============================================================
+   Status Dot — pill badge with animated dot indicator
+   ============================================================ */
+.status-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--border);
+  padding: 3px 10px;
+  font-size: 0.67rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  font-family: "SF Mono", "Cascadia Code", ui-monospace, monospace;
+  transition: color 200ms ease, border-color 200ms ease, background 200ms ease;
+}
+
+.status-dot::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-dot.is-idle {
+  color: var(--ink-3);
+}
+
+.status-dot.is-recording {
+  color: var(--good);
+  border-color: rgb(34 217 160 / 35%);
+  background: var(--good-dim);
+}
+
+.status-dot.is-recording::before {
+  animation: dot-blink 1.1s ease-in-out infinite;
+}
+
+.status-dot.is-busy {
+  color: var(--amber);
+  border-color: var(--amber-dim);
+  background: var(--amber-dim);
+}
+
+.status-dot.is-error {
+  color: var(--bad);
+  border-color: var(--bad-dim);
+  background: var(--bad-dim);
+}
+
+@keyframes dot-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+/* ============================================================
+   Recording Orb — the primary hero action button
+   ============================================================ */
+.record-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp5);
+  padding: var(--sp6) var(--sp4) var(--sp5);
+}
+
+/* Outer ring that pulses while recording */
+.record-orb-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.record-orb-ring {
+  position: absolute;
+  inset: -12px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  pointer-events: none;
+  transition: border-color 300ms ease, box-shadow 300ms ease;
+}
+
+.record-orb-ring--recording {
+  border-color: rgb(34 217 160 / 40%);
+  box-shadow: 0 0 24px var(--good-glow), inset 0 0 24px rgb(34 217 160 / 8%);
+  animation: ring-pulse 2s ease-in-out infinite;
+}
+
+@keyframes ring-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.08); opacity: 0.6; }
+}
+
+/* The orb button itself — overrides global button defaults */
+.btn-record-orb {
+  width: 108px;
+  height: 108px;
+  border-radius: 50%;
+  border: 2px solid rgb(34 217 160 / 28%);
+  background: linear-gradient(145deg, rgb(34 217 160 / 20%) 0%, rgb(6 12 28 / 92%) 100%);
+  box-shadow: 0 8px 32px var(--good-dim), inset 0 1px 0 rgb(255 255 255 / 7%);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  transition: all 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  padding: 0;
+  color: var(--good);
+  font-family: inherit;
+  appearance: none;
+}
+
+.btn-record-orb:hover:not(:disabled) {
+  transform: scale(1.07);
+  border-color: var(--good);
+  box-shadow: 0 14px 52px var(--good-glow), inset 0 1px 0 rgb(255 255 255 / 12%);
+  background: linear-gradient(145deg, rgb(34 217 160 / 30%) 0%, rgb(6 12 28 / 92%) 100%);
+}
+
+.btn-record-orb:active:not(:disabled) {
+  transform: scale(0.95);
+  transition-duration: 100ms;
+}
+
+/* Red state when recording is active */
+.btn-record-orb.is-recording {
+  border-color: rgb(240 96 96 / 35%);
+  background: linear-gradient(145deg, rgb(240 96 96 / 20%) 0%, rgb(6 12 28 / 92%) 100%);
+  box-shadow: 0 8px 32px var(--bad-dim), inset 0 1px 0 rgb(255 255 255 / 7%);
+  color: var(--bad);
+}
+
+.btn-record-orb.is-recording:hover:not(:disabled) {
+  border-color: var(--bad);
+  box-shadow: 0 14px 52px var(--bad-dim);
+  background: linear-gradient(145deg, rgb(240 96 96 / 30%) 0%, rgb(6 12 28 / 92%) 100%);
+}
+
+/* Busy/processing state */
+.btn-record-orb.is-busy {
+  border-color: rgb(13 207 191 / 35%);
+  background: linear-gradient(145deg, var(--teal-dim) 0%, rgb(6 12 28 / 92%) 100%);
+  box-shadow: 0 8px 32px var(--teal-dim), inset 0 1px 0 rgb(255 255 255 / 7%);
+  color: var(--teal);
+  cursor: not-allowed;
+}
+
+.btn-record-orb:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
+.orb-icon {
+  font-size: 2rem;
+  line-height: 1;
+  display: block;
+}
+
+.orb-label {
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  font-family: "SF Mono", "Cascadia Code", ui-monospace, monospace;
+  opacity: 0.75;
+  display: block;
+}
+
+/* ============================================================
+   Waveform Bars — 12 animated bars shown when recording
+   ============================================================ */
+.waveform {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  height: 36px;
+}
+
+.waveform span {
+  display: block;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--good);
+  height: 4px;
+  flex-shrink: 0;
+  opacity: 0.25;
+  transition: height 300ms ease, opacity 300ms ease;
+}
+
+/* Active: animate bars with stagger via --bar-i custom property */
+.waveform--active span {
+  opacity: 1;
+  animation: wave-bar 0.75s ease-in-out infinite alternate;
+  /* --bar-i is set inline on each span element */
+  animation-delay: calc(var(--bar-i, 0) * 60ms);
+}
+
+/* Even bars slightly different rhythm */
+.waveform--active span:nth-child(even) {
+  animation-duration: 0.65s;
+}
+
+@keyframes wave-bar {
+  from { height: 4px; }
+  to { height: 30px; }
+}
+
+/* ============================================================
+   Secondary Recording Actions
+   ============================================================ */
+.record-secondary-actions {
+  display: flex;
+  gap: var(--sp2);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ============================================================
+   Buttons — three-tier system: default / ghost / cancel
+   ============================================================ */
+button {
+  appearance: none;
+  border: 1px solid rgb(80 110 155 / 50%);
+  border-radius: var(--r-md);
+  padding: 9px 18px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ink);
+  background: linear-gradient(135deg, var(--amber-dim) 0%, rgb(12 22 42 / 72%) 100%);
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+  font-family: inherit;
+  letter-spacing: 0.01em;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgb(232 162 58 / 50%);
+  background: linear-gradient(135deg, rgb(232 162 58 / 26%) 0%, rgb(12 22 42 / 78%) 100%);
+  box-shadow: 0 4px 16px var(--amber-dim);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}
+
+/* Busy variant (teal tint — processing state) */
+button.is-busy {
+  border-color: rgb(13 207 191 / 40%);
+  background: linear-gradient(135deg, var(--teal-dim) 0%, rgb(12 22 42 / 72%) 100%);
+}
+
+/* Ghost — subtle, secondary actions */
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--ink-2);
+  font-size: 0.8rem;
+  padding: 6px 14px;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: rgb(255 255 255 / 5%);
+  border-color: var(--border-hi);
+  color: var(--ink);
+  transform: none;
+  box-shadow: none;
+}
+
+/* Cancel — destructive/abort action */
+.btn-cancel {
+  background: transparent;
+  border-color: rgb(240 96 96 / 30%);
+  color: var(--bad);
+  font-size: 0.8rem;
+  padding: 6px 14px;
+}
+
+.btn-cancel:hover:not(:disabled) {
+  background: var(--bad-dim);
+  border-color: var(--bad);
+  transform: none;
+  box-shadow: 0 4px 12px var(--bad-dim);
+}
+
+/* ============================================================
+   Button Grid (legacy — used by existing components)
+   ============================================================ */
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp2);
+}
+
+.button-grid.single {
+  grid-template-columns: 1fr;
+}
+
+/* Inline link — small text button */
+.inline-link {
+  margin: 0 0 var(--sp3);
+  width: fit-content;
+  border-radius: var(--r-sm);
+  padding: 5px 12px;
+  font-size: 0.76rem;
+}
+
+/* ============================================================
+   Status / Error Text
+   ============================================================ */
+.muted {
+  color: var(--ink-2);
+  margin: 0 0 var(--sp3);
+  font-size: 0.86rem;
+}
+
+.inline-error {
+  min-height: 1.2rem;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--bad);
+}
+
+.inline-next-step {
+  margin: 0 0 var(--sp2);
+  font-size: 0.78rem;
+  color: var(--ink-2);
+}
+
+.field-error {
+  margin: 0;
+  min-height: 1rem;
+  font-size: 0.78rem;
+  color: var(--bad);
+}
+
+.field-hint {
+  color: var(--ink-2);
+  font-size: 0.74rem;
+  font-style: normal;
+  margin-left: 4px;
+}
+
+.provider-status {
+  margin: 0;
+  min-height: 1rem;
+  font-size: 0.8rem;
+}
+
+/* ============================================================
+   Panel Head
+   ============================================================ */
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp3);
+  margin-bottom: var(--sp4);
+}
+
+/* ============================================================
+   Page Layouts
+   ============================================================ */
 .grid {
   display: grid;
-  gap: 1rem;
+  gap: var(--sp4);
 }
 
 .page-home {
@@ -262,122 +704,174 @@ h2 {
   display: none;
 }
 
-.muted {
-  color: var(--muted);
-  margin: 0.3rem 0 0.8rem;
-}
-
-.button-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
-}
-
-.button-grid.single {
-  grid-template-columns: 1fr;
-}
-
-button {
-  appearance: none;
-  border: 1px solid color-mix(in oklab, var(--accent), var(--line) 62%);
-  border-radius: 12px;
-  padding: 0.64rem 0.75rem;
-  font-size: 0.94rem;
-  font-weight: 600;
-  color: var(--ink);
-  background: linear-gradient(135deg, rgb(242 166 90 / 20%) 0%, rgb(15 23 42 / 70%) 100%);
-  cursor: pointer;
-  transition: transform 170ms ease, border-color 170ms ease, background 170ms ease;
-}
-
-button:hover {
-  transform: translateY(-1px);
-  border-color: color-mix(in oklab, var(--accent), white 30%);
-  background: linear-gradient(135deg, rgb(242 166 90 / 30%) 0%, rgb(15 23 42 / 75%) 100%);
-}
-
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid var(--accent-2);
-  outline-offset: 2px;
-}
-
-button:active {
-  transform: translateY(0);
-}
-
-button:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.inline-link {
-  margin: 0 0 0.6rem;
-  width: fit-content;
-  border-radius: 9px;
-  padding: 0.36rem 0.62rem;
-  font-size: 0.76rem;
-}
-
-button.is-busy {
-  border-color: color-mix(in oklab, var(--accent-2), var(--line) 30%);
-  background: linear-gradient(135deg, rgb(125 211 252 / 26%) 0%, rgb(15 23 42 / 70%) 100%);
-}
-
+/* ============================================================
+   Settings — Form Containers
+   ============================================================ */
 .settings-form {
   display: grid;
-  gap: 0.75rem;
+  gap: var(--sp4);
 }
 
+/* Legacy settings group (used by sub-components) */
 .settings-group {
-  border: 1px solid rgb(49 72 101 / 45%);
-  border-radius: 12px;
-  padding: 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--sp4);
   display: grid;
-  gap: 0.55rem;
+  gap: var(--sp3);
 }
 
 .settings-group h3 {
   margin: 0;
-  font-size: 1rem;
-  color: var(--accent-2);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--teal);
+  font-family: "SF Mono", "Cascadia Code", ui-monospace, monospace;
 }
 
+/* ============================================================
+   Settings Accordion — collapsible sections
+   ============================================================ */
+.settings-accordion {
+  display: grid;
+  gap: var(--sp2);
+  margin-top: var(--sp4);
+}
+
+.settings-section {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+/* Header trigger button — overrides global button defaults */
+.settings-section-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--sp3);
+  padding: var(--sp3) var(--sp4);
+  background: rgb(10 18 34 / 80%);
+  border: none;
+  border-radius: 0;
+  text-align: left;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  /* Reset button visual styles */
+  transform: none !important;
+  box-shadow: none !important;
+  background-image: none;
+  transition: background 180ms ease;
+  letter-spacing: 0.01em;
+}
+
+.settings-section-header:hover:not(:disabled) {
+  background: rgb(14 26 48 / 88%);
+  border-color: transparent;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+/* Completion dot — filled green when section is configured */
+.section-indicator {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-3);
+  flex-shrink: 0;
+  transition: background 240ms ease, box-shadow 240ms ease;
+}
+
+.section-indicator--done {
+  background: var(--good);
+  box-shadow: 0 0 8px var(--good-dim);
+}
+
+.section-title-text {
+  flex: 1;
+}
+
+.section-chevron {
+  font-size: 0.65rem;
+  color: var(--ink-3);
+  flex-shrink: 0;
+  transition: transform 220ms ease;
+  display: inline-block;
+}
+
+.section-chevron--open {
+  transform: rotate(180deg);
+}
+
+.settings-section-body {
+  padding: var(--sp4) var(--sp5);
+  border-top: 1px solid var(--border);
+  background: rgb(6 12 26 / 55%);
+}
+
+/* ============================================================
+   Settings Key Row (shortcut editor)
+   ============================================================ */
+.settings-key-row {
+  border: 1px dashed var(--border);
+  border-radius: var(--r-sm);
+  padding: var(--sp3);
+  display: grid;
+  gap: var(--sp2);
+}
+
+/* ============================================================
+   Toggle Row
+   ============================================================ */
 .toggle-row {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: var(--sp3);
   font-size: 0.88rem;
 }
 
+/* ============================================================
+   Text Row — form field wrapper
+   ============================================================ */
 .text-row {
   display: grid;
-  gap: 0.35rem;
+  gap: 4px;
   font-size: 0.86rem;
-}
-
-.field-hint {
-  color: var(--muted);
-  font-size: 0.75rem;
-  font-style: normal;
-  margin-left: 0.35rem;
 }
 
 .text-row input,
 .text-row select,
 .text-row textarea {
-  border: 1px solid var(--line);
-  border-radius: 11px;
-  background: rgb(2 6 23 / 42%);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-input);
   color: var(--ink);
-  padding: 0.5rem 0.58rem;
+  padding: 8px 12px;
   resize: vertical;
   min-height: 78px;
+  font-family: inherit;
+  font-size: 0.88rem;
+  transition: border-color 180ms ease;
 }
 
+.text-row input,
+.text-row select {
+  min-height: unset;
+}
+
+.text-row input:hover,
+.text-row select:hover,
+.text-row textarea:hover {
+  border-color: var(--border-hi);
+}
+
+/* ============================================================
+   Settings Actions
+   ============================================================ */
 .settings-actions {
   display: flex;
   justify-content: flex-end;
@@ -385,89 +879,135 @@ button.is-busy {
 
 .settings-actions-inline {
   justify-content: flex-start;
-  gap: 0.45rem;
+  gap: var(--sp2);
 }
 
-.settings-key-row {
-  border: 1px dashed rgb(49 72 101 / 55%);
-  border-radius: 10px;
-  padding: 0.55rem;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.provider-status {
-  margin: 0;
-  min-height: 1rem;
-  font-size: 0.8rem;
-}
-
-.field-error {
-  margin: 0;
-  min-height: 1rem;
-  font-size: 0.8rem;
-  color: var(--bad);
-}
-
-.inline-error {
-  min-height: 1.2rem;
-  margin: 0;
-  font-size: 0.8rem;
-  color: var(--bad);
-}
-
-.inline-next-step {
-  margin: 0 0 0.45rem;
-  font-size: 0.78rem;
-  color: var(--muted);
-}
-
+/* ============================================================
+   Shortcut List
+   ============================================================ */
 .shortcut-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.48rem;
+  gap: var(--sp2);
 }
 
 .shortcut-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.8rem;
-  border: 1px solid rgb(49 72 101 / 45%);
-  border-radius: 11px;
-  padding: 0.5rem 0.6rem;
-  background: rgb(2 6 23 / 30%);
+  gap: var(--sp3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 8px 12px;
+  background: rgb(4 10 24 / 45%);
 }
 
 .shortcut-action {
   color: var(--ink);
-  font-size: 0.88rem;
+  font-size: 0.85rem;
 }
 
 .shortcut-combo {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0.22rem 0.5rem;
-  background: rgb(8 16 28 / 70%);
-  color: var(--accent-2);
-  font-size: 0.76rem;
-  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 3px 8px;
+  background: rgb(5 10 24 / 80%);
+  color: var(--teal);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  font-family: "SF Mono", "Cascadia Code", ui-monospace, monospace;
+  white-space: nowrap;
 }
 
-.status-dot.is-error {
-  color: var(--bad);
+/* ============================================================
+   Toast Layer — bottom-center, slides up on entry
+   ============================================================ */
+.toast-layer {
+  position: fixed;
+  bottom: var(--sp5);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: flex;
+  flex-direction: column-reverse; /* newest toast appears on top */
+  gap: var(--sp2);
+  align-items: center;
+  width: min(440px, calc(100vw - 2rem));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  pointer-events: none;
 }
 
-.status-dot.is-error::before {
-  background: var(--bad);
+.toast-item {
+  pointer-events: auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--sp3);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: linear-gradient(155deg, rgb(16 28 52 / 97%) 0%, rgb(8 14 30 / 98%) 100%);
+  box-shadow: 0 12px 40px rgb(2 4 16 / 65%);
+  padding: 10px 14px;
+  width: 100%;
+  /* Slide up on enter */
+  animation: toast-rise 220ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
+@keyframes toast-rise {
+  from { opacity: 0; transform: translateY(14px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Left accent stripe per tone */
+.toast-success {
+  border-color: rgb(34 217 160 / 35%);
+  border-left: 3px solid var(--good);
+}
+
+.toast-error {
+  border-color: rgb(240 96 96 / 35%);
+  border-left: 3px solid var(--bad);
+}
+
+.toast-info {
+  border-color: rgb(13 207 191 / 30%);
+  border-left: 3px solid var(--teal);
+}
+
+.toast-message {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.toast-dismiss {
+  border-radius: var(--r-sm);
+  padding: 4px 10px;
+  font-size: 0.7rem;
+  background: transparent;
+  border-color: var(--border);
+  color: var(--ink-2);
+}
+
+.toast-dismiss:hover:not(:disabled) {
+  transform: none;
+  background: rgb(255 255 255 / 6%);
+  box-shadow: none;
+  border-color: var(--border-hi);
+}
+
+/* ============================================================
+   Stagger Entrance Animations
+   ============================================================ */
 [data-stagger] {
   opacity: 0;
-  transform: translateY(9px);
-  animation: panel-in 620ms cubic-bezier(0.2, 0.65, 0.2, 1) forwards;
+  transform: translateY(8px);
+  animation: panel-in 540ms cubic-bezier(0.2, 0.65, 0.2, 1) forwards;
   animation-delay: var(--delay, 0ms);
 }
 
@@ -478,6 +1018,9 @@ button.is-busy {
   }
 }
 
+/* ============================================================
+   Responsive Breakpoints
+   ============================================================ */
 @media (max-width: 1020px) {
   .page-home {
     grid-template-columns: 1fr;
@@ -501,10 +1044,6 @@ button.is-busy {
     grid-template-columns: 1fr;
   }
 
-  .page-settings {
-    grid-template-columns: 1fr;
-  }
-
   .button-grid {
     grid-template-columns: 1fr;
   }
@@ -518,19 +1057,42 @@ button.is-busy {
     align-items: flex-start;
     flex-direction: column;
   }
+
+  .app-header {
+    padding: var(--sp3) var(--sp4);
+    gap: var(--sp3);
+  }
+
+  /* Hide status chips on small screens — they clutter the header */
+  .app-header-meta {
+    display: none;
+  }
 }
 
 @media (max-width: 540px) {
   .card {
-    padding: 0.9rem;
+    padding: var(--sp4);
   }
 
   .chip {
-    font-size: 0.72rem;
+    font-size: 0.66rem;
   }
 
   button {
-    padding: 0.58rem 0.68rem;
-    font-size: 0.88rem;
+    font-size: 0.84rem;
+    padding: 8px 14px;
+  }
+
+  .app-header-title {
+    font-size: 1.08rem;
+  }
+
+  .btn-record-orb {
+    width: 92px;
+    height: 92px;
+  }
+
+  .orb-icon {
+    font-size: 1.65rem;
   }
 }


### PR DESCRIPTION
## Summary

Full greenfield redesign of the renderer UI layer. Zero backward-compat UI constraints — every visual decision optimised for the core recording workflow. No IPC contracts, state shapes, or business logic were changed.

- **New design system** — jewel amber + teal brand pair, 8px spacing grid, 3-level surface elevation, monospace for technical elements
- **Recording orb** — large circular hero button replaces 4-button grid; waveform bars animate during capture; pulse ring confirms active recording; Cancel only visible while recording
- **Compact unified header** — single `.app-header` bar replaces separate hero card + nav card
- **Settings accordion** — 5 collapsible sections with completion dots (Zeigarnik effect); Recording open by default
- **Bottom-center toasts** — combats banner blindness; slide-up spring animation; per-tone left accent stripe

## Design Spec

Full rationale, token reference, component specs, greenfield roadmap, and decision log:
[`docs/decisions/ui-redesign-spec-greenfield.md`](docs/decisions/ui-redesign-spec-greenfield.md)

## Files Changed

| File | Change |
|---|---|
| `src/renderer/styles.css` | Complete rewrite — new design token system, recording orb, waveform, accordion, bottom toast |
| `src/renderer/shell-chrome-react.tsx` | Replaced two-card layout with single `.app-header` bar |
| `src/renderer/home-react.tsx` | Recording orb + WaveformBars + adaptive secondary actions |
| `src/renderer/app-shell-react.tsx` | Settings accordion with `useState`, completion dots |
| `docs/decisions/ui-redesign-spec-greenfield.md` | New — full design spec + P0/P1/P2 roadmap |

## Greenfield Roadmap (not in this PR)

- **P0:** Real waveform amplitude via AudioContext IPC, toast countdown bar, smooth accordion CSS animation
- **P1:** Command palette (⌘K), activity feed card, setup progress ring
- **P2:** Light theme token set, full-screen recording mode, preset quick-switch chips

## Test plan

- [ ] Typecheck passes: `pnpm run typecheck` ✅
- [ ] App launches and renders Home page correctly
- [ ] Recording orb toggles green↔red on `isRecording` state change
- [ ] Waveform animates when recording, flat when idle
- [ ] Settings accordion: each section opens/closes independently
- [ ] Completion dots turn green when sections are configured
- [ ] Toasts appear bottom-center, newest on top, dismiss works
- [ ] Nav tabs switch between Home and Settings
- [ ] Status chips in header reflect live settings (provider, auto-run)
- [ ] All existing keyboard shortcuts and aria attributes intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)