### PR TITLE
fix(#201): terminal-only activity feed with max-10 result cards

### DIFF
--- a/docs/decisions/activity-feed-terminal-results-option-a.md
+++ b/docs/decisions/activity-feed-terminal-results-option-a.md
@@ -1,0 +1,47 @@
+<!--
+Where: docs/decisions/activity-feed-terminal-results-option-a.md
+What: Decision for issue #201 activity-feed result-card contract.
+Why: Lock behavior before implementation to keep one-ticket scope and avoid mixed UX semantics.
+-->
+
+# Decision: Activity Feed Terminal Results Contract (Issue #201)
+
+**Date**: 2026-02-28
+**Status**: Accepted
+**Ticket**: #201
+
+## Context
+
+Issue #201 requires the activity feed to:
+- show terminal outcomes only (success/failure),
+- cap feed size to 10,
+- avoid start/stop/cancel operational-event cards,
+- keep copyable display text for successful outcomes.
+
+The issue proposed two options for successful recording cards:
+- Option A: single final output text card.
+- Option B: per-step cards (STT and transform).
+
+## Decision
+
+Adopt **Option A**.
+
+- Each recording/transform run contributes at most one terminal activity card.
+- Successful recording cards use final displayable output text:
+  - selected output source text when present,
+  - transcript fallback when transformed text is selected but unavailable.
+- Failure cards show formatted failure detail.
+- Operational events (start/stop/cancel/dispatch-progress messages) remain toast/operational feedback only and are not shown as activity cards.
+
+## Rationale
+
+- Keeps feed concise and deterministic.
+- Aligns with current single-output selection contract.
+- Minimizes renderer data-model churn while still making copy text meaningful.
+- Prevents duplicate or intermediate-only cards when transformed output is selected.
+
+## Consequences
+
+- Activity feed no longer acts as an operational event log.
+- Existing tests that asserted start/stop feed messages must assert terminal text cards instead.
+- Future expansion to per-step cards (Option B) remains possible with a new ticket and explicit contract update.

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -451,14 +451,14 @@ test('records and stops with fake microphone audio fixture smoke @macos', async 
     await startRecordingButton.click()
     await expect(page.getByRole('button', { name: 'Stop recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toBeVisible()
-    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording started.')).toBeVisible()
+    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording started.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Cancel recording' })).toBeVisible()
 
     // Allow the fake stream to emit at least one chunk before stop.
     await page.waitForTimeout(1000)
 
     await page.getByRole('button', { name: 'Stop recording' }).click()
-    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toBeVisible()
+    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Start recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toHaveCount(0)
     await expect(page.getByText('Click to record')).toBeVisible()
@@ -503,7 +503,9 @@ test('records and stops with fake microphone audio fixture smoke @macos', async 
     }
 
     if (observedSubmission) {
-      await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Transcription complete.')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('deterministic fake recording transcript')).toBeVisible({
+        timeout: 8_000
+      })
     }
 
     const submissions = await page.evaluate(() => {
@@ -733,13 +735,13 @@ test('records and stops with deterministic synthetic microphone stream and repor
     await startRecordingButton.click()
     await expect(page.getByRole('button', { name: 'Stop recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toBeVisible()
-    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording started.')).toBeVisible()
+    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording started.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Cancel recording' })).toBeVisible()
 
     await page.waitForTimeout(1000)
 
     await page.getByRole('button', { name: 'Stop recording' }).click()
-    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toBeVisible()
+    await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Start recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toHaveCount(0)
     await expect(page.getByText('Click to record')).toBeVisible()
@@ -781,7 +783,9 @@ test('records and stops with deterministic synthetic microphone stream and repor
       test.skip(true, 'Skipping deterministic synthetic-mic verification: no submission observed on this macOS CI runner.')
     }
     if (observedSubmission) {
-      await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Transcription complete.')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('deterministic synthetic recording transcript')).toBeVisible({
+        timeout: 8_000
+      })
     }
 
     const [submissions, historyCallCount, deterministicRecorderFallback] = await Promise.all([

--- a/src/renderer/activity-feed.test.ts
+++ b/src/renderer/activity-feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { appendActivityItem, clearActivityItems, type ActivityItem } from './activity-feed'
+import { appendActivityItem, appendTerminalActivityItem, clearActivityItems, type ActivityItem } from './activity-feed'
 
 const makeItem = (id: number, message: string): ActivityItem => ({
   id,
@@ -26,5 +26,16 @@ describe('activity-feed', () => {
     expect(items).toHaveLength(2)
     expect(items[0]?.message).toBe('third')
     expect(items[1]?.message).toBe('second')
+  })
+
+  it('enforces terminal-feed cap of 10 items', () => {
+    let items: ActivityItem[] = []
+    for (let id = 1; id <= 12; id += 1) {
+      items = appendTerminalActivityItem(items, makeItem(id, `item-${id}`))
+    }
+
+    expect(items).toHaveLength(10)
+    expect(items[0]?.message).toBe('item-12')
+    expect(items[9]?.message).toBe('item-3')
   })
 })

--- a/src/renderer/activity-feed.ts
+++ b/src/renderer/activity-feed.ts
@@ -10,4 +10,7 @@ export const appendActivityItem = (items: ActivityItem[], item: ActivityItem, ma
   return next.slice(0, maxItems)
 }
 
+export const appendTerminalActivityItem = (items: ActivityItem[], item: ActivityItem): ActivityItem[] =>
+  appendActivityItem(items, item, 10)
+
 export const clearActivityItems = (): ActivityItem[] => []

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -25,7 +25,7 @@ import type {
   HotkeyErrorNotification,
   RecordingCommandDispatch
 } from '../shared/ipc'
-import { appendActivityItem, type ActivityItem } from './activity-feed'
+import { appendTerminalActivityItem, type ActivityItem } from './activity-feed'
 import { AppShell, type AppShellCallbacks, type AppTab, type ToastItem } from './app-shell-react'
 import { resolveTransformBlockedMessage } from './blocked-control'
 import { applyHotkeyErrorNotification } from './hotkey-error'
@@ -101,7 +101,12 @@ const logRendererError = (event: string, error: unknown, context?: Record<string
 }
 
 const addActivity = (message: string, tone: ActivityItem['tone'] = 'info'): void => {
-  state.activity = appendActivityItem(state.activity, {
+  void message
+  void tone
+}
+
+const addTerminalActivity = (message: string, tone: ActivityItem['tone'] = 'info'): void => {
+  state.activity = appendTerminalActivityItem(state.activity, {
     id: ++state.activityCounter,
     message,
     tone,
@@ -275,11 +280,11 @@ const refreshApiKeyStatusFromMainWithRetry = async (): Promise<void> => {
 const applyCompositeResult = (result: CompositeTransformResult): void => {
   if (result.status === 'ok') {
     state.hasCommandError = false
-    addActivity(`Transform complete: ${result.message}`, 'success')
+    addTerminalActivity(result.message, 'success')
     addToast(`Transform complete: ${result.message}`, 'success')
   } else {
     state.hasCommandError = true
-    addActivity(`Transform error: ${result.message}`, 'error')
+    addTerminalActivity(`Transform error: ${result.message}`, 'error')
     addToast(`Transform error: ${result.message}`, 'error')
   }
   rerenderShellFromState()
@@ -332,7 +337,7 @@ const runCompositeTransformAction = async (): Promise<void> => {
     const message = error instanceof Error ? error.message : 'Unknown transform error'
     logRendererError('renderer.run_transform_failed', error)
     state.hasCommandError = true
-    addActivity(`Transform failed: ${message}`, 'error')
+    addTerminalActivity(`Transform failed: ${message}`, 'error')
     addToast(`Transform failed: ${message}`, 'error')
   }
   state.pendingActionId = null
@@ -373,6 +378,7 @@ const handleSettingsEnterSaveKeydown = (event: ReactKeyboardEvent<HTMLElement>):
 const buildRecordingDeps = (): NativeRecordingDeps => ({
   state,
   addActivity,
+  addTerminalActivity,
   addToast,
   logError: logRendererError,
   onStateChange: rerenderShellFromState


### PR DESCRIPTION
Closes #201

## Summary
- implement terminal-only Activity feed contract (Option A)
- cap terminal feed entries to 10
- stop rendering operational recording events (start/stop/cancel/dispatch) as activity cards
- render successful recording cards with final copyable output text from history (selected-source aware with transcript fallback)
- keep failure cards from formatted terminal failure details
- update recording e2e expectations to assert operational feed-event absence and terminal text presence
- add decision record for #201 contract selection

## Decision
- Added: `docs/decisions/activity-feed-terminal-results-option-a.md`
- Chosen contract: Option A (single final output card per run)

## Validation
- `pnpm -s exec tsc --noEmit`
- `pnpm -s vitest run src/renderer/activity-feed.test.ts src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts`
- `pnpm -s vitest run`

## Gates
- Activity feed shows terminal outcomes only
- Max feed size is 10
- Success cards carry copyable final output text
- Decision doc + tests + docs included

## Rollback
1. Revert this PR commit.
2. Run:
   - `pnpm -s exec tsc --noEmit`
   - `pnpm -s vitest run`
3. Confirm prior operational-event activity feed behavior returns.
