### PR TITLE
feat(sty-06b): redesign Settings control patterns

### DIFF
--- a/docs/sty-06b-settings-control-redesign.md
+++ b/docs/sty-06b-settings-control-redesign.md
@@ -1,0 +1,35 @@
+<!--
+Where: docs/sty-06b-settings-control-redesign.md
+What: STY-06b implementation notes for settings control-pattern redesign.
+Why: Document output control cards, API key compact treatment, and shortcut <Kbd> contract.
+-->
+
+# STY-06b Settings Control-Pattern Redesign
+
+**Date**: 2026-02-27
+**Scope**: Settings controls visual/interaction patterns only (no persistence contract changes).
+
+## Implemented Behavior
+
+- Output source selection now uses custom exclusive radio cards (`data-output-source-card`).
+- Output destinations now use independent checkbox cards with right-aligned switch visuals (`data-output-destination-card`).
+- Warning appears when both destinations are disabled:
+  - `#settings-output-destinations-warning`
+- API key controls now use compact mono input treatment (`h-8 text-xs font-mono`) and icon eye-toggle buttons.
+- Shortcut contract rows now render segmented key combos with reusable `<Kbd>` tokens while preserving `.shortcut-combo` hooks.
+
+## Validation
+
+- `src/renderer/settings-output-react.test.tsx`
+  - verifies callback wiring and disabled-destination warning behavior.
+- `src/renderer/settings-api-keys-react.test.tsx`
+  - verifies visibility toggle, per-provider test/save callbacks, and form submission behavior.
+- `src/renderer/settings-shortcuts-react.test.tsx`
+  - verifies shortcut contract rendering and `<kbd>` tokenized combos.
+
+## Rollback
+
+1. Revert STY-06b commit(s).
+2. Run:
+   - `pnpm -s vitest run src/renderer/settings-output-react.test.tsx src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx`
+3. Confirm Settings callbacks and selector IDs remain unchanged.

--- a/src/renderer/kbd.tsx
+++ b/src/renderer/kbd.tsx
@@ -1,0 +1,24 @@
+/*
+ * Where: src/renderer/kbd.tsx
+ * What: Compact keyboard key token component for shortcut contract rendering.
+ * Why: STY-06b requires shortcut rows to render segmented combos with reusable <Kbd> visuals.
+ */
+
+import type { PropsWithChildren } from 'react'
+import { cn } from './lib/utils'
+
+interface KbdProps {
+  className?: string
+}
+
+export const Kbd = ({ className, children }: PropsWithChildren<KbdProps>) => (
+  <kbd
+    className={cn(
+      'inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-secondary px-1.5',
+      'text-[10px] font-mono text-foreground',
+      className
+    )}
+  >
+    {children}
+  </kbd>
+)

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -5,6 +5,7 @@ Why: Continue Settings migration to React while keeping API key behavior and sel
      Migrated from .ts (createElement) to .tsx (JSX) as part of the project-wide TSX migration.
 */
 
+import { Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
 import type { ChangeEvent, FormEvent } from 'react'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot } from '../shared/ipc'
