### PR TITLE
refactor(sty-08): remove legacy renderer style hooks

### DIFF
--- a/docs/sty-08-legacy-style-cleanup.md
+++ b/docs/sty-08-legacy-style-cleanup.md
@@ -1,0 +1,32 @@
+<!--
+Where: docs/sty-08-legacy-style-cleanup.md
+What: STY-08 implementation notes for legacy style/name cleanup.
+Why: Record removal of legacy class conventions from active renderer paths.
+-->
+
+# STY-08 Legacy Style Cleanup
+
+**Date**: 2026-02-27
+**Scope**: Cleanup-only ticket removing legacy style naming/hooks from active renderer paths.
+
+## Implemented Cleanup
+
+- Replaced legacy settings class hooks with utility-first classes in active settings components:
+  - removed `settings-form`, `settings-group`, `text-row`, `toggle-row`, `field-error`, `settings-actions`, `settings-key-row`
+- Introduced `data-settings-form` as the stable non-style hook for Enter-to-save routing.
+- Updated renderer save-key handler to use `[data-settings-form]` instead of `.settings-form`.
+- Removed legacy `.shortcut-combo` hook usage from active UI and replaced with `data-shortcut-combo`.
+- Updated tests/E2E selectors to use utility/data hooks instead of legacy class names.
+
+## Validation
+
+- Repo-wide grep confirms no active renderer references to removed legacy class conventions.
+- Tests updated for new hooks (`data-settings-form`, `data-shortcut-combo`).
+
+## Rollback
+
+1. Revert STY-08 commit(s).
+2. Re-run:
+   - `pnpm -s vitest run src/renderer/app-shell-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx`
+   - `pnpm -s vitest run`
+3. Verify settings save-on-Enter and shortcut contract rendering selectors still function.

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -140,7 +140,7 @@ test('saves settings after toggling transform auto-run', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Save Settings' }).click()
   await expect(page.locator('#settings-save-message')).toHaveText('Settings saved.')
-  await expect(page.locator('#toast-layer .toast-item')).toContainText('Settings saved.')
+  await expect(page.locator('#toast-layer li')).toContainText('Settings saved.')
 
   await page.locator('[data-route-tab="activity"]').click()
   await expect(page.getByText('Transformation is blocked because it is disabled.')).toHaveCount(0)
@@ -155,7 +155,7 @@ test('shows error toast when recording command fails', async ({ page, electronAp
       command: 'startRecording'
     })
   })
-  await expect(page.locator('#toast-layer .toast-item')).toContainText('startRecording failed:')
+  await expect(page.locator('#toast-layer li')).toContainText('startRecording failed:')
   await expect(page.locator('[role="status"]')).toHaveText('Error')
 })
 
@@ -168,7 +168,7 @@ test('shows toast when main broadcasts hotkey error notification', async ({ page
     })
   })
 
-  await expect(page.locator('#toast-layer .toast-item')).toContainText(
+  await expect(page.locator('#toast-layer li')).toContainText(
     'Shortcut Cmd+Opt+R failed: Global shortcut registration failed.'
   )
 })
@@ -822,7 +822,7 @@ test('supports run-selected preset, restore-defaults, and recording roadmap link
   await expect(page.locator('#settings-shortcut-cancel-recording')).toBeVisible()
 
   await page.locator('#settings-run-selected-preset').click()
-  await expect(page.locator('#toast-layer .toast-item')).toContainText(/Transformation|Clipboard|Google API key/i)
+  await expect(page.locator('#toast-layer li')).toContainText(/Transformation|Clipboard|Google API key/i)
 
   await page.locator('#settings-shortcut-start-recording').fill('Cmd+Shift+1')
   await page.locator('#settings-shortcut-stop-recording').fill('Cmd+Shift+2')
@@ -842,7 +842,7 @@ test('supports run-selected preset, restore-defaults, and recording roadmap link
   await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toHaveCount(0)
   await page.locator('[data-route-tab="settings"]').click()
   await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toBeVisible()
-  await expect(page.locator('.shortcut-combo')).toContainText(['Cmd+Shift+1', 'Cmd+Shift+2', 'Cmd+Shift+3', 'Cmd+Shift+4'])
+  await expect(page.locator('[data-shortcut-combo]')).toContainText(['Cmd+Shift+1', 'Cmd+Shift+2', 'Cmd+Shift+3', 'Cmd+Shift+4'])
 
   await page.locator('#settings-restore-defaults').click()
   await expect(page.locator('#settings-save-message')).toHaveText('Defaults restored.')

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -160,6 +160,19 @@ describe('AppShell layout (STY-02)', () => {
     ])
   })
 
