### PR TITLE
fix(selection): stabilize run-transform-on-selection capture path (#163)

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -186,6 +186,8 @@ Transformation shortcut semantics:
 - `changeDefaultTransformation` **MUST** set `transformationProfiles.defaultProfileId` to a user-selected profile id without executing transformation.
 - `runTransformationOnSelection` **MUST** require selection text; if no selection text exists, it **MUST** fail with actionable user feedback.
 - `runTransformationOnSelection` **MUST** execute using `transformationProfiles.defaultProfileId` when set; if `defaultProfileId` is `null`, it **MUST NOT** invoke LLM transformation and **MUST** return a non-error skipped outcome.
+- `runTransformationOnSelection` **MUST** use the "No text selected. Highlight text in the target app and try again." message only when selection text is empty/unreadable.
+- `runTransformationOnSelection` **MUST** return a distinct actionable error when the selection-read operation itself fails (for example permissions/focus/runtime failures).
 - when a transformation shortcut executes during active recording, execution **MUST** start immediately in parallel and **MUST NOT** wait for current recording job completion.
 - each shortcut execution request **MUST** bind a profile snapshot at enqueue time and **MUST NOT** be affected by later `defaultProfileId` changes.
 - if multiple transformation shortcuts fire concurrently, each request **MUST** retain its own bound profile snapshot and source text snapshot.

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -175,9 +175,10 @@ Steps:
 1. User presses the `runTransformOnSelection` shortcut (spec semantics: run-transformation-on-selection).
 2. App reads selected text via macOS Cmd+C selection flow.
 3. If no text is selected, app shows actionable feedback: "No text selected. Highlight text in the target app and try again."
-4. If selected text exists, app enqueues transformation with `textSource = selection` using current active profile.
-5. After processing, app applies transformed output behavior based on current output toggles.
-6. App plays transformation completion sound (success or failure tone).
+4. If selection read fails for runtime reasons (for example permissions/focus failure), app shows a distinct actionable read-failure message instead of the no-selection message.
+5. If selected text exists, app enqueues transformation with `textSource = selection` using current active profile.
+6. After processing, app applies transformed output behavior based on current output toggles.
+7. App plays transformation completion sound (success or failure tone).
 
 ---
 

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from 'node:crypto'
 import type { AudioInputSource, CompositeTransformResult, RecordingCommand, RecordingCommandDispatch } from '../../shared/ipc'
 import { resolveLlmBaseUrlOverride, resolveSttBaseUrlOverride, type Settings, type TransformationPreset } from '../../shared/domain'
+import { SELECTION_EMPTY_MESSAGE } from './transformation-error-messages'
 import type { CaptureResult } from '../services/capture-types'
 import type { RecordingOrchestrator } from '../orchestrators/recording-orchestrator'
 import type { CaptureQueue } from '../queues/capture-queue'
@@ -141,7 +142,7 @@ export class CommandRouter {
       preset,
       textSource: 'selection',
       sourceText: selectionText,
-      emptyTextMessage: 'No text selected. Highlight text in the target app and try again.'
+      emptyTextMessage: SELECTION_EMPTY_MESSAGE
     })
   }
 

--- a/src/main/core/transformation-error-messages.ts
+++ b/src/main/core/transformation-error-messages.ts
@@ -1,0 +1,10 @@
+/**
+ * Where: src/main/core/transformation-error-messages.ts
+ * What: Shared user-facing error message constants for transformation shortcut flows.
+ * Why: Keep wording consistent between hotkey pre-validation and router defense-in-depth checks.
+ */
+
+export const SELECTION_EMPTY_MESSAGE = 'No text selected. Highlight text in the target app and try again.'
+
+export const SELECTION_READ_FAILED_MESSAGE =
+  'Failed to read selected text. Verify Accessibility permission and keep the target app focused, then try again.'


### PR DESCRIPTION
## Summary
Fixes `runTransformOnSelection` false "No text selected" failures by hardening selection capture timing and serializing clipboard-probe reads.

Closes #163.

## Root Cause
`SelectionClient` used a narrow capture window (`80ms`) and no pre-copy settle delay, so shortcut-triggered Cmd+C clipboard updates could be missed in real app timing. That produced false empty-selection errors.

## Changes
- `src/main/infrastructure/selection-client.ts`
  - Added configurable pre-copy settle delay before Cmd+C (`copySettleDelayMs`, default `80ms`) to reduce modifier overlap from shortcut keypresses.
  - Increased clipboard-change poll timeout to `220ms` for better real-world capture reliability.
- `src/main/services/hotkey-service.ts`
  - Added selection-read in-flight guard to serialize `runTransformOnSelection` and avoid concurrent clipboard-probe races.
  - Added explicit read-failure feedback path (`Failed to read selected text...`) distinct from no-selection feedback.
- `src/main/core/transformation-error-messages.ts` (new)
  - Centralized shared selection error message constants.
- `src/main/core/command-router.ts`
  - Reused shared no-selection message constant for router defense-in-depth path.
- Tests
  - `src/main/infrastructure/selection-client.test.ts`
    - Added delayed clipboard-update regression test.
    - Switched delay test to fake timers to avoid wall-clock flake.
  - `src/main/services/hotkey-service.test.ts`
    - Added read-failure feedback test.
    - Added duplicate-trigger serialization test for selection read path.
    - Added router-failure forwarding test for shortcut error handling.
- Docs/spec
  - `specs/spec.md`
  - `specs/user-flow.md`
  - Clarified no-selection vs selection-read-failure behavior expectations.

## Validation
- `pnpm run typecheck`
- `pnpm vitest run src/main/infrastructure/selection-client.test.ts src/main/services/hotkey-service.test.ts src/main/core/command-router.test.ts`

## Review Notes
- Claude sub-agent review was run and findings were applied.
- Codex CLI review was attempted but blocked in that runtime by sandbox namespace restrictions (`bwrap` userns error).
