### PR TITLE
fix(198): preserve autoRunDefaultTransform=false intent during migration

### DIFF
--- a/docs/decisions/derived-transform-run-from-output-source.md
+++ b/docs/decisions/derived-transform-run-from-output-source.md
@@ -1,0 +1,47 @@
+<!--
+Where: docs/decisions/derived-transform-run-from-output-source.md
+What: Decision for issue #198 to derive capture transformation behavior from selected output source.
+Why: Replace ambiguous auto-run toggle with deterministic behavior contract.
+-->
+
+# Decision: Derive Capture Transformation From Output Source (#198)
+
+**Date**: 2026-02-28
+**Status**: Accepted
+**Ticket**: #198
+
+## Context
+
+The previous settings contract had `transformation.autoRunDefaultTransform` plus `output.selectedTextSource`.
+This produced overlapping controls and unclear behavior.
+
+Issue #198 requires deterministic behavior:
+- if `output.selectedTextSource === transformed`: run default transformation during capture flow.
+- if `output.selectedTextSource === transcript`: skip capture-time transformation.
+
+Manual transforms (clipboard/selection/shortcut-triggered transform runs) must continue to work regardless of selected output source.
+
+## Decision
+
+- Remove the `autoRunDefaultTransform` UI toggle.
+- Deprecate/remove `transformation.autoRunDefaultTransform` from schema/defaults.
+- Derive capture-time transformation from `output.selectedTextSource` only.
+- Keep transform-failure behavior unchanged:
+  - when transformed output is selected but transformation fails, transcript fallback remains available to output routing.
+
+## Migration
+
+- Existing persisted settings containing `autoRunDefaultTransform` are migrated by dropping the key.
+- When `autoRunDefaultTransform === false`, the migration also sets `output.selectedTextSource` to
+  `'transcript'` to preserve the user's intent of skipping capture-time transformation.
+  Without this, the default `selectedTextSource: 'transformed'` would silently activate
+  transformation for users who had previously disabled it, causing `transformation_failed` for
+  anyone without a Google API key.
+- When `autoRunDefaultTransform === true` (or missing), `output.selectedTextSource` is left
+  unchanged; the existing value already reflects the correct behavior.
+
+## Consequences
+
+- One less toggle in Settings; behavior is easier to reason about.
+- Capture snapshot/profile binding now depends on selected output source.
+- Tests referencing auto-run toggle/settings field must move to selected-source assertions.

--- a/docs/decisions/transformation-enable-vs-auto-run.md
+++ b/docs/decisions/transformation-enable-vs-auto-run.md
@@ -6,6 +6,8 @@ Why: Keeps settings semantics clear after simplifying transformation behavior to
 
 # Decision Record: Remove `Enable transformation`, keep `Auto-run default transform`
 
+Status: Superseded by `docs/decisions/derived-transform-run-from-output-source.md` (2026-02-28).
+
 ## Context
 
 The Transformation settings UI previously exposed two controls:

--- a/src/main/core/command-router.test.ts
+++ b/src/main/core/command-router.test.ts
@@ -92,15 +92,14 @@ describe('CommandRouter', () => {
     expect(snapshot.sttBaseUrlOverride).toBeNull()
   })
 