+  it('uses utility-based settings form container without legacy class hooks', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ activeTab: 'settings' })} callbacks={buildCallbacks()} />)
+    await flush()
+
+    const settingsForm = host.querySelector('[data-settings-form]')
+    expect(settingsForm).not.toBeNull()
+    expect(settingsForm?.className).toContain('space-y-4')
+  })
+
   it('calls onNavigate with correct tab when tab button is clicked', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -357,7 +357,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
             onKeyDown={callbacks.handleSettingsEnterSaveKeydown}
           >
             <div className="p-4">
-              <section className="settings-form mt-4">
+              <section className="mt-4 space-y-4" data-settings-form>
                 <section data-settings-section="output">
                   <SettingsSectionHeader icon={Zap} title="Output" />
                   <SettingsOutputReact
@@ -418,7 +418,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
 
                 <section data-settings-section="llm-transformation">
                   <SettingsSectionHeader icon={Cpu} title="LLM Transformation" />
-                  <section className="settings-group">
+                  <section className="space-y-3">
                     <SettingsTransformationReact
                       settings={uiState.settings}
                       presetNameError={uiState.settingsValidationErrors.presetName ?? ''}
@@ -497,7 +497,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
 
                 <section data-settings-section="global-shortcuts">
                   <SettingsSectionHeader icon={SettingsIcon} title="Global Shortcuts" />
-                  <section className="settings-group">
+                  <section className="space-y-3">
                     <SettingsShortcutEditorReact
                       settings={uiState.settings}
                       validationErrors={{

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -355,7 +355,7 @@ const handleSettingsEnterSaveKeydown = (event: ReactKeyboardEvent<HTMLElement>):
   if (!(target instanceof HTMLElement)) {
     return
   }
-  if (!target.closest('.settings-form')) {
+  if (!target.closest('[data-settings-form]')) {
     return
   }
   if (target instanceof HTMLTextAreaElement) {

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -65,7 +65,7 @@ export const SettingsApiKeysReact = ({
   return (
     <form
       id="api-keys-form"
-      className="settings-form"
+      className="space-y-3"
       onSubmit={(event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
         setSavePending(true)
@@ -78,7 +78,7 @@ export const SettingsApiKeysReact = ({
         })
       }}
     >
-      <section className="settings-group">
+      <section className="space-y-3">
         <h3>Provider API Keys</h3>
         <p className="text-xs text-muted-foreground">
           Save each provider key independently. Unsaved edits in other fields stay local until you save them.
@@ -87,7 +87,7 @@ export const SettingsApiKeysReact = ({
           const inputId = `settings-api-key-${provider}`
           const visible = visibility[provider]
           return (
-            <div key={provider} className="settings-key-row mt-3 rounded-lg border border-border bg-card p-3">
+            <div key={provider} className="rounded-lg border border-border bg-card p-3">
               <label className="block">
                 <span className="text-xs text-foreground">
                   {labelByProvider[provider]}
@@ -125,7 +125,7 @@ export const SettingsApiKeysReact = ({
                   </button>
                 </div>
               </label>
-              <div className="settings-actions settings-actions-inline mt-2">
+              <div className="mt-2 flex items-center gap-2">
                 <button
                   type="button"
                   data-api-key-test={provider}
@@ -177,7 +177,7 @@ export const SettingsApiKeysReact = ({
           )
         })}
       </section>
-      <div className="settings-actions">
+      <div className="flex items-center gap-2">
         <button
           type="submit"
           className="h-8 rounded bg-primary px-3 text-xs text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"

--- a/src/renderer/settings-endpoint-overrides-react.tsx
+++ b/src/renderer/settings-endpoint-overrides-react.tsx
@@ -44,12 +44,13 @@ export const SettingsEndpointOverridesReact = ({
   }, [settings, settings.transcription.provider, defaultPreset?.provider])
 
   return (
-    <div>
-      <label className="text-row">
+    <div className="space-y-3">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>STT base URL override (optional)</span>
         <input
           id="settings-transcription-base-url"
           type="url"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           placeholder="https://stt-proxy.local"
           value={transcriptionBaseUrl}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
@@ -59,11 +60,12 @@ export const SettingsEndpointOverridesReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-transcription-base-url">{transcriptionBaseUrlError}</p>
-      <div className="settings-actions">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-transcription-base-url">{transcriptionBaseUrlError}</p>
+      <div className="flex items-center gap-2">
         <button
           type="button"
           id="settings-reset-transcription-base-url"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
           onClick={() => {
             setTranscriptionBaseUrl('')
             onResetTranscriptionBaseUrlDraft()
@@ -72,11 +74,12 @@ export const SettingsEndpointOverridesReact = ({
           Reset STT URL to default
         </button>
       </div>
-      <label className="text-row">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>LLM base URL override (optional)</span>
         <input
           id="settings-transformation-base-url"
           type="url"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           placeholder="https://llm-proxy.local"
           value={transformationBaseUrl}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
@@ -86,11 +89,12 @@ export const SettingsEndpointOverridesReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-transformation-base-url">{transformationBaseUrlError}</p>
-      <div className="settings-actions">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-transformation-base-url">{transformationBaseUrlError}</p>
+      <div className="flex items-center gap-2">
         <button
           type="button"
           id="settings-reset-transformation-base-url"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
           onClick={() => {
             setTransformationBaseUrl('')
             onResetTransformationBaseUrlDraft()

--- a/src/renderer/settings-output-react.tsx
+++ b/src/renderer/settings-output-react.tsx
@@ -51,7 +51,7 @@ export const SettingsOutputReact = ({
   }
 
   return (
-    <section className="settings-group">
+    <section className="space-y-3">
       <p className="text-xs text-muted-foreground mb-3">Choose which text version to output, then where to send it.</p>
       <fieldset className="space-y-2">
         <legend className="text-xs font-medium text-foreground mb-2">Output text</legend>
@@ -196,10 +196,11 @@ export const SettingsOutputReact = ({
           Both destinations are disabled. Enable at least one destination to receive output text.
         </p>
       )}
-      <div className="settings-actions">
+      <div className="flex items-center gap-2 pt-1">
         <button
           type="button"
           id="settings-restore-defaults"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent disabled:opacity-50"
           disabled={restoringDefaults}
           onClick={() => {
             setRestoringDefaults(true)

--- a/src/renderer/settings-recording-react.tsx
+++ b/src/renderer/settings-recording-react.tsx
@@ -75,22 +75,23 @@ export const SettingsRecordingReact = ({
   const availableModels = STT_MODEL_ALLOWLIST[selectedProvider]
 
   return (
-    <section className="settings-group">
+    <section className="space-y-3">
       {showLegacyHeading && (
         <>
           <h3>Recording</h3>
-          <p className="muted">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
+          <p className="text-[11px] text-muted-foreground">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
         </>
       )}
       {renderSpeechToTextControls && (
         <>
-          <p className="muted" id="settings-help-stt-language">
+          <p className="text-[11px] text-muted-foreground" id="settings-help-stt-language">
             STT language defaults to auto-detect. Advanced override: set `transcription.outputLanguage` in the settings file to an ISO language code (for example `en` or `ja`).
           </p>
-          <label className="text-row">
+          <label className="flex flex-col gap-1.5 text-xs">
             <span>STT provider</span>
             <select
               id="settings-transcription-provider"
+              className="h-8 rounded border border-input bg-input px-2 text-xs"
               value={selectedProvider}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const provider = event.target.value as Settings['transcription']['provider']
@@ -105,10 +106,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="text-row">
+          <label className="flex flex-col gap-1.5 text-xs">
             <span>STT model</span>
             <select
               id="settings-transcription-model"
+              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
               value={selectedModel}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const model = event.target.value as Settings['transcription']['model']
@@ -126,12 +128,13 @@ export const SettingsRecordingReact = ({
       {renderAudioControls && (
         <>
           {!showLegacyHeading && (
-            <p className="muted">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
+            <p className="text-[11px] text-muted-foreground">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
           )}
-          <label className="text-row">
+          <label className="flex flex-col gap-1.5 text-xs">
             <span>Recording method</span>
             <select
               id="settings-recording-method"
+              className="h-8 rounded border border-input bg-input px-2 text-xs"
               value={selectedRecordingMethod}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const method = event.target.value as Settings['recording']['method']
@@ -144,10 +147,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="text-row">
+          <label className="flex flex-col gap-1.5 text-xs">
             <span>Sample rate</span>
             <select
               id="settings-recording-sample-rate"
+              className="h-8 rounded border border-input bg-input px-2 text-xs"
               value={String(selectedSampleRate)}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const sampleRate = Number(event.target.value) as Settings['recording']['sampleRateHz']
@@ -160,10 +164,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="text-row">
+          <label className="flex flex-col gap-1.5 text-xs">
             <span>Audio source</span>
             <select
               id="settings-recording-device"
+              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
               value={selectedRecordingDevice}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const deviceId = event.target.value
@@ -176,10 +181,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <div className="settings-actions">
+          <div className="flex items-center gap-2">
             <button
               type="button"
               id="settings-refresh-audio-sources"
+              className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent disabled:opacity-50"
               disabled={refreshPending}
               onClick={() => {
                 setRefreshPending(true)
@@ -191,7 +197,7 @@ export const SettingsRecordingReact = ({
               Refresh audio sources
             </button>
           </div>
-          <p className="muted" id="settings-audio-sources-message">{audioSourceHint}</p>
+          <p className="text-[11px] text-muted-foreground" id="settings-audio-sources-message">{audioSourceHint}</p>
           <a
             className="inline-link"
             href="https://github.com/massun-onibakuchi/speech-to-text-app/issues/8"

--- a/src/renderer/settings-save-react.tsx
+++ b/src/renderer/settings-save-react.tsx
@@ -16,9 +16,10 @@ export const SettingsSaveReact = ({ saveMessage, onSave }: SettingsSaveReactProp
   const [saving, setSaving] = useState(false)
 
   return (
-    <div className="settings-actions">
+    <div className="flex items-center gap-2 pt-1">
       <button
         type="button"
+        className="h-8 rounded bg-primary px-3 text-xs text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
         disabled={saving}
         onClick={() => {
           setSaving(true)
@@ -33,7 +34,7 @@ export const SettingsSaveReact = ({ saveMessage, onSave }: SettingsSaveReactProp
       >
         Save Settings
       </button>
-      <p id="settings-save-message" className="muted" aria-live="polite">
+      <p id="settings-save-message" className="text-xs text-muted-foreground" aria-live="polite">
         {saveMessage}
       </p>
     </div>

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -68,12 +68,13 @@ export const SettingsShortcutEditorReact = ({
   ])
 
   return (
-    <div>
-      <label className="text-row">
+    <div className="space-y-3">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Start recording shortcut</span>
         <input
           id="settings-shortcut-start-recording"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={startRecording}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -82,12 +83,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-start-recording">{validationErrors.startRecording ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-start-recording">{validationErrors.startRecording ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Stop recording shortcut</span>
         <input
           id="settings-shortcut-stop-recording"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={stopRecording}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -96,12 +98,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-stop-recording">{validationErrors.stopRecording ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-stop-recording">{validationErrors.stopRecording ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Toggle recording shortcut</span>
         <input
           id="settings-shortcut-toggle-recording"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={toggleRecording}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -110,12 +113,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-toggle-recording">{validationErrors.toggleRecording ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-toggle-recording">{validationErrors.toggleRecording ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Cancel recording shortcut</span>
         <input
           id="settings-shortcut-cancel-recording"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={cancelRecording}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -124,12 +128,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-cancel-recording">{validationErrors.cancelRecording ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-cancel-recording">{validationErrors.cancelRecording ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Run transform shortcut</span>
         <input
           id="settings-shortcut-run-transform"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={runTransform}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -138,12 +143,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-run-transform">{validationErrors.runTransform ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-run-transform">{validationErrors.runTransform ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Run transform on selection shortcut</span>
         <input
           id="settings-shortcut-run-transform-selection"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={runTransformOnSelection}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -152,12 +158,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-run-transform-selection">{validationErrors.runTransformOnSelection ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-run-transform-selection">{validationErrors.runTransformOnSelection ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Pick transformation shortcut</span>
         <input
           id="settings-shortcut-pick-transform"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={pickTransformation}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -166,12 +173,13 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-pick-transform">{validationErrors.pickTransformation ?? ''}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-pick-transform">{validationErrors.pickTransformation ?? ''}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Change default transformation shortcut</span>
         <input
           id="settings-shortcut-change-default-transform"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={changeTransformationDefault}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -180,7 +188,7 @@ export const SettingsShortcutEditorReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-change-default-transform">{validationErrors.changeTransformationDefault ?? ''}</p>
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-change-default-transform">{validationErrors.changeTransformationDefault ?? ''}</p>
     </div>
   )
 }

--- a/src/renderer/settings-shortcuts-react.test.tsx
+++ b/src/renderer/settings-shortcuts-react.test.tsx
@@ -42,7 +42,7 @@ describe('SettingsShortcutsReact', () => {
     await flush()
 
     expect(host.querySelector('h2')?.textContent).toBe('Shortcut Contract')
-    const combos = [...host.querySelectorAll<HTMLElement>('.shortcut-combo')].map((node) => node.textContent)
+    const combos = [...host.querySelectorAll<HTMLElement>('[data-shortcut-combo]')].map((node) => node.textContent)
     expect(combos).toEqual(['Cmd+Opt+R', 'Cmd+Opt+L'])
     expect(host.querySelectorAll('kbd').length).toBeGreaterThanOrEqual(4)
   })

--- a/src/renderer/settings-shortcuts-react.tsx
+++ b/src/renderer/settings-shortcuts-react.tsx
@@ -25,7 +25,7 @@ export const SettingsShortcutsReact = ({ shortcuts }: SettingsShortcutsReactProp
       {shortcuts.map((shortcut) => (
         <li key={shortcut.action} className="flex items-center justify-between gap-3">
           <span className="text-xs text-foreground">{shortcut.action}</span>
-          <span className="shortcut-combo flex flex-wrap items-center justify-end gap-1">
+          <span className="flex flex-wrap items-center justify-end gap-1" data-shortcut-combo>
             {shortcut.combo.split('+').map((segment, index) => (
               <span key={`${shortcut.action}-${segment}-${index}`} className="inline-flex items-center gap-1">
                 {index > 0 && <span className="text-[10px] text-muted-foreground">+</span>}

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -63,12 +63,13 @@ export const SettingsTransformationReact = ({
   ])
 
   return (
-    <div>
+    <div className="space-y-3">
       <h3>Transformation</h3>
-      <label className="text-row">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Default profile</span>
         <select
           id="settings-transform-default-preset"
+          className="h-8 rounded border border-input bg-input px-2 text-xs"
           value={settings.transformation.defaultPresetId}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const selected = event.target.value
@@ -80,13 +81,14 @@ export const SettingsTransformationReact = ({
           ))}
         </select>
       </label>
-      <p className="muted" id="settings-help-default-profile">
+      <p className="text-[11px] text-muted-foreground" id="settings-help-default-profile">
         Used for recording/capture transformations, the Run Transform shortcut, and manual Transform actions. Saved across app restarts.
       </p>
-      <div className="settings-actions">
+      <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
           id="settings-preset-add"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
           onClick={() => { onAddPreset() }}
         >
           Add Profile
@@ -94,6 +96,7 @@ export const SettingsTransformationReact = ({
         <button
           type="button"
           id="settings-preset-remove"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
           onClick={() => { onRemovePreset(settings.transformation.defaultPresetId) }}
         >
           Remove Profile
@@ -101,16 +104,18 @@ export const SettingsTransformationReact = ({
         <button
           type="button"
           id="settings-run-selected-preset"
+          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
           onClick={() => { onRunSelectedPreset() }}
         >
           Run Selected Profile
         </button>
       </div>
-      <label className="text-row">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Profile name</span>
         <input
           id="settings-transform-preset-name"
           type="text"
+          className="h-8 rounded border border-input bg-input px-2 text-xs"
           value={presetName}
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value
@@ -119,11 +124,12 @@ export const SettingsTransformationReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-preset-name">{presetNameError}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-preset-name">{presetNameError}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>Profile model</span>
         <select
           id="settings-transform-preset-model"
+          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
           value={presetModel}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const value = event.target.value as Settings['transformation']['presets'][number]['model']
@@ -134,7 +140,7 @@ export const SettingsTransformationReact = ({
           <option value="gemini-2.5-flash">gemini-2.5-flash</option>
         </select>
       </label>
-      <label className="toggle-row">
+      <label className="flex items-center gap-2 text-xs">
         <input
           type="checkbox"
           id="settings-transform-auto-run"
@@ -147,14 +153,15 @@ export const SettingsTransformationReact = ({
         />
         <span>Auto-run default transform</span>
       </label>
-      <p className="muted" id="settings-help-transform-auto-run">
+      <p className="text-[11px] text-muted-foreground" id="settings-help-transform-auto-run">
         Only affects recording/capture automatic transformation using the default profile. Manual transforms still work when this is off.
       </p>
-      <label className="text-row">
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>System prompt</span>
         <textarea
           id="settings-system-prompt"
           rows={3}
+          className="min-h-[60px] resize-none rounded border border-input bg-input px-2 py-1.5 text-xs"
           value={systemPrompt}
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
             const value = event.target.value
@@ -163,12 +170,13 @@ export const SettingsTransformationReact = ({
           }}
         />
       </label>
-      <p className="field-error" id="settings-error-system-prompt">{systemPromptError}</p>
-      <label className="text-row">
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-system-prompt">{systemPromptError}</p>
+      <label className="flex flex-col gap-1.5 text-xs">
         <span>User prompt</span>
         <textarea
           id="settings-user-prompt"
           rows={3}
+          className="min-h-[60px] resize-none rounded border border-input bg-input px-2 py-1.5 text-xs font-mono"
           value={userPrompt}
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
             const value = event.target.value
@@ -177,8 +185,8 @@ export const SettingsTransformationReact = ({
           }}
         />
       </label>
-      <p className="muted" id="settings-help-user-prompt">Required. Include {'{{text}}'} where the transcript should be inserted.</p>
-      <p className="field-error" id="settings-error-user-prompt">{userPromptError}</p>
+      <p className="text-[11px] text-muted-foreground" id="settings-help-user-prompt">Required. Include {'{{text}}'} where the transcript should be inserted.</p>
+      <p className="min-h-4 text-[10px] text-destructive" id="settings-error-user-prompt">{userPromptError}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Implements STY-08 cleanup from `docs/style-update-execution-plan.md` by removing remaining legacy style class conventions from active renderer paths.

## Ticket Scope
- Plan ticket: **STY-08 [P2] Legacy style removal and utility-only cleanup**
- Scope gate respected: cleanup only, no net-new feature behavior.

## Changes
- Replaced legacy settings class hooks with utility-first classes in active renderer components:
  - removed usage patterns like `settings-form`, `settings-group`, `text-row`, `toggle-row`, `field-error`, `settings-actions`, `settings-key-row`.
- Introduced stable non-style hook:
  - `data-settings-form` in AppShell settings container.
  - updated Enter-to-save routing in renderer app to target `[data-settings-form]`.
- Replaced `.shortcut-combo` hook usage with `data-shortcut-combo` in UI/tests/e2e.
- Replaced stale toast selector usage in e2e from `.toast-item` to `#toast-layer li`.
- Added STY-08 cleanup note:
  - `docs/sty-08-legacy-style-cleanup.md`.

## Validation
- `pnpm -s exec tsc --noEmit`
- `pnpm -s vitest run src/renderer/app-shell-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx src/renderer/settings-recording-react.test.tsx src/renderer/settings-transformation-react.test.tsx src/renderer/settings-endpoint-overrides-react.test.tsx src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-save-react.test.tsx`
- `pnpm -s vitest run`

## Codex Subagent Review
- Ran codex subagent review on branch diff.
- Result: **No findings** in STY-08 scope.

## Rollback
1. Revert this PR commit.
2. Re-run:
   - `pnpm -s vitest run src/renderer/app-shell-react.test.tsx src/renderer/settings-shortcuts-react.test.tsx`
   - `pnpm -s vitest run`
3. Verify settings Enter-to-save and shortcut/toast selector behavior still pass.
