### PR TITLE
feat(sty-07): migrate footer status bar and toast visuals

### DIFF
--- a/docs/sty-07-status-bar-and-toast.md
+++ b/docs/sty-07-status-bar-and-toast.md
@@ -1,0 +1,43 @@
+<!--
+Where: docs/sty-07-status-bar-and-toast.md
+What: STY-07 implementation notes for footer status bar and toast visual migration.
+Why: Capture shipped metadata/connectivity/footer and toast tone contract.
+-->
+
+# STY-07 Status Bar and Toast Visual Migration
+
+**Date**: 2026-02-27
+**Scope**: Footer status bar + toast item visual migration only.
+
+## Implemented Behavior
+
+- Status bar footer keeps compact strip layout (`border-t bg-card/50 px-4 py-1.5`) with split clusters.
+- Left metadata cluster shows:
+  - STT provider/model (`provider/model`)
+  - LLM provider (from default profile)
+  - audio device id
+- Right metadata cluster shows:
+  - active profile name (`data-status-active-profile`)
+  - connectivity icon + text pair (`data-status-connectivity`)
+- Connectivity maps to existing readiness signal (`ping`):
+  - `pong` -> `Ready` + Wifi icon
+  - otherwise -> `Offline` + WifiOff icon
+- Toast cards now include explicit tone label + icon (Info/Success/Error) and semantic border tint:
+  - success: `border-success/20`
+  - error: `border-destructive/30`
+  - info: default border
+- Toast items expose `data-toast-tone` and retain existing role semantics (`alert` for error, otherwise `status`).
+
+## Validation
+
+- `src/renderer/status-bar-react.test.tsx`
+  - verifies metadata render and ready/offline connectivity text.
+- `src/renderer/app-shell-react.test.tsx`
+  - verifies toast tone labels and tone data attributes.
+
+## Rollback
+
+1. Revert STY-07 commit(s).
+2. Run:
+   - `pnpm -s vitest run src/renderer/status-bar-react.test.tsx src/renderer/app-shell-react.test.tsx`
+3. Confirm footer and toast behavior still renders with existing callbacks/data sources.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -202,4 +202,26 @@ describe('AppShell layout (STY-02)', () => {
 
     expect(host.textContent).toContain('UI failed to initialize')
   })
+
+  it('renders toast items with tone label and semantic data attribute', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <AppShell
+        state={buildState({
+          toasts: [
+            { id: 1, message: 'Settings saved.', tone: 'success' },
+            { id: 2, message: 'Network unavailable.', tone: 'error' }
+          ]
+        })}
+        callbacks={buildCallbacks()}
+      />
+    )
+    await flush()
+
+    expect(host.querySelector('[data-toast-tone="success"]')?.textContent).toContain('Success')
+    expect(host.querySelector('[data-toast-tone="error"]')?.textContent).toContain('Error')
+  })
 })

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -19,7 +19,7 @@
  */
 
 import type { ComponentType, KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { Activity, Cpu, Mic, Settings as SettingsIcon, Zap } from 'lucide-react'
+import { Activity, CheckCircle2, CircleAlert, Cpu, Info, Mic, Settings as SettingsIcon, Zap } from 'lucide-react'
 import { DEFAULT_SETTINGS, type OutputTextSource, type Settings } from '../shared/domain'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot, AudioInputSource, RecordingCommand } from '../shared/ipc'
 import type { ActivityItem } from './activity-feed'
