### PR TITLE
feat(sty-02): app shell re-architecture and tab/component stubs

### DIFF
--- a/src/renderer/activity-feed-react.tsx
+++ b/src/renderer/activity-feed-react.tsx
@@ -1,0 +1,39 @@
+/*
+ * Where: src/renderer/activity-feed-react.tsx
+ * What: Activity feed tab React component — placeholder for STY-04.
+ * Why: STY-02 requires this component slot to exist so the tabbed workspace can mount;
+ *      full card/status/transcript implementation lands in STY-04.
+ */
+
+import { Loader2 } from 'lucide-react'
+import type { ActivityItem } from './activity-feed'
+
+interface ActivityFeedReactProps {
+  activity: ActivityItem[]
+}
+
+export const ActivityFeedReact = ({ activity }: ActivityFeedReactProps) => {
+  if (activity.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground p-8">
+        <Loader2 className="size-8 opacity-20" />
+        <p className="text-xs text-center">No activity yet.</p>
+        <p className="text-[11px] text-center">Recordings will appear here after transcription.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-y-auto p-4 gap-2">
+      {activity.map((item) => (
+        <div
+          key={item.id}
+          className="rounded-lg border bg-card p-3 text-xs text-muted-foreground"
+        >
+          <span className="text-[10px] font-mono mr-2 text-muted-foreground/60">{item.createdAt}</span>
+          {item.message}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Where: src/renderer/app-shell-react.test.tsx
+ * What: Layout and tab-routing tests for the new STY-02 shell architecture.
+ * Why: Assert h-screen structure, w-[320px] left panel, persistent header/footer,
+ *      and tab state model without relying on geometry (deferred to e2e in STY-09).
+ */
+
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS } from '../shared/domain'
+import type { ApiKeyStatusSnapshot } from '../shared/ipc'
+import { AppShell, type AppShellCallbacks, type AppShellState, type AppTab } from './app-shell-react'
+
+const flush = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+let root: Root | null = null
+
+afterEach(() => {
+  root?.unmount()
+  root = null
+  document.body.innerHTML = ''
+})
+
+const readyStatus: ApiKeyStatusSnapshot = { groq: true, elevenlabs: true, google: true }
+
+// Minimal valid state for AppShell rendering
+const buildState = (overrides: Partial<AppShellState> = {}): AppShellState => ({
+  activeTab: 'activity',
+  ping: 'pong',
+  settings: DEFAULT_SETTINGS,
+  apiKeyStatus: readyStatus,
+  apiKeySaveStatus: { groq: '', elevenlabs: '', google: '' },
+  apiKeyTestStatus: { groq: '', elevenlabs: '', google: '' },
+  apiKeysSaveMessage: '',
+  pendingActionId: null,
+  hasCommandError: false,
+  audioInputSources: [],
+  audioSourceHint: '',
+  settingsValidationErrors: {},
+  settingsSaveMessage: '',
+  toasts: [],
+  activity: [],
+  ...overrides
+})
+
+// Minimal no-op callbacks
+const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCallbacks => ({
+  onNavigate: vi.fn(),
+  onRunRecordingCommand: vi.fn(),
+  onOpenSettings: vi.fn(),
+  onTestApiKey: vi.fn().mockResolvedValue(undefined),
+  onSaveApiKey: vi.fn().mockResolvedValue(undefined),
+  onSaveApiKeys: vi.fn().mockResolvedValue(undefined),
+  onRefreshAudioSources: vi.fn().mockResolvedValue(undefined),
+  onSelectRecordingMethod: vi.fn(),
+  onSelectRecordingSampleRate: vi.fn(),
+  onSelectRecordingDevice: vi.fn(),
+  onSelectTranscriptionProvider: vi.fn(),
+  onSelectTranscriptionModel: vi.fn(),
+  onToggleAutoRun: vi.fn(),
+  onSelectDefaultPreset: vi.fn(),
+  onChangeDefaultPresetDraft: vi.fn(),
+  onRunSelectedPreset: vi.fn(),
+  onAddPreset: vi.fn(),
+  onRemovePreset: vi.fn(),
+  onChangeTranscriptionBaseUrlDraft: vi.fn(),
+  onChangeTransformationBaseUrlDraft: vi.fn(),
+  onResetTranscriptionBaseUrlDraft: vi.fn(),
+  onResetTransformationBaseUrlDraft: vi.fn(),
+  onChangeShortcutDraft: vi.fn(),
+  onChangeOutputSelection: vi.fn(),
+  onRestoreDefaults: vi.fn().mockResolvedValue(undefined),
+  onSave: vi.fn().mockResolvedValue(undefined),
+  onDismissToast: vi.fn(),
+  isNativeRecording: vi.fn().mockReturnValue(false),
+  handleSettingsEnterSaveKeydown: vi.fn(),
+  ...overrides
+})
+
+describe('AppShell layout (STY-02)', () => {
+  it('renders root shell with h-screen class — fixed height layout', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
+    await flush()
+
+    // Root shell must use h-screen for fixed viewport height per spec section 5.1
+    const shell = host.firstElementChild
+    expect(shell?.classList.contains('h-screen')).toBe(true)
+  })
+
+  it('renders left panel with w-[320px] class — fixed recording panel width', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
+    await flush()
+
+    // Left panel must be fixed width per spec section 5.2
+    const leftPanel = host.querySelector('aside')
+    expect(leftPanel).not.toBeNull()
+    expect(leftPanel?.className).toContain('w-[320px]')
+  })
+
+  it('renders persistent header and footer — always visible per spec section 5.5', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
+    await flush()
+
+    expect(host.querySelector('header')).not.toBeNull()
+    expect(host.querySelector('footer')).not.toBeNull()
+  })
+
+  it('renders three tab buttons — activity, profiles, settings', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
+    await flush()
+
+    const tabs = ['activity', 'profiles', 'settings'] satisfies AppTab[]
+    for (const tab of tabs) {
+      expect(host.querySelector(`[data-route-tab="${tab}"]`)).not.toBeNull()
+    }
+  })
+
+  it('calls onNavigate with correct tab when tab button is clicked', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const onNavigate = vi.fn()
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks({ onNavigate })} />)
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')?.click()
+    expect(onNavigate).toHaveBeenCalledWith('settings')
+
+    host.querySelector<HTMLButtonElement>('[data-route-tab="profiles"]')?.click()
+    expect(onNavigate).toHaveBeenCalledWith('profiles')
+  })
+
+  it('waveform strip has 32 bars in the left panel', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
+    await flush()
+
+    // The waveform strip renders 32 bars per spec section 6.2
+    const bars = host.querySelectorAll('aside .rounded-full')
+    expect(bars.length).toBe(32)
+  })
+
+  it('shows null settings error state when settings are unavailable', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ settings: null })} callbacks={buildCallbacks()} />)
+    await flush()
+
+    expect(host.textContent).toContain('UI failed to initialize')
+  })
+})

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -1,0 +1,22 @@
+/*
+ * Where: src/renderer/profiles-panel-react.tsx
+ * What: Profiles panel tab React component — placeholder for STY-05.
+ * Why: STY-02 requires this component slot to exist so the tabbed workspace can mount;
+ *      full card/inline-edit implementation lands in STY-05.
+ */
+
+import { Zap } from 'lucide-react'
+
+// Props will be expanded in STY-05 to include profile data and handlers.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ProfilesPanelReactProps {
+  // Intentionally empty for the STY-02 placeholder — expanded in STY-05.
+}
+
+export const ProfilesPanelReact = (_props: ProfilesPanelReactProps) => (
+  <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground p-8">
+    <Zap className="size-8 opacity-20" />
+    <p className="text-xs text-center">Profiles panel.</p>
+    <p className="text-[11px] text-center">Transformation profiles will appear here.</p>
+  </div>
+)

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -32,7 +32,7 @@ const BOOT_MAX_FLUSH_ATTEMPTS = 30
 const waitForBoot = async (): Promise<void> => {
   for (let attempt = 0; attempt < BOOT_MAX_FLUSH_ATTEMPTS; attempt += 1) {
     await flush()
-    if (document.querySelector('[data-route-tab="home"]')) {
+    if (document.querySelector('[data-route-tab="activity"]')) {
       return
     }
   }
@@ -138,7 +138,8 @@ describe('renderer app', () => {
     await waitForBoot()
 
     // Keep route-tab selectors as an explicit UI contract for navigation tests/e2e flows.
-    expect(mountPoint.querySelector('[data-route-tab="home"]')).not.toBeNull()
+    // New tab model: activity | profiles | settings (replaces home | settings).
+    expect(mountPoint.querySelector('[data-route-tab="activity"]')).not.toBeNull()
     expect(mountPoint.querySelector('[data-route-tab="settings"]')).not.toBeNull()
     expect(mountPoint.textContent).toContain('Speech-to-Text v1')
     expect(mountPoint.textContent).toContain('Recording Controls')
@@ -162,7 +163,7 @@ describe('renderer app', () => {
     expect(harness.onHotkeyErrorSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('refreshes API key status when navigating back to Home', async () => {
+  it('refreshes API key status when navigating to activity tab', async () => {
     const mountPoint = document.createElement('div')
     mountPoint.id = 'app'
     document.body.append(mountPoint)
@@ -181,9 +182,9 @@ describe('renderer app', () => {
     })
 
     const settingsTab = mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')
-    const homeTab = mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="home"]')
+    const activityTab = mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="activity"]')
     settingsTab?.click()
-    homeTab?.click()
+    activityTab?.click()
 
     await waitForCondition(
       'API key blocked message after home tab navigation',

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -1,52 +1,45 @@
 /*
-Where: src/renderer/shell-chrome-react.tsx
-What: React-rendered shell chrome (hero + top navigation).
-Why: Reduce legacy template rendering and keep navigation click ownership in React.
-     Migrated from .ts (createElement) to .tsx (JSX) as the proof-of-concept for the
-     project-wide TSX migration (see docs/decisions/tsx-migration.md).
-*/
+ * Where: src/renderer/shell-chrome-react.tsx
+ * What: Compact app header bar — logo, app name, recording state dot.
+ * Why: STY-02 re-architecture moves the tab rail into the right workspace panel;
+ *      the header is now a fixed visual anchor that shows global recording state.
+ *
+ * UX rationale:
+ *   • State dot in the header gives permanent visual feedback without occupying
+ *     the content area — the user always knows if recording is active.
+ *   • animate-pulse on the recording dot uses a subdued animation pattern (allowed
+ *     by spec section 7) rather than a distracting entrance animation.
+ */
 
-import type { CSSProperties } from 'react'
-import type { Settings } from '../shared/domain'
-
-type AppPage = 'home' | 'settings'
+import { AudioWaveform } from 'lucide-react'
+import { cn } from './lib/utils'
 
 interface ShellChromeReactProps {
-  ping: string
-  settings: Settings
-  currentPage: AppPage
-  onNavigate: (page: AppPage) => void
+  isRecording: boolean
 }
 
-export const ShellChromeReact = ({ settings, currentPage, onNavigate }: ShellChromeReactProps) => (
-  <>
-    <section className="hero card" data-stagger="" style={{ '--delay': '40ms' } as CSSProperties}>
-      <p className="eyebrow">Speech-to-Text Control Room</p>
-      <h1>Speech-to-Text v1</h1>
-      <div className="hero-meta">
-        <span className="chip">STT {settings.transcription.provider} / {settings.transcription.model}</span>
-        <span className="chip">Transform Auto-run {settings.transformation.autoRunDefaultTransform ? 'On' : 'Off'}</span>
+export const ShellChromeReact = ({ isRecording }: ShellChromeReactProps) => (
+  <header className="flex items-center justify-between border-b px-4 py-2 bg-card/50">
+    {/* Logo + App name */}
+    <div className="flex items-center gap-2">
+      <div className="size-6 rounded-md bg-primary/10 flex items-center justify-center">
+        <AudioWaveform className="size-3.5 text-primary" aria-hidden="true" />
       </div>
-    </section>
-    <nav className="top-nav card" aria-label="Primary">
-      <button
-        type="button"
-        className={`nav-tab${currentPage === 'home' ? ' is-active' : ''}`}
-        data-route-tab="home"
-        aria-pressed={currentPage === 'home' ? 'true' : 'false'}
-        onClick={() => { onNavigate('home') }}
-      >
-        Home
-      </button>
-      <button
-        type="button"
-        className={`nav-tab${currentPage === 'settings' ? ' is-active' : ''}`}
-        data-route-tab="settings"
-        aria-pressed={currentPage === 'settings' ? 'true' : 'false'}
-        onClick={() => { onNavigate('settings') }}
-      >
-        Settings
-      </button>
-    </nav>
-  </>
+      <span className="text-sm font-semibold tracking-tight">Speech-to-Text v1</span>
+    </div>
+
+    {/* Recording state dot: provides persistent global recording feedback per spec section 5.3 */}
+    <div className="flex items-center gap-1.5" aria-live="polite" aria-atomic="true">
+      <span
+        className={cn(
+          'size-2 rounded-full',
+          isRecording ? 'bg-recording animate-pulse' : 'bg-success'
+        )}
+        aria-hidden="true"
+      />
+      <span className="text-[10px] text-muted-foreground">
+        {isRecording ? 'Recording' : 'Ready'}
+      </span>
+    </div>
+  </header>
 )

--- a/src/renderer/status-bar-react.tsx
+++ b/src/renderer/status-bar-react.tsx
@@ -1,0 +1,40 @@
+/*
+ * Where: src/renderer/status-bar-react.tsx
+ * What: Status bar footer React component — placeholder for STY-07.
+ * Why: STY-02 requires a footer component to complete the shell architecture;
+ *      full metadata/connectivity implementation lands in STY-07.
+ */
+
+import { Cpu, Mic, Wifi } from 'lucide-react'
+import type { Settings } from '../shared/domain'
+
+interface StatusBarReactProps {
+  settings: Settings
+}
+
+export const StatusBarReact = ({ settings }: StatusBarReactProps) => (
+  <footer className="flex items-center justify-between border-t bg-card/50 px-4 py-1.5">
+    {/* Left cluster: STT provider/model + LLM provider + audio device */}
+    <div className="flex items-center gap-4 text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <Mic className="size-3" />
+        <span className="font-mono text-[10px]">
+          {settings.transcription.provider}/{settings.transcription.model}
+        </span>
+      </span>
+      <span className="flex items-center gap-1">
+        <Cpu className="size-3" />
+        <span className="font-mono text-[10px]">
+          {settings.transformation.autoRunDefaultTransform ? 'auto-transform on' : 'manual'}
+        </span>
+      </span>
+    </div>
+    {/* Right cluster: connectivity */}
+    <div className="flex items-center gap-3 text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <Wifi className="size-3 text-success" />
+        <span className="text-[10px]">Ready</span>
+      </span>
+    </div>
+  </footer>
+)


### PR DESCRIPTION
## Summary

- Replace home/settings two-page model with fixed left panel + three-tab workspace
- New UI-local tab model: `activity | profiles | settings` (IPC contracts unchanged)
- Implement spec-compliant shell layout: `flex h-screen flex-col`, fixed `w-[320px]` left panel, persistent `<header>` and `<footer>`
- Add flat underline tab rail (Activity/Profiles/Settings) with `data-route-tab` attributes per spec section 5.4
- `ShellChromeReact`: convert hero+nav to compact header with logo, app name, recording state dot
- `StatusBarReact`: placeholder footer with STT provider and connectivity display
- `ActivityFeedReact`: placeholder activity tab (full implementation STY-04)
- `ProfilesPanelReact`: placeholder profiles tab (full implementation STY-05)
- Static 32-bar waveform strip in left panel (animation in STY-03)
- Update `renderer-app.tsx`: `state.activeTab` replaces `state.currentPage`; API key refresh on activity tab nav

## Gates Validated

- ✅ `pnpm run build` passes
- ✅ `pnpm run test` passes — 423 tests
- ✅ 6 new layout tests in `app-shell-react.test.tsx`: h-screen, w-[320px], persistent header/footer, 3 tabs, waveform strip, null-settings error state
- ✅ Scope gate: shell/routing/layout and stubs only; no tab card details
- ✅ Feasibility gate: app startup and navigation remain functional
- ✅ Tab-state refactor does not alter data/service ownership or IPC contracts

## Rollback

```bash
git revert HEAD
pnpm run build && pnpm run test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)