### PR TITLE
fix: remove active preset and remember pick-and-run focus (#167)

### DIFF
--- a/docs/decisions/transformation-active-vs-default-profile.md
+++ b/docs/decisions/transformation-active-vs-default-profile.md
@@ -6,6 +6,11 @@ Why: Clarifies user-facing semantics in Settings and documents existing behavior
 
 # Decision Record: Active vs Default Transformation Profile
 
+## Superseded
+- This record is superseded by `docs/decisions/transformation-remove-active-preset-last-picked-focus.md` (2026-02-27, issue #167).
+- Current architecture no longer keeps `activePresetId`.
+- `defaultPresetId` is the only persistent execution selector; `lastPickedPresetId` is picker-focus memory only.
+
 ## Update (2026-02-26, final `#127` cleanup)
 
 This decision record was updated after the initial clarification pass. The original split semantics ("manual transforms use active, default flows use default") were an interim clarification. Final `#127` behavior removes `active` from user-facing Settings and standardizes user-triggered/manual transform actions on the default profile.

--- a/docs/decisions/transformation-remove-active-preset-last-picked-focus.md
+++ b/docs/decisions/transformation-remove-active-preset-last-picked-focus.md
@@ -1,0 +1,40 @@
+<!--
+Where: docs/decisions/transformation-remove-active-preset-last-picked-focus.md
+What: Decision record for removing active preset state and adding last-picked focus memory for Pick-and-Run.
+Why: Issue #167 requires removing active profile semantics and optimizing repeated picker workflows.
+-->
+
+# Decision: Remove `activePresetId`, add `lastPickedPresetId` focus memory
+
+## Date
+2026-02-27
+
+## Context
+- The app previously kept `activePresetId` as an internal field after user-facing active profile controls were removed.
+- Pick-and-run used this hidden field as picker focus seed, which made behavior indirect and confusing.
+- Issue `#167` requires:
+  - remove `activePresetId` completely (no backward runtime behavior),
+  - keep pick-and-run request-scoped,
+  - remember the last picked profile and focus it on next picker open.
+
+## Decision
+- Remove `transformation.activePresetId` from schema, defaults, runtime state, and code paths.
+- Add `transformation.lastPickedPresetId: string | null`.
+- Pick-and-run behavior:
+  - execute using selected preset for current request only,
+  - persist `lastPickedPresetId` after successful selection,
+  - do not mutate `defaultPresetId`.
+- Picker focus resolution order:
+  1. `lastPickedPresetId` when valid
+  2. `defaultPresetId` when valid
+  3. first available preset
+
+## Rationale
+- Separates persistent default behavior from temporary picker execution behavior.
+- Preserves fast repeat workflow without reintroducing hidden active-profile semantics.
+- Keeps profile editing and manual/default transformations aligned on `defaultPresetId`.
+
+## Consequences
+- Settings and migrations normalize away legacy `activePresetId`.
+- Tests and docs that mention active profile semantics must be updated.
+- Picker-related behavior is now explicitly testable via `lastPickedPresetId`.

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -480,8 +480,8 @@ test(
   const sentinel = `CFG_SENTINEL_${Date.now()}`
 
   await page.locator('#settings-preset-add').click()
-  const activeConfigSelect = page.locator('#settings-transform-active-preset')
-  const selectedConfigId = await activeConfigSelect.inputValue()
+  const defaultConfigSelect = page.locator('#settings-transform-default-preset')
+  const selectedConfigId = await defaultConfigSelect.inputValue()
   const configName = `Config E2E ${Date.now()}`
   await page.locator('#settings-transform-preset-name').fill(configName)
   await page.locator('#settings-user-prompt').fill(`Return this token exactly: ${sentinel}`)
@@ -490,7 +490,7 @@ test(
 
   const settingsAfterSave = await page.evaluate(async () => window.speechToTextApi.getSettings())
   expect(settingsAfterSave.transformation.presets.length).toBe(previousPresetCount + 1)
-  expect(settingsAfterSave.transformation.activePresetId).toBe(selectedConfigId)
+  expect(settingsAfterSave.transformation.defaultPresetId).toBe(selectedConfigId)
   expect(
     settingsAfterSave.transformation.presets.some(
       (preset: { id: string; name: string }) => preset.id === selectedConfigId && preset.name === configName
@@ -521,7 +521,7 @@ test(
   }
 )
 
-test('opens dedicated picker window for pick-and-run shortcut and updates active preset', async ({ page, electronApp }) => {
+test('opens dedicated picker window for pick-and-run shortcut and updates last-picked preset', async ({ page, electronApp }) => {
   await page.evaluate(async () => {
     const settings = await window.speechToTextApi.getSettings()
     if (settings.transformation.presets.length >= 2) {
@@ -531,8 +531,8 @@ test('opens dedicated picker window for pick-and-run shortcut and updates active
       ...settings,
       transformation: {
         ...settings.transformation,
-        activePresetId: 'default',
         defaultPresetId: 'default',
+        lastPickedPresetId: null,
         presets: [
           settings.transformation.presets[0],
           {
@@ -557,7 +557,7 @@ test('opens dedicated picker window for pick-and-run shortcut and updates active
 
   await expect.poll(async () => {
     const settings = await page.evaluate(async () => window.speechToTextApi.getSettings())
-    return settings.transformation.activePresetId
+    return settings.transformation.lastPickedPresetId
   }).toBe('picker-b')
 })
 

--- a/specs/decision-pick-and-run-persistence.md
+++ b/specs/decision-pick-and-run-persistence.md
@@ -1,14 +1,14 @@
 <!--
 Where: specs/decision-pick-and-run-persistence.md
-What: Decision record for pick-and-run active-profile persistence behavior.
-Why: Resolve #70 conflict between user feedback and current normative spec.
+What: Decision record for pick-and-run execution vs picker-focus persistence behavior.
+Why: Clarify #167 semantics after removing active-profile state.
 -->
 
-# Decision: pick-and-run active profile persistence
+# Decision: Pick-and-run request scope with remembered picker focus
 
-- Date: 2026-02-19
-- Issue: #85
-- Status: Supersedes prior #70 decision
+- Date: 2026-02-27
+- Issue: #167
+- Status: Supersedes prior #85 wording that referenced `activePresetId`
 
 ## Decision
 
@@ -16,17 +16,18 @@ Why: Resolve #70 conflict between user feedback and current normative spec.
 
 1. User picks a profile.
 2. System executes transformation with that picked profile for the current request.
-3. System does not update persisted `transformation.activePresetId`.
-4. Subsequent active-target shortcuts continue using persisted active profile unless changed explicitly by other controls.
+3. System updates persisted `transformation.lastPickedPresetId` to the selected profile id.
+4. System does not update persisted `transformation.defaultPresetId`.
+5. Subsequent picker opens focus `lastPickedPresetId` when valid; otherwise fall back to `defaultPresetId`, then first profile.
 
 ## Rationale
 
-- Issue #85 explicitly rejects the prior persistent interpretation.
-- One-time behavior matches user expectation for a temporary pick-and-run action.
-- Keeps persistent profile state changes scoped to explicit settings/profile actions.
+- Preserves request-scoped execution while supporting repeat workflows (press shortcut, Enter to repeat last pick).
+- Keeps default-profile semantics stable and explicit.
+- Removes hidden `activePresetId` coupling from picker behavior.
 
 ## Consequences
 
-- Spec wording is updated to remove persistent side-effect semantics for pick-and-run.
-- Any implementation/tests relying on pick-and-run persistence must be updated to request-scoped behavior.
-- Issue #83 is treated as invalid and should not be used as normative direction.
+- Pick-and-run now persists only picker focus memory (`lastPickedPresetId`).
+- Any implementation/tests relying on `activePresetId` must be removed or rewritten.
+- Specs and decision docs must no longer describe `activePresetId` behavior.

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -120,8 +120,8 @@ describe('CommandRouter', () => {
     const settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        activePresetId: 'active-id',
         defaultPresetId: 'default-id',
+        lastPickedPresetId: 'active-id',
         autoRunDefaultTransform: true,
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
@@ -360,8 +360,8 @@ describe('CommandRouter', () => {
     const settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        activePresetId: 'active-id',
         defaultPresetId: 'default-id',
+        lastPickedPresetId: 'active-id',
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'picked-id', name: 'Picked' }
@@ -382,8 +382,9 @@ describe('CommandRouter', () => {
     // Must use the explicitly supplied preset — not the active or default one.
     expect(snapshot.profileId).toBe('picked-id')
     expect(snapshot.textSource).toBe('clipboard')
-    // Settings are not mutated — activePresetId stays unchanged.
-    expect(settings.transformation.activePresetId).toBe('active-id')
+    // Settings are not mutated by one-time run.
+    expect(settings.transformation.defaultPresetId).toBe('default-id')
+    expect(settings.transformation.lastPickedPresetId).toBe('active-id')
   })
 
   it('runDefaultCompositeFromClipboard uses default preset id', async () => {
@@ -391,8 +392,8 @@ describe('CommandRouter', () => {
     const settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        activePresetId: 'active-id',
         defaultPresetId: 'default-id',
+        lastPickedPresetId: 'active-id',
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' }
@@ -418,8 +419,8 @@ describe('CommandRouter', () => {
     const settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        activePresetId: 'active-id',
         defaultPresetId: 'default-id',
+        lastPickedPresetId: 'active-id',
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' }
@@ -458,8 +459,8 @@ describe('CommandRouter', () => {
     const settings: Settings = makeSettings({
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        activePresetId: 'a',
         defaultPresetId: 'a',
+        lastPickedPresetId: null,
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'a', name: 'A', model: 'gemini-2.5-flash' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'b', name: 'B', model: 'gemini-2.5-flash' }

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -143,7 +143,7 @@ const hotkeyService = new HotkeyService({
   settingsService,
   commandRouter,
   runRecordingCommand,
-  pickProfile: (presets, currentActiveId) => profilePickerService.pickProfile(presets, currentActiveId),
+  pickProfile: (presets, focusedPresetId) => profilePickerService.pickProfile(presets, focusedPresetId),
   readSelectionText: () => selectionClient.readSelection(),
   onCompositeResult: broadcastCompositeTransformStatus,
   onShortcutError: (payload) => {

--- a/src/main/orchestrators/processing-orchestrator.test.ts
+++ b/src/main/orchestrators/processing-orchestrator.test.ts
@@ -7,8 +7,8 @@ const baseSettings: Settings = {
   ...DEFAULT_SETTINGS,
   transformation: {
     ...DEFAULT_SETTINGS.transformation,
-    activePresetId: 'default',
     defaultPresetId: 'default',
+    lastPickedPresetId: null,
     autoRunDefaultTransform: true,
     presets: [
       {

--- a/src/main/orchestrators/transformation-orchestrator.test.ts
+++ b/src/main/orchestrators/transformation-orchestrator.test.ts
@@ -6,8 +6,8 @@ const baseSettings: Settings = {
   ...DEFAULT_SETTINGS,
   transformation: {
     ...DEFAULT_SETTINGS.transformation,
-    activePresetId: 'default',
     defaultPresetId: 'default',
+    lastPickedPresetId: null,
     presets: [
       {
         ...DEFAULT_SETTINGS.transformation.presets[0],
@@ -90,8 +90,8 @@ describe('TransformationOrchestrator', () => {
           ...baseSettings,
           transformation: {
             ...baseSettings.transformation,
-            activePresetId: 'active-profile',
             defaultPresetId: 'default-profile',
+            lastPickedPresetId: null,
             presets: [
               {
                 ...baseSettings.transformation.presets[0],

--- a/src/main/services/profile-picker-service.test.ts
+++ b/src/main/services/profile-picker-service.test.ts
@@ -87,13 +87,13 @@ describe('buildPickerWindowHeight', () => {
 })
 
 describe('buildPickerHtml', () => {
-  it('renders profile names and current-active hint text', () => {
+  it('renders profile names and focused-entry hint text', () => {
     const html = buildPickerHtml([makePreset('a', 'Alpha'), makePreset('b', 'Beta')], 'a')
     expect(html).toContain('Pick Transformation Profile')
     expect(html).toContain('Alpha')
     expect(html).toContain('Beta')
-    expect(html).toContain('Currently active')
-    expect(html).toContain('Set active and run')
+    expect(html).toContain('Focused on open')
+    expect(html).toContain('Pick and run')
   })
 })
 

--- a/src/main/services/profile-picker-service.ts
+++ b/src/main/services/profile-picker-service.ts
@@ -76,7 +76,7 @@ const buildPickerWindowHeight = (presetCount: number): number => {
   return WINDOW_BASE_HEIGHT + visibleItemCount * WINDOW_ITEM_HEIGHT
 }
 
-const buildPickerHtml = (presets: readonly TransformationPreset[], currentActiveId: string): string => {
+const buildPickerHtml = (presets: readonly TransformationPreset[], focusedPresetId: string): string => {
   const itemsJson = escapeInlineScriptJson(
     JSON.stringify(
       presets.map((preset) => ({
@@ -85,7 +85,7 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], currentActive
       }))
     )
   )
-  const escapedActiveId = escapeInlineScriptJson(JSON.stringify(currentActiveId))
+  const escapedFocusedId = escapeInlineScriptJson(JSON.stringify(focusedPresetId))
 
   return `<!doctype html>
 <html lang="en">
@@ -170,11 +170,11 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], currentActive
     </main>
     <script>
       const items = ${itemsJson};
-      const activeId = ${escapedActiveId};
+      const focusedId = ${escapedFocusedId};
       const listNode = document.getElementById('picker-list');
       let selectedIndex = Math.max(
         0,
-        items.findIndex((item) => item.id === activeId)
+        items.findIndex((item) => item.id === focusedId)
       );
 
       const select = (nextIndex) => {
@@ -213,7 +213,7 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], currentActive
           '>': '&gt;',
           '\"': '&quot;',
           \"'\": '&#39;'
-        }[ch])) + '</span><span class="item-tag">' + (item.id === activeId ? 'Currently active' : 'Set active and run') + '</span>';
+        }[ch])) + '</span><span class="item-tag">' + (item.id === focusedId ? 'Focused on open' : 'Pick and run') + '</span>';
         button.addEventListener('click', () => pick(index));
         li.appendChild(button);
         listNode.appendChild(li);
@@ -281,7 +281,7 @@ export class ProfilePickerService {
     }
   }
 
-  async pickProfile(presets: readonly TransformationPreset[], currentActiveId: string): Promise<string | null> {
+  async pickProfile(presets: readonly TransformationPreset[], focusedPresetId: string): Promise<string | null> {
     if (presets.length === 0) {
       return null
     }
@@ -357,7 +357,7 @@ export class ProfilePickerService {
         finish(null, false)
       })
 
-      const html = buildPickerHtml(presets, currentActiveId)
+      const html = buildPickerHtml(presets, focusedPresetId)
       void Promise.resolve(pickerWindow.loadURL(toDataUrl(html)))
         .then(() => {
           if (settled) {

--- a/src/main/services/settings-service.test.ts
+++ b/src/main/services/settings-service.test.ts
@@ -213,6 +213,28 @@ describe('SettingsService', () => {
     )
   })
 
+  it('removes legacy activePresetId and initializes lastPickedPresetId to null on load', () => {
+    const legacySettings = structuredClone(DEFAULT_SETTINGS) as any
+    legacySettings.transformation.activePresetId = 'legacy-active'
+    delete legacySettings.transformation.lastPickedPresetId
+
+    const data = { settings: legacySettings }
+    const set = vi.fn((key: 'settings', value: Settings) => {
+      data[key] = value
+    })
+    const store = {
+      get: () => data.settings,
+      set
+    } as any
+
+    const service = new SettingsService(store)
+    const loaded = service.getSettings()
+
+    expect(loaded.transformation.lastPickedPresetId).toBeNull()
+    expect((loaded.transformation as Record<string, unknown>).activePresetId).toBeUndefined()
+    expect(set).toHaveBeenCalledOnce()
+  })
+
   it('preserves legacy scalar override values during one-time map migration', () => {
     const legacySettings = structuredClone(DEFAULT_SETTINGS) as any
     delete legacySettings.transcription.baseUrlOverrides

--- a/src/main/test-support/settings-fixtures.ts
+++ b/src/main/test-support/settings-fixtures.ts
@@ -16,12 +16,12 @@ export const SETTINGS_TRANSFORM_AUTO_RUN_DISABLED: Settings = buildSettings({
   }
 })
 
-/** Two transformation presets with 'a' as both active and default. */
+/** Two transformation presets with 'a' as default. */
 export const SETTINGS_MULTI_PRESET: Settings = buildSettings({
   transformation: {
     ...buildSettings().transformation,
-    activePresetId: 'a',
     defaultPresetId: 'a',
+    lastPickedPresetId: null,
     presets: [
       { ...buildSettings().transformation.presets[0], id: 'a', name: 'Preset A' },
       { ...buildSettings().transformation.presets[0], id: 'b', name: 'Preset B' }

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -85,9 +85,8 @@ export interface AppShellCallbacks {
   onSelectTranscriptionProvider: (provider: Settings['transcription']['provider']) => void
   onSelectTranscriptionModel: (model: Settings['transcription']['model']) => void
   onToggleAutoRun: (checked: boolean) => void
-  // onSelectActivePreset removed: active profile is no longer user-facing (#127)
   onSelectDefaultPreset: (presetId: string) => void
-  onChangeActivePresetDraft: (
+  onChangeDefaultPresetDraft: (
     patch: Partial<Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>>
   ) => void
   onRunSelectedPreset: () => void
@@ -244,10 +243,10 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                 onSelectDefaultPreset={(presetId: string) => {
                   callbacks.onSelectDefaultPreset(presetId)
                 }}
-                onChangeActivePresetDraft={(
+                onChangeDefaultPresetDraft={(
                   patch: Partial<Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>>
                 ) => {
-                  callbacks.onChangeActivePresetDraft(patch)
+                  callbacks.onChangeDefaultPresetDraft(patch)
                 }}
                 onRunSelectedPreset={() => {
                   callbacks.onRunSelectedPreset()

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -229,29 +229,29 @@ describe('renderer app', () => {
     expect(harness.setSettingsSpy.mock.calls.length).toBe(beforeTextareaEnterCalls)
   })
 
-  it('syncs hidden active preset to the default preset on boot so the editor matches the visible selector', async () => {
+  it('uses default preset id for editor selection even when lastPickedPresetId differs', async () => {
     const mountPoint = document.createElement('div')
     mountPoint.id = 'app'
     document.body.append(mountPoint)
 
     const harness = buildIpcHarness()
     const divergentSettings = structuredClone(DEFAULT_SETTINGS)
-    divergentSettings.transformation.activePresetId = 'active-id'
     divergentSettings.transformation.defaultPresetId = 'default-id'
+    divergentSettings.transformation.lastPickedPresetId = 'other-id'
     divergentSettings.transformation.presets = [
-      {
-        ...divergentSettings.transformation.presets[0],
-        id: 'active-id',
-        name: 'Active Profile',
-        systemPrompt: 'active system',
-        userPrompt: 'active {{text}}'
-      },
       {
         ...divergentSettings.transformation.presets[0],
         id: 'default-id',
         name: 'Default Profile',
         systemPrompt: 'default system',
         userPrompt: 'default {{text}}'
+      },
+      {
+        ...divergentSettings.transformation.presets[0],
+        id: 'other-id',
+        name: 'Other Profile',
+        systemPrompt: 'other system',
+        userPrompt: 'other {{text}}'
       }
     ]
     harness.api.getSettings = async () => structuredClone(divergentSettings)
@@ -278,12 +278,12 @@ describe('renderer app', () => {
 
     const harness = buildIpcHarness()
     const invalidSettings = structuredClone(DEFAULT_SETTINGS)
-    invalidSettings.transformation.activePresetId = 'active-id'
     invalidSettings.transformation.defaultPresetId = 'missing-default-id'
+    invalidSettings.transformation.lastPickedPresetId = 'missing-last-picked-id'
     invalidSettings.transformation.presets = [
       {
         ...invalidSettings.transformation.presets[0],
-        id: 'active-id',
+        id: 'fallback-id',
         name: 'Fallback Profile',
         systemPrompt: 'fallback system',
         userPrompt: 'fallback {{text}}'
@@ -309,7 +309,7 @@ describe('renderer app', () => {
     const defaultSelect = mountPoint.querySelector<HTMLSelectElement>('#settings-transform-default-preset')
     const presetNameInput = mountPoint.querySelector<HTMLInputElement>('#settings-transform-preset-name')
 
-    expect(defaultSelect?.value).toBe('active-id')
+    expect(defaultSelect?.value).toBe('fallback-id')
     expect(presetNameInput?.value).toBe('Fallback Profile')
   })
 })

--- a/src/renderer/settings-endpoint-overrides-react.tsx
+++ b/src/renderer/settings-endpoint-overrides-react.tsx
@@ -28,20 +28,20 @@ export const SettingsEndpointOverridesReact = ({
   onResetTranscriptionBaseUrlDraft,
   onResetTransformationBaseUrlDraft
 }: SettingsEndpointOverridesReactProps) => {
-  const activePreset =
-    settings.transformation.presets.find((preset) => preset.id === settings.transformation.activePresetId) ??
+  const defaultPreset =
+    settings.transformation.presets.find((preset) => preset.id === settings.transformation.defaultPresetId) ??
     settings.transformation.presets[0]
   const [transcriptionBaseUrl, setTranscriptionBaseUrl] = useState(
     resolveSttBaseUrlOverride(settings, settings.transcription.provider) ?? ''
   )
   const [transformationBaseUrl, setTransformationBaseUrl] = useState(
-    resolveLlmBaseUrlOverride(settings, activePreset?.provider ?? 'google') ?? ''
+    resolveLlmBaseUrlOverride(settings, defaultPreset?.provider ?? 'google') ?? ''
   )
 
   useEffect(() => {
     setTranscriptionBaseUrl(resolveSttBaseUrlOverride(settings, settings.transcription.provider) ?? '')
-    setTransformationBaseUrl(resolveLlmBaseUrlOverride(settings, activePreset?.provider ?? 'google') ?? '')
-  }, [settings, settings.transcription.provider, activePreset?.provider])
+    setTransformationBaseUrl(resolveLlmBaseUrlOverride(settings, defaultPreset?.provider ?? 'google') ?? '')
+  }, [settings, settings.transcription.provider, defaultPreset?.provider])
 
   return (
     <div>

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -34,7 +34,7 @@ describe('SettingsTransformationReact', () => {
 
     const onToggleAutoRun = vi.fn()
     const onSelectDefaultPreset = vi.fn()
-    const onChangeActivePresetDraft = vi.fn()
+    const onChangeDefaultPresetDraft = vi.fn()
     const onRunSelectedPreset = vi.fn()
     const onAddPreset = vi.fn()
     const onRemovePreset = vi.fn()
@@ -48,7 +48,7 @@ describe('SettingsTransformationReact', () => {
           userPromptError=""
           onToggleAutoRun={onToggleAutoRun}
           onSelectDefaultPreset={onSelectDefaultPreset}
-          onChangeActivePresetDraft={onChangeActivePresetDraft}
+          onChangeDefaultPresetDraft={onChangeDefaultPresetDraft}
           onRunSelectedPreset={onRunSelectedPreset}
           onAddPreset={onAddPreset}
           onRemovePreset={onRemovePreset}
@@ -104,7 +104,7 @@ describe('SettingsTransformationReact', () => {
       valueSetter?.call(presetNameInput, 'Edited preset')
       presetNameInput?.dispatchEvent(new Event('input', { bubbles: true }))
     })
-    expect(onChangeActivePresetDraft).toHaveBeenCalledWith({ name: 'Edited preset' })
+    expect(onChangeDefaultPresetDraft).toHaveBeenCalledWith({ name: 'Edited preset' })
   })
 
   it('updates preset validation message on rerendered props', async () => {
@@ -121,7 +121,7 @@ describe('SettingsTransformationReact', () => {
           userPromptError=""
           onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
-          onChangeActivePresetDraft={() => {}}
+          onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}
           onAddPreset={() => {}}
           onRemovePreset={() => {}}
@@ -140,7 +140,7 @@ describe('SettingsTransformationReact', () => {
           userPromptError="User prompt must include {{text}}."
           onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
-          onChangeActivePresetDraft={() => {}}
+          onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}
           onAddPreset={() => {}}
           onRemovePreset={() => {}}
@@ -157,15 +157,15 @@ describe('SettingsTransformationReact', () => {
     expect(host.querySelector('#settings-error-user-prompt')?.textContent).toContain('{{text}}')
   })
 
-  it('removes the displayed default profile even when hidden active/default ids diverge', async () => {
+  it('removes the displayed default profile even when lastPicked/default ids diverge', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
 
     const onRemovePreset = vi.fn()
     const settings = structuredClone(DEFAULT_SETTINGS)
-    settings.transformation.activePresetId = 'active-id'
     settings.transformation.defaultPresetId = 'default-id'
+    settings.transformation.lastPickedPresetId = 'active-id'
     settings.transformation.presets = [
       { ...settings.transformation.presets[0], id: 'active-id', name: 'Active' },
       { ...settings.transformation.presets[0], id: 'default-id', name: 'Default' }
@@ -180,7 +180,7 @@ describe('SettingsTransformationReact', () => {
           userPromptError=""
           onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
-          onChangeActivePresetDraft={() => {}}
+          onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}
           onAddPreset={() => {}}
           onRemovePreset={onRemovePreset}

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -16,10 +16,8 @@ interface SettingsTransformationReactProps {
   systemPromptError: string
   userPromptError: string
   onToggleAutoRun: (checked: boolean) => void
-  // onSelectActivePreset removed: active profile is no longer user-facing (#127).
-  // Selecting the default profile also selects which profile to edit.
   onSelectDefaultPreset: (presetId: string) => void
-  onChangeActivePresetDraft: (
+  onChangeDefaultPresetDraft: (
     patch: Partial<Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>>
   ) => void
   onRunSelectedPreset: () => void
@@ -34,36 +32,34 @@ export const SettingsTransformationReact = ({
   userPromptError,
   onToggleAutoRun,
   onSelectDefaultPreset,
-  onChangeActivePresetDraft,
+  onChangeDefaultPresetDraft,
   onRunSelectedPreset,
   onAddPreset,
   onRemovePreset
 }: SettingsTransformationReactProps) => {
-  // Editor tracks the active preset, which is kept in sync with defaultPresetId (#127).
-  const activePreset =
-    settings.transformation.presets.find((preset) => preset.id === settings.transformation.activePresetId) ??
+  const defaultPreset =
+    settings.transformation.presets.find((preset) => preset.id === settings.transformation.defaultPresetId) ??
     settings.transformation.presets[0]
 
   const [autoRun, setAutoRun] = useState(settings.transformation.autoRunDefaultTransform)
-  const [presetName, setPresetName] = useState(activePreset?.name ?? 'Default')
-  const [presetModel, setPresetModel] = useState(activePreset?.model ?? 'gemini-2.5-flash')
-  const [systemPrompt, setSystemPrompt] = useState(activePreset?.systemPrompt ?? '')
-  const [userPrompt, setUserPrompt] = useState(activePreset?.userPrompt ?? '')
+  const [presetName, setPresetName] = useState(defaultPreset?.name ?? 'Default')
+  const [presetModel, setPresetModel] = useState(defaultPreset?.model ?? 'gemini-2.5-flash')
+  const [systemPrompt, setSystemPrompt] = useState(defaultPreset?.systemPrompt ?? '')
+  const [userPrompt, setUserPrompt] = useState(defaultPreset?.userPrompt ?? '')
 
   useEffect(() => {
     setAutoRun(settings.transformation.autoRunDefaultTransform)
-    setPresetName(activePreset?.name ?? 'Default')
-    setPresetModel(activePreset?.model ?? 'gemini-2.5-flash')
-    setSystemPrompt(activePreset?.systemPrompt ?? '')
-    setUserPrompt(activePreset?.userPrompt ?? '')
+    setPresetName(defaultPreset?.name ?? 'Default')
+    setPresetModel(defaultPreset?.model ?? 'gemini-2.5-flash')
+    setSystemPrompt(defaultPreset?.systemPrompt ?? '')
+    setUserPrompt(defaultPreset?.userPrompt ?? '')
   }, [
     settings.transformation.autoRunDefaultTransform,
-    settings.transformation.activePresetId,
     settings.transformation.defaultPresetId,
-    activePreset?.name,
-    activePreset?.model,
-    activePreset?.systemPrompt,
-    activePreset?.userPrompt
+    defaultPreset?.name,
+    defaultPreset?.model,
+    defaultPreset?.systemPrompt,
+    defaultPreset?.userPrompt
   ])
 
   return (
@@ -119,7 +115,7 @@ export const SettingsTransformationReact = ({
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
             setPresetName(value)
-            onChangeActivePresetDraft({ name: value })
+            onChangeDefaultPresetDraft({ name: value })
           }}
         />
       </label>
@@ -132,7 +128,7 @@ export const SettingsTransformationReact = ({
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const value = event.target.value as Settings['transformation']['presets'][number]['model']
             setPresetModel(value)
-            onChangeActivePresetDraft({ model: value })
+            onChangeDefaultPresetDraft({ model: value })
           }}
         >
           <option value="gemini-2.5-flash">gemini-2.5-flash</option>
@@ -163,7 +159,7 @@ export const SettingsTransformationReact = ({
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
             const value = event.target.value
             setSystemPrompt(value)
-            onChangeActivePresetDraft({ systemPrompt: value })
+            onChangeDefaultPresetDraft({ systemPrompt: value })
           }}
         />
       </label>
@@ -177,7 +173,7 @@ export const SettingsTransformationReact = ({
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
             const value = event.target.value
             setUserPrompt(value)
-            onChangeActivePresetDraft({ userPrompt: value })
+            onChangeDefaultPresetDraft({ userPrompt: value })
           }}
         />
       </label>

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -134,18 +134,14 @@ export const SettingsSchema = v.object({
   }),
   transformation: v.pipe(
     v.object({
-      activePresetId: v.string(),
       defaultPresetId: v.string(),
+      lastPickedPresetId: v.nullable(v.string()),
       baseUrlOverrides: v.object({
         google: v.nullable(v.string())
       }),
       presets: v.pipe(v.array(TransformationPresetSchema), v.minLength(1)),
       autoRunDefaultTransform: v.boolean()
     }),
-    v.check((val) => {
-      const ids = new Set(val.presets.map((p) => p.id))
-      return ids.has(val.activePresetId)
-    }, 'Active transformation preset must reference an existing preset id'),
     v.check((val) => {
       const ids = new Set(val.presets.map((p) => p.id))
       return ids.has(val.defaultPresetId)
@@ -206,8 +202,8 @@ export const DEFAULT_SETTINGS: Settings = {
     networkRetries: 2
   },
   transformation: {
-    activePresetId: 'default',
     defaultPresetId: 'default',
+    lastPickedPresetId: null,
     baseUrlOverrides: {
       google: null
     },


### PR DESCRIPTION
## Goal
Close #167 by removing `activePresetId` from runtime settings/codepaths and making Pick-and-Run remember/focus the last picked profile.

## What Changed
- removed `transformation.activePresetId` from shared schema/defaults/runtime codepaths
- added `transformation.lastPickedPresetId: string | null`
- updated Pick-and-Run hotkey flow:
  - picker focus uses `lastPickedPresetId` (fallback: `defaultPresetId` -> first preset)
  - successful pick persists `lastPickedPresetId`
  - `defaultPresetId` remains unchanged by Pick-and-Run
  - duplicate pick-and-run triggers are ignored while picker selection is in-flight
- updated renderer settings editing paths to use `defaultPresetId` only
- updated settings migration to remove legacy `activePresetId` and initialize `lastPickedPresetId`
- updated decision/spec docs for the new semantics

## Tests
- `pnpm run typecheck`
- `pnpm vitest run src/main/services/hotkey-service.test.ts src/main/services/settings-service.test.ts src/main/services/profile-picker-service.test.ts src/main/core/command-router.test.ts src/renderer/settings-mutations.test.ts src/renderer/settings-transformation-react.test.tsx src/renderer/renderer-app.test.ts`

## Notes
- One ticket = one PR: this PR targets only #167.