@@ -169,6 +169,35 @@ const SettingsSectionHeader = ({
     <h3 className="text-sm font-semibold text-foreground m-0">{title}</h3>
   </div>
 )
+
+const ToastTone = ({
+  tone
+}: {
+  tone: ActivityItem['tone']
+}) => {
+  if (tone === 'error') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-destructive">
+        <CircleAlert className="size-3" aria-hidden="true" />
+        Error
+      </span>
+    )
+  }
+  if (tone === 'success') {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-success">
+        <CheckCircle2 className="size-3" aria-hidden="true" />
+        Success
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+      <Info className="size-3" aria-hidden="true" />
+      Info
+    </span>
+  )
+}
 
 // Flat underline tab button — no pill, no background fill per spec section 5.4.
 const TabButton = ({
@@ -513,7 +542,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
       </main>
 
       {/* ── Footer: status bar ───────────────────────────────── */}
-      <StatusBarReact settings={uiState.settings} />
+      <StatusBarReact settings={uiState.settings} ping={uiState.ping} />
 
       {/* ── Toast overlay (fixed, pointer-events managed per item) ── */}
       <ul
@@ -525,10 +554,18 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
         {uiState.toasts.map((toast) => (
           <li
             key={toast.id}
-            className="pointer-events-auto grid grid-cols-[1fr_auto] items-start gap-2 rounded-lg border bg-card/95 p-3"
+            className={cn(
+              'pointer-events-auto grid grid-cols-[1fr_auto] items-start gap-2 rounded-lg border bg-card/95 p-3',
+              toast.tone === 'error' && 'border-destructive/30',
+              toast.tone === 'success' && 'border-success/20'
+            )}
             role={toast.tone === 'error' ? 'alert' : 'status'}
+            data-toast-tone={toast.tone}
           >
-            <p className="text-xs leading-snug m-0">{toast.message}</p>
+            <div>
+              <ToastTone tone={toast.tone} />
+              <p className="mt-1 text-xs leading-snug m-0">{toast.message}</p>
+            </div>
             <button
               type="button"
               className="text-[10px] px-2 py-1 rounded bg-secondary hover:bg-accent transition-colors"

--- a/src/renderer/status-bar-react.test.tsx
+++ b/src/renderer/status-bar-react.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Where: src/renderer/status-bar-react.test.tsx
+ * What: Component tests for STY-07 status bar metadata and connectivity pairing.
+ * Why: Ensure footer keeps icon+text status semantics and compact metadata rendering.
+ */
+
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS } from '../shared/domain'
+import { StatusBarReact } from './status-bar-react'
+
+const flush = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+let root: Root | null = null
+
+afterEach(() => {
+  root?.unmount()
+  root = null
+  document.body.innerHTML = ''
+})
+
+describe('StatusBarReact', () => {
+  it('renders metadata cluster and ready connectivity when ping is pong', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<StatusBarReact settings={DEFAULT_SETTINGS} ping="pong" />)
+    await flush()
+
+    expect(host.textContent).toContain('groq/whisper-large-v3-turbo')
+    expect(host.textContent).toContain('google')
+    expect(host.textContent).toContain('system_default')
+    expect(host.querySelector('[data-status-active-profile]')?.textContent).toContain('Default')
+    expect(host.querySelector('[data-status-connectivity]')?.textContent).toContain('Ready')
+  })
+
+  it('renders offline connectivity label when ping is not pong', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<StatusBarReact settings={DEFAULT_SETTINGS} ping="nope" />)
+    await flush()
+
+    expect(host.querySelector('[data-status-connectivity]')?.textContent).toContain('Offline')
+  })
+})
+

--- a/src/renderer/status-bar-react.tsx
+++ b/src/renderer/status-bar-react.tsx
@@ -1,40 +1,48 @@
 /*
  * Where: src/renderer/status-bar-react.tsx
- * What: Status bar footer React component — placeholder for STY-07.
- * Why: STY-02 requires a footer component to complete the shell architecture;
- *      full metadata/connectivity implementation lands in STY-07.
+ * What: Status bar footer React component for STY-07 metadata/connectivity strip.
+ * Why: Keeps compact operational context visible without using color-only status cues.
  */
 
-import { Cpu, Mic, Wifi } from 'lucide-react'
+import { Cpu, Mic, Wifi, WifiOff } from 'lucide-react'
 import type { Settings } from '../shared/domain'
 
 interface StatusBarReactProps {
   settings: Settings
+  ping: string
 }
 
