### PR TITLE
feat(home): simplify controls to toggle + conditional cancel (#168)

### DIFF
--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -87,7 +87,12 @@ test('shows Home operational cards and hides Session Activity panel by default',
   await page.locator('[data-route-tab="home"]').click()
 
   await expect(page.getByRole('heading', { name: 'Recording Controls' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Transform Shortcut' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Transform Shortcut' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Toggle' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Cancel' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Start' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Stop' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Transform' })).toHaveCount(0)
   await expect(page.locator('article').filter({ has: page.getByRole('heading', { name: 'Recording Controls' }) }).locator('[role="status"]')).toHaveText('Idle')
   await expect(page.getByRole('heading', { name: 'Processing History' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Session Activity' })).toHaveCount(0)
@@ -165,14 +170,14 @@ test('blocks start recording when STT API key is missing', async () => {
     await page.locator('[data-route-tab="home"]').click()
     await expect(page.getByText(`Recording is blocked because the ${providerLabel} API key is missing.`)).toBeVisible()
     await expect(page.getByText(`Open Settings > Provider API Keys and save a ${nextStepLabel} key.`)).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Start' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: 'Toggle' })).toBeDisabled()
   } finally {
     await app.close()
     fs.rmSync(profileRoot, { recursive: true, force: true })
   }
 })
 
-test('blocks composite transform when Google API key is missing', async () => {
+test('does not expose Home transform control when Google API key is missing', async () => {
   const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'speech-to-text-e2e-'))
   const xdgConfigHome = path.join(profileRoot, 'xdg-config')
   const app = await launchElectronApp({
@@ -186,11 +191,10 @@ test('blocks composite transform when Google API key is missing', async () => {
     const page = await app.firstWindow()
     await page.waitForSelector('h1:has-text("Speech-to-Text v1")')
 
-    await page.locator('[data-route-tab="settings"]').click()
     await page.locator('[data-route-tab="home"]').click()
-    await expect(page.getByText('Transformation is blocked because the Google API key is missing.')).toBeVisible()
-    await expect(page.getByText('Open Settings > Provider API Keys and save a Google key.')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Transform' })).toBeDisabled()
+    await expect(page.getByRole('heading', { name: 'Transform Shortcut' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Transform' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Toggle' })).toBeVisible()
   } finally {
     await app.close()
     fs.rmSync(profileRoot, { recursive: true, force: true })
@@ -450,7 +454,7 @@ test('runs live Gemini transformation using configured Google API key @live-prov
   }, sourceText)
 
   await page.locator('[data-route-tab="home"]').click()
-  await expect(page.getByRole('button', { name: 'Transform' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Transform' })).toHaveCount(0)
 
   const runtimePage = page.isClosed() ? await electronApp.firstWindow() : page
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -139,7 +139,7 @@ To support future streaming mode without breaking v1 behavior, the architecture 
 
 ### 4.1 Recording commands
 
-The system **MUST** support these global and UI-triggerable recording commands:
+The system **MUST** support these recording commands:
 - `startRecording`
 - `stopRecording`
 - `toggleRecording`
@@ -150,6 +150,13 @@ Behavior:
 - `stopRecording` **MUST** finalize the current capture into exactly one job.
 - `cancelRecording` **MUST** stop active capture and **MUST NOT** enqueue a processing job.
 - `toggleRecording` **MUST** start if idle and stop if recording.
+
+### 4.1.1 Home control surface
+
+- Home **MUST** expose `toggleRecording` as the primary recording control.
+- Home **MUST** show `cancelRecording` only while recording is active.
+- Home **MUST NOT** render separate Start/Stop recording buttons.
+- Home **MUST NOT** render a Run Transformation button.
 
 ### 4.2 Global shortcuts
 

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -20,6 +20,13 @@ Personal-use scope: prioritize practical local behavior and fast iteration.
 - Treat transformation as optional, with transcription-only flow always supported.
 - Preserve reliability for rapid back-to-back recordings (no dropped completed result).
 
+## Home Surface Controls (v1)
+
+- Home always shows `Toggle` for recording start/stop.
+- Home shows `Cancel` only while recording is active.
+- Home does not show separate Start/Stop buttons.
+- Home does not show a Run Transformation button.
+
 Global output rule used in all flows:
 - If `copy_*_to_clipboard` is enabled, text is copied to clipboard.
 - If `paste_*_at_cursor` is enabled, text is pasted at cursor when ready.

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -58,7 +58,6 @@ export interface AppShellState {
   apiKeySaveStatus: Record<ApiKeyProvider, string>
   apiKeyTestStatus: Record<ApiKeyProvider, string>
   apiKeysSaveMessage: string
-  lastTransformSummary: string
   pendingActionId: string | null
   hasCommandError: boolean
   audioInputSources: AudioInputSource[]
@@ -73,7 +72,6 @@ export interface AppShellState {
 export interface AppShellCallbacks {
   onNavigate: (page: 'home' | 'settings') => void
   onRunRecordingCommand: (command: RecordingCommand) => void
-  onRunCompositeTransform: () => void
   onOpenSettings: () => void
   onTestApiKey: (provider: ApiKeyProvider, candidateValue: string) => Promise<void>
   onSaveApiKey: (provider: ApiKeyProvider, candidateValue: string) => Promise<void>
@@ -166,15 +164,11 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
         <HomeReact
           settings={uiState.settings}
           apiKeyStatus={uiState.apiKeyStatus}
-          lastTransformSummary={uiState.lastTransformSummary}
           pendingActionId={uiState.pendingActionId}
           hasCommandError={uiState.hasCommandError}
           isRecording={callbacks.isNativeRecording()}
           onRunRecordingCommand={(command: RecordingCommand) => {
             callbacks.onRunRecordingCommand(command)
-          }}
-          onRunCompositeTransform={() => {
-            callbacks.onRunCompositeTransform()
           }}
           onOpenSettings={() => {
             callbacks.onOpenSettings()

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -175,9 +175,9 @@ describe('renderer app', () => {
     await waitForBoot()
 
     harness.setApiKeyStatus({
-      groq: true,
+      groq: false,
       elevenlabs: true,
-      google: false
+      google: true
     })
 
     const settingsTab = mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')
@@ -187,10 +187,10 @@ describe('renderer app', () => {
 
     await waitForCondition(
       'API key blocked message after home tab navigation',
-      () => !!mountPoint.textContent?.includes('Transformation is blocked because the Google API key is missing.')
+      () => !!mountPoint.textContent?.includes('Recording is blocked because the Groq API key is missing.')
     )
 
-    expect(mountPoint.textContent).toContain('Transformation is blocked because the Google API key is missing.')
+    expect(mountPoint.textContent).toContain('Recording is blocked because the Groq API key is missing.')
   })
 
   it('saves settings on Enter from inputs but not textarea via React-owned keydown handling', async () => {

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -71,7 +71,6 @@ const state = {
   toasts: [] as ToastItem[],
   toastCounter: 0,
   toastTimers: new Map<number, ReturnType<typeof setTimeout>>(),
-  lastTransformSummary: 'No transformation run yet.',
   settingsSaveMessage: '',
   audioInputSources: [] as AudioInputSource[],
   audioSourceHint: '',
@@ -276,12 +275,10 @@ const refreshApiKeyStatusFromMainWithRetry = async (): Promise<void> => {
 const applyCompositeResult = (result: CompositeTransformResult): void => {
   if (result.status === 'ok') {
     state.hasCommandError = false
-    state.lastTransformSummary = `Last transform: success (${new Date().toLocaleTimeString()})`
     addActivity(`Transform complete: ${result.message}`, 'success')
     addToast(`Transform complete: ${result.message}`, 'success')
   } else {
     state.hasCommandError = true
-    state.lastTransformSummary = `Last transform: failed (${new Date().toLocaleTimeString()}) - ${result.message}`
     addActivity(`Transform error: ${result.message}`, 'error')
     addToast(`Transform error: ${result.message}`, 'error')
   }
@@ -405,9 +402,6 @@ const rerenderShellFromState = (): void => {
     onNavigate: navigateToPage,
     onRunRecordingCommand: (command) => {
       void runRecordingCommandAction(command)
-    },
-    onRunCompositeTransform: () => {
-      void runCompositeTransformAction()
     },
     onOpenSettings: openSettingsRoute,
     onTestApiKey: (provider, candidateValue) => mutations.runApiKeyConnectionTest(provider, candidateValue),
@@ -570,7 +564,6 @@ export const stopRendererAppForTests = (): void => {
   state.activityCounter = 0
   state.toasts = []
   state.toastCounter = 0
-  state.lastTransformSummary = 'No transformation run yet.'
   state.settingsSaveMessage = ''
   state.audioInputSources = []
   state.audioSourceHint = ''


### PR DESCRIPTION
## Summary
- remove Home `Start` / `Stop` recording controls
- remove Home `Run Transformation` control/card
- keep Home `Toggle` control always visible
- show Home `Cancel` only while recording is active
- keep transformation execution paths outside Home unchanged (shortcuts + Settings run-selected)

Closes #168.

## Changes
- `src/renderer/home-react.tsx`
  - reduced Home controls to `Toggle` (+ conditional `Cancel` when `isRecording`)
  - removed Home transform shortcut panel/button
  - kept recording blocked deep-link and status badge behavior
- `src/renderer/app-shell-react.tsx`
  - removed Home-only `onRunCompositeTransform` and `lastTransformSummary` plumbing
- `src/renderer/renderer-app.tsx`
  - removed unused `lastTransformSummary` state/writes
  - removed unused Home composite transform callback wiring
  - retained `runCompositeTransformAction` for Settings run-selected flow
- `src/renderer/home-react.test.tsx`
  - added coverage for: toggle-only idle UI, conditional cancel visibility, blocked-toggle + enabled-cancel behavior
- `src/renderer/renderer-app.test.ts`
  - updated Home refresh assertion to recording-blocked messaging
- `e2e/electron-ui.e2e.ts`
  - updated Home assertions for removed controls and toggle/cancel behavior
- `specs/spec.md`, `specs/user-flow.md`
  - documented Home control surface contract

## Gate Check
- [x] Home does not render Start/Stop buttons
- [x] Home does not render Run Transformation button
- [x] Home keeps Toggle available
- [x] Home shows Cancel only during active recording
- [x] tests/docs updated for this UI behavior change

## Validation
- `pnpm run typecheck`
- `pnpm vitest run src/renderer/home-react.test.tsx src/renderer/renderer-app.test.ts`
- `pnpm exec playwright test e2e/electron-ui.e2e.ts --list` (suite parsing/registration check)
- `pnpm run build`

## Notes
- Targeted Playwright execution in this environment fails before assertions because Electron cannot launch without X server/`$DISPLAY`.
