### PR TITLE
fix: activity feed uses terminal transform results only (#220)

### DIFF
--- a/docs/decisions/activity-feed-terminal-results-option-a.md
+++ b/docs/decisions/activity-feed-terminal-results-option-a.md
@@ -45,3 +45,5 @@ Adopt **Option A**.
 - Activity feed no longer acts as an operational event log.
 - Existing tests that asserted start/stop feed messages must assert terminal text cards instead.
 - Future expansion to per-step cards (Option B) remains possible with a new ticket and explicit contract update.
+- Follow-up issue #220 applies the same rule to standalone transform acknowledgements:
+  `Transformation enqueued.` is non-terminal and must not be appended to Activity.

--- a/src/main/core/command-router.ts
+++ b/src/main/core/command-router.ts
@@ -9,7 +9,13 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import type { AudioInputSource, CompositeTransformResult, RecordingCommand, RecordingCommandDispatch } from '../../shared/ipc'
+import {
+  COMPOSITE_TRANSFORM_ENQUEUED_MESSAGE,
+  type AudioInputSource,
+  type CompositeTransformResult,
+  type RecordingCommand,
+  type RecordingCommandDispatch
+} from '../../shared/ipc'
 import { resolveLlmBaseUrlOverride, resolveSttBaseUrlOverride, type Settings, type TransformationPreset } from '../../shared/domain'
 import { SELECTION_EMPTY_MESSAGE } from './transformation-error-messages'
 import type { CaptureResult } from '../services/capture-types'
@@ -181,7 +187,7 @@ export class CommandRouter {
     })
 
     this.transformQueue.enqueue(snapshot)
-    return { status: 'ok', message: 'Transformation enqueued.' }
+    return { status: 'ok', message: COMPOSITE_TRANSFORM_ENQUEUED_MESSAGE }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -43,6 +43,9 @@ export interface CompositeTransformResult {
   status: 'ok' | 'error'
   message: string
 }
+
+// Shared non-terminal transform acknowledgement text used by main+renderer.
+export const COMPOSITE_TRANSFORM_ENQUEUED_MESSAGE = 'Transformation enqueued.'
 export interface HotkeyErrorNotification {
   combo: string
   message: string


### PR DESCRIPTION
## Summary
- stop appending non-terminal transform acknowledgement (Transformation enqueued.) to Activity
- keep terminal transform success/failure entries in Activity
- share enqueue acknowledgement constant between main and renderer to avoid message drift
- document #220 behavior in the activity-feed terminal-results decision doc

## Tests
- CI=1 pnpm vitest src/renderer/renderer-app.test.ts src/renderer/activity-feed.test.ts src/main/core/command-router.test.ts

## Issue
- Closes #220