### PR TITLE
feat(sty-06a): reorder Settings IA and section structure

### DIFF
--- a/docs/sty-06a-settings-ia-reorder.md
+++ b/docs/sty-06a-settings-ia-reorder.md
@@ -1,0 +1,38 @@
+<!--
+Where: docs/sty-06a-settings-ia-reorder.md
+What: STY-06a implementation notes for Settings information-architecture reorder.
+Why: Document shipped section order contract, validation scope, and rollback checks.
+-->
+
+# STY-06a Settings IA Reorder
+
+**Date**: 2026-02-27
+**Scope**: Settings tab section ordering and section header/separator structure only.
+
+## Implemented Behavior
+
+- Settings sections now render in this order:
+  1. Output
+  2. Speech-to-Text
+  3. LLM Transformation
+  4. Audio Input
+  5. Global Shortcuts
+- Section wrappers expose stable `data-settings-section` markers for deterministic order tests.
+- Section headers use the compact icon + title pattern (`flex items-center gap-2 mb-4`, `size-4 text-primary`, `text-sm font-semibold text-foreground`).
+- Visual separators are inserted between sections to enforce IA boundaries.
+- Control behavior/persistence callbacks remain unchanged; only render placement changed.
+
+## Validation
+
+- `src/renderer/app-shell-react.test.tsx`
+  - Adds/validates STY-06a section render order with `data-settings-section` markers.
+- `src/renderer/settings-recording-react.test.tsx`
+  - Verifies split rendering modes (`speech-to-text` vs `audio-input`) still expose expected controls/selectors.
+
+## Rollback
+
+1. Revert STY-06a commit(s).
+2. Run:
+   - `pnpm -s vitest run src/renderer/app-shell-react.test.tsx`
+   - `pnpm -s vitest run src/renderer/settings-recording-react.test.tsx`
+3. Confirm Settings tab still renders and save/validation flows continue to work.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -140,6 +140,26 @@ describe('AppShell layout (STY-02)', () => {
     }
   })
 
+  it('renders Settings IA sections in STY-06a order', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ activeTab: 'settings' })} callbacks={buildCallbacks()} />)
+    await flush()
+
+    const sectionOrder = Array.from(host.querySelectorAll('[data-settings-section]')).map((node) =>
+      node.getAttribute('data-settings-section')
+    )
+    expect(sectionOrder).toEqual([
+      'output',
+      'speech-to-text',
+      'llm-transformation',
+      'audio-input',
+      'global-shortcuts'
+    ])
+  })
+
   it('calls onNavigate with correct tab when tab button is clicked', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-recording-react.test.tsx
+++ b/src/renderer/settings-recording-react.test.tsx
@@ -119,4 +119,46 @@ describe('SettingsRecordingReact', () => {
     })
     expect(refreshButton?.disabled).toBe(false)
   })
+
+  it('can render speech-to-text and audio-input controls as separate sections', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <>
+          <SettingsRecordingReact
+            section="speech-to-text"
+            settings={DEFAULT_SETTINGS}
+            audioInputSources={[{ id: 'system_default', label: 'System Default Microphone' }]}
+            audioSourceHint="Detected 0 selectable microphone source(s)."
+            onRefreshAudioSources={vi.fn().mockResolvedValue(undefined)}
+            onSelectRecordingMethod={vi.fn()}
+            onSelectRecordingSampleRate={vi.fn()}
+            onSelectRecordingDevice={vi.fn()}
+            onSelectTranscriptionProvider={vi.fn()}
+            onSelectTranscriptionModel={vi.fn()}
+          />
+          <SettingsRecordingReact
+            section="audio-input"
+            settings={DEFAULT_SETTINGS}
+            audioInputSources={[{ id: 'system_default', label: 'System Default Microphone' }]}
+            audioSourceHint="Detected 0 selectable microphone source(s)."
+            onRefreshAudioSources={vi.fn().mockResolvedValue(undefined)}
+            onSelectRecordingMethod={vi.fn()}
+            onSelectRecordingSampleRate={vi.fn()}
+            onSelectRecordingDevice={vi.fn()}
+            onSelectTranscriptionProvider={vi.fn()}
+            onSelectTranscriptionModel={vi.fn()}
+          />
+        </>
+      )
+    })
+
+    expect(host.querySelectorAll('#settings-transcription-provider')).toHaveLength(1)
+    expect(host.querySelectorAll('#settings-recording-device')).toHaveLength(1)
+    expect(host.querySelectorAll('#settings-help-stt-language')).toHaveLength(1)
+    expect(host.querySelectorAll('#settings-audio-sources-message')).toHaveLength(1)
+  })
 })