@@ -79,50 +80,56 @@ export const SettingsApiKeysReact = ({
     >
       <section className="settings-group">
         <h3>Provider API Keys</h3>
-        <p className="muted">
+        <p className="text-xs text-muted-foreground">
           Save each provider key independently. Unsaved edits in other fields stay local until you save them.
         </p>
         {providers.map((provider) => {
           const inputId = `settings-api-key-${provider}`
           const visible = visibility[provider]
           return (
-            <div key={provider} className="settings-key-row">
-              <label className="text-row">
-                <span>
+            <div key={provider} className="settings-key-row mt-3 rounded-lg border border-border bg-card p-3">
+              <label className="block">
+                <span className="text-xs text-foreground">
                   {labelByProvider[provider]}
-                  {' '}
-                  <em className="field-hint">{statusText(apiKeyStatus[provider])}</em>
+                  {'  '}
+                  <em className="text-[10px] text-muted-foreground not-italic">{statusText(apiKeyStatus[provider])}</em>
                 </span>
-                <input
-                  id={inputId}
-                  type={visible ? 'text' : 'password'}
-                  autoComplete="off"
-                  placeholder={`Enter ${labelByProvider[provider]}`}
-                  value={values[provider]}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    setValues((current) => ({
-                      ...current,
-                      [provider]: event.target.value
-                    }))
-                  }}
-                />
+                <div className="mt-2 flex items-center gap-2">
+                  <input
+                    id={inputId}
+                    type={visible ? 'text' : 'password'}
+                    autoComplete="off"
+                    placeholder={`Enter ${labelByProvider[provider]}`}
+                    value={values[provider]}
+                    className="h-8 flex-1 rounded border border-input bg-input px-2 text-xs font-mono text-foreground"
+                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                      setValues((current) => ({
+                        ...current,
+                        [provider]: event.target.value
+                      }))
+                    }}
+                  />
+                  <button
+                    type="button"
+                    data-api-key-visibility-toggle={provider}
+                    className="rounded bg-secondary p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    aria-label={visible ? `Hide ${labelByProvider[provider]}` : `Show ${labelByProvider[provider]}`}
+                    onClick={() => {
+                      setVisibility((current) => ({
+                        ...current,
+                        [provider]: !current[provider]
+                      }))
+                    }}
+                  >
+                    {visible ? <EyeOff className="size-3.5" aria-hidden="true" /> : <Eye className="size-3.5" aria-hidden="true" />}
+                  </button>
+                </div>
               </label>
-              <div className="settings-actions settings-actions-inline">
-                <button
-                  type="button"
-                  data-api-key-visibility-toggle={provider}
-                  onClick={() => {
-                    setVisibility((current) => ({
-                      ...current,
-                      [provider]: !current[provider]
-                    }))
-                  }}
-                >
-                  {visible ? 'Hide' : 'Show'}
-                </button>
+              <div className="settings-actions settings-actions-inline mt-2">
                 <button
                   type="button"
                   data-api-key-test={provider}
+                  className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
                   disabled={pendingTestByProvider[provider] || pendingSaveByProvider[provider] || savePending}
                   onClick={() => {
                     setPendingTestByProvider((current) => ({
@@ -142,6 +149,7 @@ export const SettingsApiKeysReact = ({
                 <button
                   type="button"
                   data-api-key-save={provider}
+                  className="h-7 rounded bg-primary px-2 text-xs text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
                   disabled={pendingSaveByProvider[provider] || savePending}
                   onClick={() => {
                     setPendingSaveByProvider((current) => ({
@@ -159,10 +167,10 @@ export const SettingsApiKeysReact = ({
                   Save
                 </button>
               </div>
-              <p className="muted provider-status" id={`api-key-save-status-${provider}`} aria-live="polite">
+              <p className="text-[10px] text-muted-foreground" id={`api-key-save-status-${provider}`} aria-live="polite">
                 {apiKeySaveStatus[provider]}
               </p>
-              <p className="muted provider-status" id={`api-key-test-status-${provider}`} aria-live="polite">
+              <p className="text-[10px] text-muted-foreground" id={`api-key-test-status-${provider}`} aria-live="polite">
                 {apiKeyTestStatus[provider]}
               </p>
             </div>
@@ -170,9 +178,15 @@ export const SettingsApiKeysReact = ({
         })}
       </section>
       <div className="settings-actions">
-        <button type="submit" disabled={savePending || anyProviderSavePending}>Save API Keys</button>
+        <button
+          type="submit"
+          className="h-8 rounded bg-primary px-3 text-xs text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
+          disabled={savePending || anyProviderSavePending}
+        >
+          Save API Keys
+        </button>
       </div>
-      <p id="api-keys-save-message" className="muted" aria-live="polite">{saveMessage}</p>
+      <p id="api-keys-save-message" className="text-xs text-muted-foreground" aria-live="polite">{saveMessage}</p>
     </form>
   )
 }

--- a/src/renderer/settings-output-react.test.tsx
+++ b/src/renderer/settings-output-react.test.tsx
@@ -89,4 +89,42 @@ describe('SettingsOutputReact', () => {
     })
     expect(restoreButton?.disabled).toBe(false)
   })
+
+  it('shows destination warning when both output destinations are disabled', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const onChangeOutputSelection = vi.fn()
+    await act(async () => {
+      root?.render(
+        <SettingsOutputReact
+          settings={DEFAULT_SETTINGS}
+          onChangeOutputSelection={onChangeOutputSelection}
+          onRestoreDefaults={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    })
+
+    const copyOutput = host.querySelector<HTMLInputElement>('#settings-output-copy')
+    const pasteOutput = host.querySelector<HTMLInputElement>('#settings-output-paste')
+
+    if (copyOutput?.checked) {
+      await act(async () => {
+        copyOutput.click()
+      })
+    }
+    if (pasteOutput?.checked) {
+      await act(async () => {
+        pasteOutput.click()
+      })
+    }
+
+    expect(host.querySelector('#settings-output-destinations-warning')?.textContent).toContain('Both destinations are disabled')
+
+    const copyCard = host.querySelector('[data-output-destination-card="copy"]')
+    const pasteCard = host.querySelector('[data-output-destination-card="paste"]')
+    expect(copyCard?.className).toContain('border-border')
+    expect(pasteCard?.className).toContain('border-border')
+  })
 })

--- a/src/renderer/settings-output-react.tsx
+++ b/src/renderer/settings-output-react.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import type { OutputTextSource, Settings } from '../shared/domain'
 import { getSelectedOutputDestinations } from '../shared/output-selection'
+import { cn } from './lib/utils'
 
 interface SettingsOutputReactProps {
   settings: Settings
@@ -51,60 +52,150 @@ export const SettingsOutputReact = ({
 
   return (
     <section className="settings-group">
-      <h3>Output</h3>
-      <p className="muted">Choose which text version to output, then where to send it.</p>
-      <fieldset className="settings-subgroup">
-        <legend>Output text</legend>
-        <label className="toggle-row">
+      <p className="text-xs text-muted-foreground mb-3">Choose which text version to output, then where to send it.</p>
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-medium text-foreground mb-2">Output text</legend>
+        <label
+          className={cn(
+            'flex items-center justify-between rounded-lg border p-3 cursor-pointer transition-colors',
+            selectedTextSource === 'transcript'
+              ? 'border-primary/50 bg-primary/5'
+              : 'border-border bg-card hover:bg-accent'
+          )}
+          data-output-source-card="transcript"
+        >
           <input
             type="radio"
             name="settings-output-text-source"
             id="settings-output-text-transcript"
+            className="sr-only"
             checked={selectedTextSource === 'transcript'}
             onChange={() => {
               applySelection('transcript', { copyToClipboard: copyChecked, pasteAtCursor: pasteChecked })
             }}
           />
-          <span>Raw dictation</span>
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                'size-4 rounded-full border-2 flex items-center justify-center',
+                selectedTextSource === 'transcript' ? 'border-primary' : 'border-border'
+              )}
+            >
+              {selectedTextSource === 'transcript' && <span className="size-2 rounded-full bg-primary" />}
+            </span>
+            <span className="text-xs text-foreground">Raw dictation</span>
+          </div>
         </label>
-        <label className="toggle-row">
+        <label
+          className={cn(
+            'flex items-center justify-between rounded-lg border p-3 cursor-pointer transition-colors',
+            selectedTextSource === 'transformed'
+              ? 'border-primary/50 bg-primary/5'
+              : 'border-border bg-card hover:bg-accent'
+          )}
+          data-output-source-card="transformed"
+        >
           <input
             type="radio"
             name="settings-output-text-source"
             id="settings-output-text-transformed"
+            className="sr-only"
             checked={selectedTextSource === 'transformed'}
             onChange={() => {
               applySelection('transformed', { copyToClipboard: copyChecked, pasteAtCursor: pasteChecked })
             }}
           />
-          <span>Transformed text</span>
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                'size-4 rounded-full border-2 flex items-center justify-center',
+                selectedTextSource === 'transformed' ? 'border-primary' : 'border-border'
+              )}
+            >
+              {selectedTextSource === 'transformed' && <span className="size-2 rounded-full bg-primary" />}
+            </span>
+            <span className="text-xs text-foreground">Transformed text</span>
+          </div>
         </label>
       </fieldset>
-      <p className="muted">When transformed text is selected, raw dictation is treated as intermediate output.</p>
-      <label className="toggle-row">
+      <p className="text-[11px] text-muted-foreground mt-2">When transformed text is selected, raw dictation is treated as intermediate output.</p>
+      <label
+        className={cn(
+          'mt-3 flex items-center justify-between rounded-lg border p-3 cursor-pointer transition-colors',
+          copyChecked ? 'border-primary/50 bg-primary/5' : 'border-border bg-card hover:bg-accent'
+        )}
+        data-output-destination-card="copy"
+      >
         <input
           type="checkbox"
           id="settings-output-copy"
+          className="sr-only"
           checked={copyChecked}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const checked = event.target.checked
             applySelection(selectedTextSource, { copyToClipboard: checked, pasteAtCursor: pasteChecked })
           }}
         />
-        <span>Copy to clipboard</span>
+        <div className="flex flex-col">
+          <span className="text-xs text-foreground">Copy to clipboard</span>
+          <span className="text-[10px] text-muted-foreground">Keep output ready for paste</span>
+        </div>
+        <span
+          className={cn(
+            'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+            copyChecked ? 'bg-primary' : 'bg-secondary'
+          )}
+          aria-hidden="true"
+        >
+          <span
+            className={cn(
+              'inline-block size-4 transform rounded-full bg-primary-foreground transition-transform',
+              copyChecked ? 'translate-x-4' : 'translate-x-0.5'
+            )}
+          />
+        </span>
       </label>
-      <label className="toggle-row">
+      <label
+        className={cn(
+          'mt-2 flex items-center justify-between rounded-lg border p-3 cursor-pointer transition-colors',
+          pasteChecked ? 'border-primary/50 bg-primary/5' : 'border-border bg-card hover:bg-accent'
+        )}
+        data-output-destination-card="paste"
+      >
         <input
           type="checkbox"
           id="settings-output-paste"
+          className="sr-only"
           checked={pasteChecked}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const checked = event.target.checked
             applySelection(selectedTextSource, { copyToClipboard: copyChecked, pasteAtCursor: checked })
           }}
         />
-        <span>Paste at cursor</span>
+        <div className="flex flex-col">
+          <span className="text-xs text-foreground">Paste at cursor</span>
+          <span className="text-[10px] text-muted-foreground">Insert output into focused field</span>
+        </div>
+        <span
+          className={cn(
+            'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+            pasteChecked ? 'bg-primary' : 'bg-secondary'
+          )}
+          aria-hidden="true"
+        >
+          <span
+            className={cn(
+              'inline-block size-4 transform rounded-full bg-primary-foreground transition-transform',
+              pasteChecked ? 'translate-x-4' : 'translate-x-0.5'
+            )}
+          />
+        </span>
       </label>
+      {!copyChecked && !pasteChecked && (
+        <p id="settings-output-destinations-warning" className="mt-2 text-[10px] text-warning">
+          Both destinations are disabled. Enable at least one destination to receive output text.
+        </p>
+      )}
       <div className="settings-actions">
         <button
           type="button"

--- a/src/renderer/settings-shortcuts-react.test.tsx
+++ b/src/renderer/settings-shortcuts-react.test.tsx
@@ -44,5 +44,6 @@ describe('SettingsShortcutsReact', () => {
     expect(host.querySelector('h2')?.textContent).toBe('Shortcut Contract')
     const combos = [...host.querySelectorAll<HTMLElement>('.shortcut-combo')].map((node) => node.textContent)
     expect(combos).toEqual(['Cmd+Opt+R', 'Cmd+Opt+L'])
+    expect(host.querySelectorAll('kbd').length).toBeGreaterThanOrEqual(4)
   })
 })

--- a/src/renderer/settings-shortcuts-react.tsx
+++ b/src/renderer/settings-shortcuts-react.tsx
@@ -5,9 +5,8 @@ Why: Continue renderer migration by moving Settings UI slices from legacy string
      Migrated from .ts (createElement) to .tsx (JSX) as part of the project-wide TSX migration.
 */
 
-import type { CSSProperties } from 'react'
-
-type StaggerStyle = CSSProperties & { '--delay': string }
+import { Kbd } from './kbd'
+import { cn } from './lib/utils'
 
 export interface ShortcutBinding {
   action: string
@@ -19,14 +18,21 @@ interface SettingsShortcutsReactProps {
 }
 
 export const SettingsShortcutsReact = ({ shortcuts }: SettingsShortcutsReactProps) => (
-  <article className="card shortcuts" data-stagger="" style={{ '--delay': '400ms' } as StaggerStyle}>
-    <h2>Shortcut Contract</h2>
-    <p className="muted">Reference from v1 spec for default operator bindings.</p>
-    <ul className="shortcut-list">
+  <article className="mt-3 rounded-lg border border-border bg-card p-3">
+    <h2 className="text-sm font-semibold text-foreground m-0">Shortcut Contract</h2>
+    <p className="mt-1 text-[11px] text-muted-foreground">Reference from v1 spec for default operator bindings.</p>
+    <ul className="mt-3 space-y-2">
       {shortcuts.map((shortcut) => (
-        <li key={shortcut.action} className="shortcut-item">
-          <span className="shortcut-action">{shortcut.action}</span>
-          <kbd className="shortcut-combo">{shortcut.combo}</kbd>
+        <li key={shortcut.action} className="flex items-center justify-between gap-3">
+          <span className="text-xs text-foreground">{shortcut.action}</span>
+          <span className="shortcut-combo flex flex-wrap items-center justify-end gap-1">
+            {shortcut.combo.split('+').map((segment, index) => (
+              <span key={`${shortcut.action}-${segment}-${index}`} className="inline-flex items-center gap-1">
+                {index > 0 && <span className="text-[10px] text-muted-foreground">+</span>}
+                <Kbd className={cn('h-5')}>{segment}</Kbd>
+              </span>
+            ))}
+          </span>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
Implements STY-06b from `docs/style-update-execution-plan.md` by redesigning Settings control patterns for Output, API keys, and shortcut contract rendering.

## Ticket Scope
- Plan ticket: **STY-06b [P1] Settings control-pattern redesign**
- Scope gate respected: control visuals/interactions only; no persistence contract changes.

## Changes
- Output section (`SettingsOutputReact`)
  - Replaced plain radio controls with custom exclusive source cards (`data-output-source-card`).
  - Replaced destination checkboxes with independent checkbox cards + switch visuals (`data-output-destination-card`).
  - Added warning when both destinations are disabled: `#settings-output-destinations-warning`.
  - Preserved existing selector IDs and callback wiring.
- API key section (`SettingsApiKeysReact`)
  - Applied compact mono input styling (`h-8 text-xs font-mono`).
  - Added eye icon visibility toggle treatment (Eye/EyeOff), preserving `data-api-key-visibility-toggle` hooks.
  - Kept per-provider test/save behavior and form submission contract unchanged.
- Shortcut contract (`SettingsShortcutsReact`)
  - Added reusable `<Kbd>` component in `src/renderer/kbd.tsx`.
  - Rendered segmented key combos with `<Kbd>` tokens while keeping `.shortcut-combo` wrapper hooks.
- Docs
  - Added `docs/sty-06b-settings-control-redesign.md`.

## Validation
- `pnpm -s exec tsc --noEmit`
- `pnpm -s vitest run src/renderer/settings-output-react.test.tsx src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx`
- `pnpm -s vitest run`

## Tests Added/Updated
- `src/renderer/settings-output-react.test.tsx`
  - Added warning-state coverage when both destinations are disabled.
- `src/renderer/settings-shortcuts-react.test.tsx`
  - Added segmented `<kbd>` rendering assertion.

## Rollback
1. Revert this PR commit.
2. Re-run:
   - `pnpm -s vitest run src/renderer/settings-output-react.test.tsx src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx`
   - `pnpm -s vitest run`
3. Verify Settings IDs/callback contracts remain unchanged.