-export const StatusBarReact = ({ settings }: StatusBarReactProps) => (
-  <footer className="flex items-center justify-between border-t bg-card/50 px-4 py-1.5">
-    {/* Left cluster: STT provider/model + LLM provider + audio device */}
-    <div className="flex items-center gap-4 text-muted-foreground">
-      <span className="flex items-center gap-1">
-        <Mic className="size-3" />
-        <span className="font-mono text-[10px]">
-          {settings.transcription.provider}/{settings.transcription.model}
+export const StatusBarReact = ({ settings, ping }: StatusBarReactProps) => {
+  const isReady = ping === 'pong'
+  const defaultPreset =
+    settings.transformation.presets.find((preset) => preset.id === settings.transformation.defaultPresetId) ??
+    settings.transformation.presets[0]
+  const llmProvider = defaultPreset?.provider ?? 'unknown'
+
+  return (
+    <footer className="flex items-center justify-between border-t bg-card/50 px-4 py-1.5">
+      <div className="flex items-center gap-4 text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Mic className="size-3" aria-hidden="true" />
+          <span className="font-mono text-[10px]">
+            {settings.transcription.provider}/{settings.transcription.model}
+          </span>
         </span>
-      </span>
-      <span className="flex items-center gap-1">
-        <Cpu className="size-3" />
-        <span className="font-mono text-[10px]">
-          {settings.transformation.autoRunDefaultTransform ? 'auto-transform on' : 'manual'}
+        <span className="flex items-center gap-1">
+          <Cpu className="size-3" aria-hidden="true" />
+          <span className="font-mono text-[10px]">{llmProvider}</span>
         </span>
-      </span>
-    </div>
-    {/* Right cluster: connectivity */}
-    <div className="flex items-center gap-3 text-muted-foreground">
-      <span className="flex items-center gap-1">
-        <Wifi className="size-3 text-success" />
-        <span className="text-[10px]">Ready</span>
-      </span>
-    </div>
-  </footer>
-)
+        <span className="text-[10px] font-mono">{settings.recording.device}</span>
+      </div>
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <span className="text-[10px] text-primary" data-status-active-profile>
+          {defaultPreset?.name ?? 'Default'}
+        </span>
+        <span className="flex items-center gap-1" data-status-connectivity>
+          {isReady ? <Wifi className="size-3 text-success" aria-hidden="true" /> : <WifiOff className="size-3 text-destructive" aria-hidden="true" />}
+          <span className="text-[10px]">{isReady ? 'Ready' : 'Offline'}</span>
+        </span>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
Implements STY-07 from `docs/style-update-execution-plan.md` by migrating footer status bar and toast visuals to the new style contract.

## Ticket Scope
- Plan ticket: **STY-07 [P1] Status bar and toast visual migration**
- Scope gate respected: footer/toast visual behavior only; data sources unchanged.

## Changes
- Status bar (`StatusBarReact`)
  - Promoted from placeholder to STY-07 metadata strip.
  - Left cluster now shows:
    - STT provider/model (`provider/model`)
    - LLM provider (derived from default transformation profile)
    - audio device id
  - Right cluster now shows:
    - active profile name (`data-status-active-profile`)
    - connectivity icon + text pair (`data-status-connectivity`)
  - Connectivity wired to existing readiness signal (`ping`):
    - `pong` -> `Ready` + `Wifi`
    - non-`pong` -> `Offline` + `WifiOff`
- Toast layer (`AppShell`)
  - Added explicit tone label+icon row (Info/Success/Error) for readability beyond color.
  - Added semantic border tint by tone and `data-toast-tone` attribute for deterministic tests.
  - Preserved existing role semantics and dismiss behavior.

## Validation
- `pnpm -s exec tsc --noEmit`
- `pnpm -s vitest run src/renderer/status-bar-react.test.tsx src/renderer/app-shell-react.test.tsx`
- `pnpm -s vitest run`

## Tests Added/Updated
- Added `src/renderer/status-bar-react.test.tsx`
  - ready/offline connectivity assertions
  - metadata/profile rendering assertions
- Updated `src/renderer/app-shell-react.test.tsx`
  - toast tone label + semantic data attribute assertions

## Docs
- Added `docs/sty-07-status-bar-and-toast.md`

## Rollback
1. Revert this PR commit.
2. Re-run:
   - `pnpm -s vitest run src/renderer/status-bar-react.test.tsx src/renderer/app-shell-react.test.tsx`
   - `pnpm -s vitest run`
3. Verify footer/toast rendering and interactions remain functional.