--- a/src/renderer/settings-recording-react.tsx
+++ b/src/renderer/settings-recording-react.tsx
@@ -14,6 +14,7 @@ interface SettingsRecordingReactProps {
   settings: Settings
   audioInputSources: AudioInputSource[]
   audioSourceHint: string
+  section?: 'all' | 'speech-to-text' | 'audio-input'
   onRefreshAudioSources: () => Promise<void>
   onSelectRecordingMethod: (method: Settings['recording']['method']) => void
   onSelectRecordingSampleRate: (sampleRateHz: Settings['recording']['sampleRateHz']) => void
@@ -39,6 +40,7 @@ export const SettingsRecordingReact = ({
   settings,
   audioInputSources,
   audioSourceHint,
+  section = 'all',
   onRefreshAudioSources,
   onSelectRecordingMethod,
   onSelectRecordingSampleRate,
@@ -52,6 +54,9 @@ export const SettingsRecordingReact = ({
   const [selectedProvider, setSelectedProvider] = useState<Settings['transcription']['provider']>(settings.transcription.provider)
   const [selectedModel, setSelectedModel] = useState<Settings['transcription']['model']>(settings.transcription.model)
   const [refreshPending, setRefreshPending] = useState(false)
+  const renderSpeechToTextControls = section === 'all' || section === 'speech-to-text'
+  const renderAudioControls = section === 'all' || section === 'audio-input'
+  const showLegacyHeading = section === 'all'
 
   useEffect(() => {
     setSelectedRecordingMethod(settings.recording.method)
@@ -71,117 +76,132 @@ export const SettingsRecordingReact = ({
 
   return (
     <section className="settings-group">
-      <h3>Recording</h3>
-      <p className="muted">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
-      <p className="muted" id="settings-help-stt-language">
-        STT language defaults to auto-detect. Advanced override: set `transcription.outputLanguage` in the settings file to an ISO language code (for example `en` or `ja`).
-      </p>
-      <label className="text-row">
-        <span>Recording method</span>
-        <select
-          id="settings-recording-method"
-          value={selectedRecordingMethod}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            const method = event.target.value as Settings['recording']['method']
-            setSelectedRecordingMethod(method)
-            onSelectRecordingMethod(method)
-          }}
-        >
-          {recordingMethodOptions.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-        </select>
-      </label>
-      <label className="text-row">
-        <span>Sample rate</span>
-        <select
-          id="settings-recording-sample-rate"
-          value={String(selectedSampleRate)}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            const sampleRate = Number(event.target.value) as Settings['recording']['sampleRateHz']
-            setSelectedSampleRate(sampleRate)
-            onSelectRecordingSampleRate(sampleRate)
-          }}
-        >
-          {recordingSampleRateOptions.map((option) => (
-            <option key={String(option.value)} value={String(option.value)}>{option.label}</option>
-          ))}
-        </select>
-      </label>
-      <label className="text-row">
-        <span>Audio source</span>
-        <select
-          id="settings-recording-device"
-          value={selectedRecordingDevice}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            const deviceId = event.target.value
-            setSelectedRecordingDevice(deviceId)
-            onSelectRecordingDevice(deviceId)
-          }}
-        >
-          {audioInputSources.map((source) => (
-            <option key={source.id} value={source.id}>{source.label}</option>
-          ))}
-        </select>
-      </label>
-      <label className="text-row">
-        <span>STT provider</span>
-        <select
-          id="settings-transcription-provider"
-          value={selectedProvider}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            const provider = event.target.value as Settings['transcription']['provider']
-            const nextModel = STT_MODEL_ALLOWLIST[provider][0]
-            setSelectedProvider(provider)
-            setSelectedModel(nextModel)
-            onSelectTranscriptionProvider(provider)
-          }}
-        >
-          {sttProviderOptions.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-        </select>
-      </label>
-      <label className="text-row">
-        <span>STT model</span>
-        <select
-          id="settings-transcription-model"
-          value={selectedModel}
-          onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-            const model = event.target.value as Settings['transcription']['model']
-            setSelectedModel(model)
-            onSelectTranscriptionModel(model)
-          }}
-        >
-          {availableModels.map((model) => (
-            <option key={model} value={model}>{model}</option>
-          ))}
-        </select>
-      </label>
-      <div className="settings-actions">
-        <button
-          type="button"
-          id="settings-refresh-audio-sources"
-          disabled={refreshPending}
-          onClick={() => {
-            setRefreshPending(true)
-            void onRefreshAudioSources().finally(() => {
-              setRefreshPending(false)
-            })
-          }}
-        >
-          Refresh audio sources
-        </button>
-      </div>
-      <p className="muted" id="settings-audio-sources-message">{audioSourceHint}</p>
-      <a
-        className="inline-link"
-        href="https://github.com/massun-onibakuchi/speech-to-text-app/issues/8"
-        target="_blank"
-        rel="noreferrer"
-      >
-        View roadmap item
-      </a>
+      {showLegacyHeading && (
+        <>
+          <h3>Recording</h3>
+          <p className="muted">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
+        </>
+      )}
+      {renderSpeechToTextControls && (
+        <>
+          <p className="muted" id="settings-help-stt-language">
+            STT language defaults to auto-detect. Advanced override: set `transcription.outputLanguage` in the settings file to an ISO language code (for example `en` or `ja`).
+          </p>
+          <label className="text-row">
+            <span>STT provider</span>
+            <select
+              id="settings-transcription-provider"
+              value={selectedProvider}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const provider = event.target.value as Settings['transcription']['provider']
+                const nextModel = STT_MODEL_ALLOWLIST[provider][0]
+                setSelectedProvider(provider)
+                setSelectedModel(nextModel)
+                onSelectTranscriptionProvider(provider)
+              }}
+            >
+              {sttProviderOptions.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-row">
+            <span>STT model</span>
+            <select
+              id="settings-transcription-model"
+              value={selectedModel}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const model = event.target.value as Settings['transcription']['model']
+                setSelectedModel(model)
+                onSelectTranscriptionModel(model)
+              }}
+            >
+              {availableModels.map((model) => (
+                <option key={model} value={model}>{model}</option>
+              ))}
+            </select>
+          </label>
+        </>
+      )}
+      {renderAudioControls && (
+        <>
+          {!showLegacyHeading && (
+            <p className="muted">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
+          )}
+          <label className="text-row">
+            <span>Recording method</span>
+            <select
+              id="settings-recording-method"
+              value={selectedRecordingMethod}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const method = event.target.value as Settings['recording']['method']
+                setSelectedRecordingMethod(method)
+                onSelectRecordingMethod(method)
+              }}
+            >
+              {recordingMethodOptions.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-row">
+            <span>Sample rate</span>
+            <select
+              id="settings-recording-sample-rate"
+              value={String(selectedSampleRate)}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const sampleRate = Number(event.target.value) as Settings['recording']['sampleRateHz']
+                setSelectedSampleRate(sampleRate)
+                onSelectRecordingSampleRate(sampleRate)
+              }}
+            >
+              {recordingSampleRateOptions.map((option) => (
+                <option key={String(option.value)} value={String(option.value)}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-row">
+            <span>Audio source</span>
+            <select
+              id="settings-recording-device"
+              value={selectedRecordingDevice}
+              onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                const deviceId = event.target.value
+                setSelectedRecordingDevice(deviceId)
+                onSelectRecordingDevice(deviceId)
+              }}
+            >
+              {audioInputSources.map((source) => (
+                <option key={source.id} value={source.id}>{source.label}</option>
+              ))}
+            </select>
+          </label>
+          <div className="settings-actions">
+            <button
+              type="button"
+              id="settings-refresh-audio-sources"
+              disabled={refreshPending}
+              onClick={() => {
+                setRefreshPending(true)
+                void onRefreshAudioSources().finally(() => {
+                  setRefreshPending(false)
+                })
+              }}
+            >
+              Refresh audio sources
+            </button>
+          </div>
+          <p className="muted" id="settings-audio-sources-message">{audioSourceHint}</p>
+          <a
+            className="inline-link"
+            href="https://github.com/massun-onibakuchi/speech-to-text-app/issues/8"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View roadmap item
+          </a>
+        </>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
Implements STY-06a from `docs/style-update-execution-plan.md` by reordering Settings information architecture and adding section header/separator structure, without changing persistence semantics.

## Ticket Scope
- Plan ticket: **STY-06a [P1] Settings IA Reorder**
- Scope gate respected: IA ordering and headers only.

## Changes
- Reordered Settings tab sections in `AppShell` to:
  1. Output
  2. Speech-to-Text
  3. LLM Transformation
  4. Audio Input
  5. Global Shortcuts
- Added stable section markers for testability: `data-settings-section="..."`.
- Added section heading pattern (icon + compact typography) and separators between sections.
- Split `SettingsRecordingReact` rendering into section modes to preserve control behavior while enabling IA separation:
  - `section="speech-to-text"`
  - `section="audio-input"`
  - default `section="all"` (legacy complete section behavior preserved)
- Added STY-06a implementation doc:
  - `docs/sty-06a-settings-ia-reorder.md`

## Validation
- `pnpm -s exec tsc --noEmit`
- `pnpm -s vitest run src/renderer/app-shell-react.test.tsx src/renderer/settings-recording-react.test.tsx`
- `pnpm -s vitest run`

## Tests Added/Updated
- `src/renderer/app-shell-react.test.tsx`
  - asserts STY-06a render order via `data-settings-section`.
- `src/renderer/settings-recording-react.test.tsx`
  - verifies split rendering modes preserve expected control selectors.

## Rollback
1. Revert this PR commit.
2. Re-run:
   - `pnpm -s vitest run src/renderer/app-shell-react.test.tsx src/renderer/settings-recording-react.test.tsx`
   - `pnpm -s vitest run`
3. Verify Settings tab still renders and save/validation behavior is unchanged.
