### PR TITLE
fix: normalize Option-modified shortcut labels (#225)

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -167,6 +167,7 @@ Behavior:
 - Recording commands exposed as global shortcuts **MUST** include `toggleRecording` and `cancelRecording`.
 - Invalid shortcut strings **SHOULD** be rejected with user-visible feedback.
 - Conflicting keybinds **SHOULD** be rejected with actionable validation feedback.
+- Shortcut capture UI **MUST** render Option-modified shortcuts with base key labels (for example `Opt+P`, `Opt+1`; not symbol substitutions like `Opt+π`).
 - If global shortcut registration fails at runtime, the app **MUST** show actionable user feedback and **MUST** keep UI command execution available.
 - Transformation shortcuts **MUST** be common across presets (not preset-specific).
 - The system **MUST** provide these transformation-related shortcuts:


### PR DESCRIPTION
## Summary
- normalize shortcut capture so Option-modified keys use semantic base labels (e.g. Opt+P, Opt+1)
- avoid symbol-substitution labels from Option key text output (e.g. Opt+π)
- preserve duplicate detection across legacy saved symbol shortcuts by canonicalizing known legacy Option symbols
- document shortcut-capture label expectation in spec section 4.2

## Tests
- CI=1 pnpm vitest src/renderer/shortcut-capture.test.ts src/renderer/settings-shortcut-editor-react.test.tsx src/renderer/settings-validation.test.ts

## Issue
- Closes #225