### PR TITLE
fix: play STT completion sound once across output modes (#228)

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -207,7 +207,9 @@ The app **MUST** play notification sounds for:
 - Recording started.
 - Recording stopped.
 - Recording cancelled.
-- Transformation finished (success or failure).
+- Successful capture completion.
+- Transformation failure when transformation was attempted and failed.
+- Successful capture completion **MUST** play the completion success sound exactly once regardless of `output.selectedTextSource` (`transcript` or `transformed`).
 
 Additional notes:
 - Distinct tones **SHOULD** be used for success vs failure.

--- a/src/main/orchestrators/capture-pipeline.ts
+++ b/src/main/orchestrators/capture-pipeline.ts
@@ -131,18 +131,6 @@ export function createCaptureProcessor(deps: CapturePipelineDeps): CaptureProces
       }
     }
 
-    if (attemptedTransformation) {
-      const transformationSoundEvent =
-        terminalStatus === 'transformation_failed'
-          ? 'transformation_failed'
-          : terminalStatus === 'succeeded'
-            ? 'transformation_succeeded'
-            : null
-      if (transformationSoundEvent !== null) {
-        deps.soundService?.play(transformationSoundEvent)
-      }
-    }
-
     // --- Stage 3: Ordered Output Commit ---
     // When transformation fails but transcript exists, still output the transcript (spec 6.2).
     if (transcriptText !== null) {
@@ -186,6 +174,16 @@ export function createCaptureProcessor(deps: CapturePipelineDeps): CaptureProces
       failureCategory,
       createdAt: new Date().toISOString()
     })
+
+    const completionSoundEvent =
+      terminalStatus === 'succeeded'
+        ? 'transformation_succeeded'
+        : attemptedTransformation && terminalStatus === 'transformation_failed'
+          ? 'transformation_failed'
+          : null
+    if (completionSoundEvent !== null) {
+      deps.soundService?.play(completionSoundEvent)
+    }
 
     return terminalStatus
   }


### PR DESCRIPTION
## Summary
- move completion sound dispatch to final terminal-status stage in capture pipeline
- play success completion sound exactly once for successful capture completion in both output modes (transcript and transformed)
- preserve transformation-failure sound only when transformation was attempted and failed
- add regression tests for transcript mode parity, single-call expectations, and no sound on failed completion paths
- clarify sound contract text in spec section 4.3

## Tests
- CI=1 pnpm vitest src/main/orchestrators/capture-pipeline.test.ts

## Issue
- Closes #228