### PR TITLE
feat(settings): autosave non-API fields and remove explicit save controls (#224)

### DIFF
--- a/docs/decisions/settings-non-api-autosave.md
+++ b/docs/decisions/settings-non-api-autosave.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/settings-non-api-autosave.md
+What: Decision record for non-API settings autosave behavior.
+Why: Ticket #224 changes persistence interaction and removes explicit non-API save controls.
+-->
+
+# Decision: Non-API Settings Autosave
+
+## Status
+Accepted - February 28, 2026
+
+## Context
+Non-API settings previously depended on explicit save actions and Enter-key coupling in settings forms. This created inconsistent UX across controls and added extra user steps for routine updates.
+
+## Decision
+- Non-API-key settings use debounced autosave (`450ms`) from field change handlers.
+- Non-API explicit save controls are removed from Shortcuts and Settings tabs.
+- API key fields remain manual-save and keep their dedicated validation-and-save flow.
+- Renderer validation blocks invalid non-API edits from being persisted and shows inline/save feedback.
+- On autosave failure for otherwise valid edits, renderer reverts to the last persisted valid settings snapshot and shows failure feedback.
+
+## Consequences
+- Persistence is immediate for non-secret controls without Enter/save click.
+- Failed invalid edits do not overwrite the last valid persisted value.
+- Save ownership is explicit by field class: non-API fields autosave; API keys manual save.

--- a/docs/settings-field-save-matrix.md
+++ b/docs/settings-field-save-matrix.md
@@ -1,0 +1,31 @@
+<!--
+Where: docs/settings-field-save-matrix.md
+What: Save-ownership matrix for settings fields under ticket #224.
+Why: Define which fields autosave vs manual-save to keep behavior explicit and testable.
+-->
+
+# Settings Field Save Matrix (#224)
+
+## Scope
+- Date: February 28, 2026
+- In scope: non-API-key settings fields in Shortcuts and Settings tabs
+- Out of scope: API key values and API key validation/save flow
+
+## Save Policy
+- Debounced autosave window for non-secret fields: `450ms`.
+- Autosave target: `window.speechToTextApi.setSettings(...)`.
+- Validation failure policy: block autosave in renderer for invalid non-API values, keep the last persisted valid snapshot unchanged, and surface inline + save feedback.
+
+| Area | Field(s) | Save Mode | Notes |
+|---|---|---|---|
+| Output | `selectedTextSource`, destination toggles (`copyToClipboard`, `pasteAtCursor`) | Autosave | Applies on toggle/radio change. |
+| Speech-to-Text | provider, model, base URL override | Autosave | Provider/model changes persist immediately (debounced). Invalid base URL values are blocked by renderer validation and not persisted. |
+| LLM Transformation | base URL override (default preset provider) | Autosave | Invalid URL values are blocked by renderer validation and not persisted. |
+| Audio Input | recording method, sample rate, audio device | Autosave | Device selection updates `autoDetectAudioSource` and `detectedAudioSource` before autosave. |
+| Shortcuts | all shortcut bindings | Autosave | No Enter-to-save coupling; edits persist automatically (debounced). |
+| API keys | provider API keys (Groq, ElevenLabs, Google) | Manual Save | Explicit provider-level `Save` action remains; includes connection validation before persistence. |
+
+## UI Contract
+- No non-API `Save Settings` control is rendered in Shortcuts or Settings tabs.
+- Enter key is not required for non-API settings persistence.
+- API key save controls remain manual and separate from autosave behavior.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -68,10 +68,8 @@ const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCal
   onResetTransformationBaseUrlDraft: vi.fn(),
   onChangeShortcutDraft: vi.fn(),
   onChangeOutputSelection: vi.fn(),
-  onSave: vi.fn().mockResolvedValue(undefined),
   onDismissToast: vi.fn(),
   isNativeRecording: vi.fn().mockReturnValue(false),
-  handleSettingsEnterSaveKeydown: vi.fn(),
   ...overrides
 })
 
@@ -246,5 +244,43 @@ describe('AppShell layout (STY-02)', () => {
 
     expect(host.querySelector('[data-toast-tone="success"]')?.textContent).toContain('Success')
     expect(host.querySelector('[data-toast-tone="error"]')?.textContent).toContain('Error')
+  })
+
+  it('does not render the non-API "Save Settings" button in Shortcuts or Settings tabs', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ activeTab: 'shortcuts' })} callbacks={buildCallbacks()} />)
+    await flush()
+    expect(host.textContent).not.toContain('Save Settings')
+
+    root.render(<AppShell state={buildState({ activeTab: 'settings' })} callbacks={buildCallbacks()} />)
+    await flush()
+    expect(host.textContent).not.toContain('Save Settings')
+  })
+
+  it('renders settings save/autosave feedback message on shortcuts and settings tabs', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <AppShell
+        state={buildState({ activeTab: 'shortcuts', settingsSaveMessage: 'Autosave failed: Disk full.' })}
+        callbacks={buildCallbacks()}
+      />
+    )
+    await flush()
+    expect(host.querySelector('[data-settings-save-message]')?.textContent).toContain('Autosave failed: Disk full.')
+
+    root.render(
+      <AppShell
+        state={buildState({ activeTab: 'settings', settingsSaveMessage: 'Settings autosaved.' })}
+        callbacks={buildCallbacks()}
+      />
+    )
+    await flush()
+    expect(host.querySelector('[data-settings-save-message]')?.textContent).toContain('Settings autosaved.')
   })
 })


### PR DESCRIPTION
## Summary\n- route non-API settings edits through debounced autosave callbacks (no Enter/save-button dependency)\n- validate non-API edits in renderer before autosave, surface inline/save feedback, and avoid persisting invalid URL/shortcut values\n- keep API key flow manual-save only and add save-feedback rendering for settings/shortcuts tabs\n- add docs: field save matrix and decision record for #224\n\n## Tests\n- pnpm test -- src/renderer/renderer-app.test.ts src/renderer/settings-endpoint-overrides-react.test.tsx src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/app-shell-react.test.tsx\n- pnpm typecheck\n\nCloses #224