-  it('submitRecordedAudio binds transformation profile from settings when enabled', () => {
+  it('submitRecordedAudio binds transformation profile when selected output source is transformed', () => {
     const captureQueue = { enqueue: vi.fn() }
     const settings = makeSettings({
-      transformation: {
-        ...DEFAULT_SETTINGS.transformation,
-        autoRunDefaultTransform: true
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transformed'
       }
     })
-    // Explicitly enable auto-run so capture snapshots bind the default transformation profile.
     const deps = makeDeps({
       captureQueue,
       settingsService: { getSettings: () => settings }
@@ -122,11 +121,14 @@ describe('CommandRouter', () => {
         ...DEFAULT_SETTINGS.transformation,
         defaultPresetId: 'default-id',
         lastPickedPresetId: 'active-id',
-        autoRunDefaultTransform: true,
         presets: [
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'active-id', name: 'Active' },
           { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' }
         ]
+      },
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transformed'
       }
     })
     const deps = makeDeps({
@@ -141,12 +143,12 @@ describe('CommandRouter', () => {
     expect(snapshot.transformationProfile?.profileId).toBe('default-id')
   })
 
-  it('submitRecordedAudio binds transformationProfile when auto-run is on', () => {
+  it('submitRecordedAudio binds transformationProfile when selected output source is transformed', () => {
     const captureQueue = { enqueue: vi.fn() }
     const settings = makeSettings({
-      transformation: {
-        ...DEFAULT_SETTINGS.transformation,
-        autoRunDefaultTransform: true
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transformed'
       }
     })
     const deps = makeDeps({
@@ -161,12 +163,12 @@ describe('CommandRouter', () => {
     expect(snapshot.transformationProfile?.profileId).toBe('default')
   })
 
-  it('submitRecordedAudio sets transformationProfile to null when auto-run default transform is disabled', () => {
+  it('submitRecordedAudio sets transformationProfile to null when selected output source is transcript', () => {
     const captureQueue = { enqueue: vi.fn() }
     const settings = makeSettings({
-      transformation: {
-        ...DEFAULT_SETTINGS.transformation,
-        autoRunDefaultTransform: false
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transcript'
       }
     })
     const deps = makeDeps({
@@ -218,11 +220,14 @@ describe('CommandRouter', () => {
       },
       transformation: {
         ...DEFAULT_SETTINGS.transformation,
-        autoRunDefaultTransform: true,
         baseUrlOverrides: {
           ...DEFAULT_SETTINGS.transformation.baseUrlOverrides,
           google: 'https://llm-proxy.local'
         }
+      },
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transformed'
       }
     })
     const deps = makeDeps({
@@ -243,10 +248,11 @@ describe('CommandRouter', () => {
     expect(transformSnapshot.baseUrlOverride).toBe('https://llm-proxy.local')
   })
 
-  it('runCompositeFromClipboard enqueues regardless of auto-run setting', async () => {
+  it('runCompositeFromClipboard enqueues regardless of selected output source', async () => {
     const settings = makeSettings({
-      transformation: {
-        ...DEFAULT_SETTINGS.transformation,
+      output: {
+        ...DEFAULT_SETTINGS.output,
+        selectedTextSource: 'transcript'
       }
     })
     const transformQueue = { enqueue: vi.fn() }

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -212,11 +212,11 @@ export class CommandRouter {
 
   /**
    * Resolve transformation profile for capture snapshot.
-   * Returns null when auto-run is off,
+   * Returns null when selected output source is transcript,
    * meaning the capture pipeline skips LLM transformation.
    */
   private resolveTransformationProfile(settings: Settings): TransformationProfileSnapshot | null {
-    if (!settings.transformation.autoRunDefaultTransform) {
+    if (settings.output.selectedTextSource !== 'transformed') {
       return null
     }
 

--- a/src/main/orchestrators/processing-orchestrator.test.ts
+++ b/src/main/orchestrators/processing-orchestrator.test.ts
@@ -9,7 +9,6 @@ const baseSettings: Settings = {
     ...DEFAULT_SETTINGS.transformation,
     defaultPresetId: 'default',
     lastPickedPresetId: null,
-    autoRunDefaultTransform: true,
     presets: [
       {
         ...DEFAULT_SETTINGS.transformation.presets[0],
@@ -19,6 +18,10 @@ const baseSettings: Settings = {
         userPrompt: 'rewrite: {{input}}'
       }
     ]
+  },
+  output: {
+    ...DEFAULT_SETTINGS.output,
+    selectedTextSource: 'transformed'
   }
 }
 
@@ -33,14 +36,14 @@ const job: QueueJobRecord = {
 }
 
 describe('ProcessingOrchestrator', () => {
-  it('runs transformation when auto-run is on', async () => {
+  it('runs transformation when selected output source is transformed', async () => {
     const appendRecord = vi.fn()
     const transform = vi.fn(async () => ({ text: 'hello transformed', model: 'gemini-2.5-flash' as const }))
     const settings: Settings = {
       ...baseSettings,
-      transformation: {
-        ...baseSettings.transformation,
-        autoRunDefaultTransform: true
+      output: {
+        ...baseSettings.output,
+        selectedTextSource: 'transformed'
       }
     }
 
@@ -67,14 +70,14 @@ describe('ProcessingOrchestrator', () => {
     expect(appendRecord).toHaveBeenCalledTimes(1)
   })
 
-  it('skips auto-run transformation when auto-run default transform is disabled', async () => {
+  it('skips capture-time transformation when selected output source is transcript', async () => {
     const appendRecord = vi.fn()
     const transform = vi.fn()
     const settings: Settings = {
       ...baseSettings,
-      transformation: {
-        ...baseSettings.transformation,
-        autoRunDefaultTransform: false
+      output: {
+        ...baseSettings.output,
+        selectedTextSource: 'transcript'
       }
     }
 

--- a/src/main/orchestrators/processing-orchestrator.ts
+++ b/src/main/orchestrators/processing-orchestrator.ts
@@ -118,7 +118,7 @@ export class ProcessingOrchestrator {
 
     if (
       terminalStatus === 'succeeded' &&
-      settings.transformation.autoRunDefaultTransform &&
+      settings.output.selectedTextSource === 'transformed' &&
       transcriptText !== null
     ) {
       try {

--- a/src/main/orchestrators/transformation-orchestrator.test.ts
+++ b/src/main/orchestrators/transformation-orchestrator.test.ts
@@ -21,15 +21,15 @@ const baseSettings: Settings = {
 }
 
 describe('TransformationOrchestrator', () => {
-  it('runs clipboard transform even when auto-run is off', async () => {
+  it('runs clipboard transform regardless of selected output source', async () => {
     const transform = vi.fn(async () => ({ text: 'transformed text', model: 'gemini-2.5-flash' as const }))
     const orchestrator = new TransformationOrchestrator({
       settingsService: {
         getSettings: () => ({
           ...baseSettings,
-          transformation: {
-            ...baseSettings.transformation,
-            autoRunDefaultTransform: false
+          output: {
+            ...baseSettings.output,
+            selectedTextSource: 'transcript'
           }
         })
       },

--- a/src/main/test-support/settings-fixtures.ts
+++ b/src/main/test-support/settings-fixtures.ts
@@ -8,11 +8,11 @@ import type { Settings } from '../../shared/domain'
 /** Minimal valid settings using all defaults. */
 export const SETTINGS_MINIMAL: Settings = buildSettings()
 
-/** Auto-run transformation disabled — processing skips LLM step. */
-export const SETTINGS_TRANSFORM_AUTO_RUN_DISABLED: Settings = buildSettings({
-  transformation: {
-    ...buildSettings().transformation,
-    autoRunDefaultTransform: false
+/** Transcript output selected — capture processing skips LLM step. */
+export const SETTINGS_TRANSFORM_DERIVED_SKIP: Settings = buildSettings({
+  output: {
+    ...buildSettings().output,
+    selectedTextSource: 'transcript'
   }
 })
 

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -62,7 +62,6 @@ const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCal
   onSelectRecordingDevice: vi.fn(),
   onSelectTranscriptionProvider: vi.fn(),
   onSelectTranscriptionModel: vi.fn(),
-  onToggleAutoRun: vi.fn(),
   onSelectDefaultPreset: vi.fn(),
   onSelectDefaultPresetAndSave: vi.fn().mockResolvedValue(true),
   onChangeDefaultPresetDraft: vi.fn(),

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -99,7 +99,6 @@ export interface AppShellCallbacks {
   onSelectRecordingDevice: (deviceId: string) => void
   onSelectTranscriptionProvider: (provider: Settings['transcription']['provider']) => void
   onSelectTranscriptionModel: (model: Settings['transcription']['model']) => void
-  onToggleAutoRun: (checked: boolean) => void
   onSelectDefaultPreset: (presetId: string) => void
   onSelectDefaultPresetAndSave: (presetId: string) => Promise<boolean>
   onChangeDefaultPresetDraft: (
@@ -424,9 +423,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                       presetNameError={uiState.settingsValidationErrors.presetName ?? ''}
                       systemPromptError={uiState.settingsValidationErrors.systemPrompt ?? ''}
                       userPromptError={uiState.settingsValidationErrors.userPrompt ?? ''}
-                      onToggleAutoRun={(checked: boolean) => {
-                        callbacks.onToggleAutoRun(checked)
-                      }}
                       onSelectDefaultPreset={(presetId: string) => {
                         callbacks.onSelectDefaultPreset(presetId)
                       }}

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -435,12 +435,6 @@ const rerenderShellFromState = (): void => {
         transcription: { ...current.transcription, model }
       }))
     },
-    onToggleAutoRun: (checked) => {
-      applyNonSecretAutosavePatch((current) => ({
-        ...current,
-        transformation: { ...current.transformation, autoRunDefaultTransform: checked }
-      }))
-    },
     onSelectDefaultPreset: mutations.setDefaultTransformationPreset,
     onSelectDefaultPresetAndSave: mutations.setDefaultTransformationPresetAndSave,
     onChangeDefaultPresetDraft: mutations.patchDefaultTransformationPresetDraft,

--- a/src/renderer/settings-transformation-react.test.tsx
+++ b/src/renderer/settings-transformation-react.test.tsx
@@ -32,7 +32,6 @@ describe('SettingsTransformationReact', () => {
     document.body.append(host)
     root = createRoot(host)
 
-    const onToggleAutoRun = vi.fn()
     const onSelectDefaultPreset = vi.fn()
     const onChangeDefaultPresetDraft = vi.fn()
     const onRunSelectedPreset = vi.fn()
@@ -46,7 +45,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError=""
           systemPromptError=""
           userPromptError=""
-          onToggleAutoRun={onToggleAutoRun}
           onSelectDefaultPreset={onSelectDefaultPreset}
           onChangeDefaultPresetDraft={onChangeDefaultPresetDraft}
           onRunSelectedPreset={onRunSelectedPreset}
@@ -59,7 +57,6 @@ describe('SettingsTransformationReact', () => {
     // Active profile should no longer appear in the UI (#127)
     expect(host.textContent).not.toContain('Active profile')
     expect(host.textContent).toContain('Default profile')
-    expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('recording/capture automatic transformation')
     expect(host.querySelector('#settings-help-active-profile')).toBeNull()
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Run Transform shortcut')
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('manual Transform actions')
@@ -76,11 +73,6 @@ describe('SettingsTransformationReact', () => {
     expect(host.querySelector('#settings-help-transform-enabled')).toBeNull()
     // Active preset selector no longer rendered (#127)
     expect(host.querySelector('#settings-transform-active-preset')).toBeNull()
-
-    await act(async () => {
-      host.querySelector<HTMLInputElement>('#settings-transform-auto-run')?.click()
-    })
-    expect(onToggleAutoRun).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       host.querySelector<HTMLButtonElement>('#settings-run-selected-preset')?.click()
@@ -119,7 +111,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError=""
           systemPromptError=""
           userPromptError=""
-          onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
           onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}
@@ -138,7 +129,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError="Profile name is required."
           systemPromptError="System prompt is required."
           userPromptError="User prompt must include {{text}}."
-          onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
           onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}
@@ -149,7 +139,6 @@ describe('SettingsTransformationReact', () => {
     })
     expect(host.querySelector('#settings-error-preset-name')?.textContent).toContain('Profile name is required.')
     expect(host.querySelector('#settings-help-transform-enabled')).toBeNull()
-    expect(host.querySelector('#settings-help-transform-auto-run')?.textContent).toContain('Manual transforms still work')
     // Active profile help text is no longer rendered (#127)
     expect(host.querySelector('#settings-help-active-profile')).toBeNull()
     expect(host.querySelector('#settings-help-default-profile')?.textContent).toContain('Saved across app restarts')
@@ -178,7 +167,6 @@ describe('SettingsTransformationReact', () => {
           presetNameError=""
           systemPromptError=""
           userPromptError=""
-          onToggleAutoRun={() => {}}
           onSelectDefaultPreset={() => {}}
           onChangeDefaultPresetDraft={() => {}}
           onRunSelectedPreset={() => {}}

--- a/src/renderer/settings-transformation-react.tsx
+++ b/src/renderer/settings-transformation-react.tsx
@@ -15,7 +15,6 @@ interface SettingsTransformationReactProps {
   presetNameError: string
   systemPromptError: string
   userPromptError: string
-  onToggleAutoRun: (checked: boolean) => void
   onSelectDefaultPreset: (presetId: string) => void
   onChangeDefaultPresetDraft: (
     patch: Partial<Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>>
@@ -30,7 +29,6 @@ export const SettingsTransformationReact = ({
   presetNameError,
   systemPromptError,
   userPromptError,
-  onToggleAutoRun,
   onSelectDefaultPreset,
   onChangeDefaultPresetDraft,
   onRunSelectedPreset,
@@ -41,20 +39,17 @@ export const SettingsTransformationReact = ({
     settings.transformation.presets.find((preset) => preset.id === settings.transformation.defaultPresetId) ??
     settings.transformation.presets[0]
 
-  const [autoRun, setAutoRun] = useState(settings.transformation.autoRunDefaultTransform)
   const [presetName, setPresetName] = useState(defaultPreset?.name ?? 'Default')
   const [presetModel, setPresetModel] = useState(defaultPreset?.model ?? 'gemini-2.5-flash')
   const [systemPrompt, setSystemPrompt] = useState(defaultPreset?.systemPrompt ?? '')
   const [userPrompt, setUserPrompt] = useState(defaultPreset?.userPrompt ?? '')
 
   useEffect(() => {
-    setAutoRun(settings.transformation.autoRunDefaultTransform)
     setPresetName(defaultPreset?.name ?? 'Default')
     setPresetModel(defaultPreset?.model ?? 'gemini-2.5-flash')
     setSystemPrompt(defaultPreset?.systemPrompt ?? '')
     setUserPrompt(defaultPreset?.userPrompt ?? '')
   }, [
-    settings.transformation.autoRunDefaultTransform,
     settings.transformation.defaultPresetId,
     defaultPreset?.name,
     defaultPreset?.model,
@@ -140,22 +135,6 @@ export const SettingsTransformationReact = ({
           <option value="gemini-2.5-flash">gemini-2.5-flash</option>
         </select>
       </label>
-      <label className="flex items-center gap-2 text-xs">
-        <input
-          type="checkbox"
-          id="settings-transform-auto-run"
-          checked={autoRun}
-          onChange={(event: ChangeEvent<HTMLInputElement>) => {
-            const checked = event.target.checked
-            setAutoRun(checked)
-            onToggleAutoRun(checked)
-          }}
-        />
-        <span>Auto-run default transform</span>
-      </label>
-      <p className="text-[11px] text-muted-foreground" id="settings-help-transform-auto-run">
-        Only affects recording/capture automatic transformation using the default profile. Manual transforms still work when this is off.
-      </p>
       <label className="flex flex-col gap-1.5 text-xs">
         <span>System prompt</span>
         <textarea

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -139,8 +139,7 @@ export const SettingsSchema = v.object({
       baseUrlOverrides: v.object({
         google: v.nullable(v.string())
       }),
-      presets: v.pipe(v.array(TransformationPresetSchema), v.minLength(1)),
-      autoRunDefaultTransform: v.boolean()
+      presets: v.pipe(v.array(TransformationPresetSchema), v.minLength(1))
     }),
     v.check((val) => {
       const ids = new Set(val.presets.map((p) => p.id))
@@ -217,8 +216,7 @@ export const DEFAULT_SETTINGS: Settings = {
         userPrompt: '',
         shortcut: 'Cmd+Opt+L'
       }
-    ],
-    autoRunDefaultTransform: false
+    ]
   },
   output: {
     selectedTextSource: 'transformed',


### PR DESCRIPTION
## Summary

- **High**: Migration `migrateRemovedAutoRunDefaultTransform` previously dropped `autoRunDefaultTransform` without checking its value. Since `DEFAULT_SETTINGS.output.selectedTextSource` is `'transformed'`, users who had `autoRunDefaultTransform: false` would silently get capture-time transformation activated after upgrade — causing `transformation_failed` for anyone without a Google API key. Migration now maps `autoRunDefaultTransform=false` → `output.selectedTextSource='transcript'`.
- **Medium**: Added two regression tests in `settings-service.test.ts` covering both `false→transcript` and `true→unchanged` migration paths.
- **Low**: E2E autosave test cleanup now always clicks the `transcript` card before restoring `baselineTranscriptCopy`, preventing cross-test leakage when `baselineSource` is `'transformed'` (previously wrote transcript baseline into transformed settings).
- **Docs**: Updated `derived-transform-run-from-output-source.md` to document the corrected migration contract.

## Test plan

- [x] All 73 unit test files pass (`npx vitest run`)
- [x] Migration regression: `autoRunDefaultTransform=false` → `selectedTextSource='transcript'`
- [x] Migration regression: `autoRunDefaultTransform=true` → `selectedTextSource` unchanged
- [x] E2E autosave test cleanup scope is correct regardless of `baselineSource` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)