### PR TITLE
refactor(settings): remove URL reset actions from settings UI (#227)

### DIFF
--- a/docs/decisions/settings-endpoint-overrides-react-slice.md
+++ b/docs/decisions/settings-endpoint-overrides-react-slice.md
@@ -15,8 +15,6 @@ Why: Keep one event owner per interaction path while continuing incremental rend
 - Move endpoint override control rendering and interaction ownership to a dedicated React component:
   - `#settings-transcription-base-url`
   - `#settings-transformation-base-url`
-  - `#settings-reset-transcription-base-url`
-  - `#settings-reset-transformation-base-url`
 - Keep existing selector IDs and form submit contract so validation/save flow remains unchanged.
 - Remove equivalent legacy reset-button listeners from `wireActions`.
 

--- a/docs/decisions/settings-remove-url-reset-actions.md
+++ b/docs/decisions/settings-remove-url-reset-actions.md
@@ -1,0 +1,23 @@
+<!--
+Where: docs/decisions/settings-remove-url-reset-actions.md
+What: Decision record for removing reset-to-default URL controls from Settings UI.
+Why: Ticket #227 removes reset actions and keeps URL management to direct edits only.
+-->
+
+# Decision: Remove URL Reset-to-Default Controls
+
+## Status
+Accepted - February 28, 2026
+
+## Context
+Settings exposed reset buttons for STT and LLM base URL override fields. The requested UI contract is to remove those reset actions and keep URL handling to direct field edits.
+
+## Decision
+- Remove `Reset STT URL to default` and `Reset LLM URL to default` controls.
+- Remove reset callback plumbing from AppShell and renderer orchestration.
+- Keep manual URL editing and autosave behavior unchanged.
+
+## Consequences
+- Users clear overrides by editing the URL input directly.
+- Settings component contracts are smaller (no reset callbacks for URL overrides).
+- Tests assert reset controls are absent while URL edit callbacks continue to function.

--- a/docs/decisions/stt-provider-unified-form.md
+++ b/docs/decisions/stt-provider-unified-form.md
@@ -40,7 +40,7 @@ All element IDs and `data-*` test hooks remain identical to the pre-refactor str
 - `[data-api-key-visibility-toggle="{provider}"]`
 - `[data-api-key-test="{provider}"]` / `[data-api-key-save="{provider}"]`
 - `#api-key-save-status-{provider}` / `#api-key-test-status-{provider}`
-- `#settings-transcription-base-url` / `#settings-reset-transcription-base-url`
+- `#settings-transcription-base-url`
 - `#settings-error-transcription-base-url`
 
 ## Model List Derivation

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -64,8 +64,6 @@ const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCal
   onRemovePresetAndSave: vi.fn().mockResolvedValue(true),
   onChangeTranscriptionBaseUrlDraft: vi.fn(),
   onChangeTransformationBaseUrlDraft: vi.fn(),
-  onResetTranscriptionBaseUrlDraft: vi.fn(),
-  onResetTransformationBaseUrlDraft: vi.fn(),
   onChangeShortcutDraft: vi.fn(),
   onChangeOutputSelection: vi.fn(),
   onDismissToast: vi.fn(),
@@ -282,5 +280,17 @@ describe('AppShell layout (STY-02)', () => {
     )
     await flush()
     expect(host.querySelector('[data-settings-save-message]')?.textContent).toContain('Settings autosaved.')
+  })
+
+  it('does not render URL reset controls in Settings tab', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ activeTab: 'settings' })} callbacks={buildCallbacks()} />)
+    await flush()
+
+    expect(host.querySelector('#settings-reset-transcription-base-url')).toBeNull()
+    expect(host.querySelector('#settings-reset-transformation-base-url')).toBeNull()
   })
 })

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -101,8 +101,6 @@ export interface AppShellCallbacks {
   onRemovePresetAndSave: (presetId: string) => Promise<boolean>
   onChangeTranscriptionBaseUrlDraft: (value: string) => void
   onChangeTransformationBaseUrlDraft: (value: string) => void
-  onResetTranscriptionBaseUrlDraft: () => void
-  onResetTransformationBaseUrlDraft: () => void
   onChangeShortcutDraft: (key: ShortcutKey, value: string) => void
   onChangeOutputSelection: (
     selection: OutputTextSource,
@@ -419,9 +417,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                     onChangeTranscriptionBaseUrlDraft={(value: string) => {
                       callbacks.onChangeTranscriptionBaseUrlDraft(value)
                     }}
-                    onResetTranscriptionBaseUrlDraft={() => {
-                      callbacks.onResetTranscriptionBaseUrlDraft()
-                    }}
                   />
                 </section>
 
@@ -444,9 +439,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                       transformationBaseUrlError={uiState.settingsValidationErrors.transformationBaseUrl ?? ''}
                       onChangeTransformationBaseUrlDraft={(value: string) => {
                         callbacks.onChangeTransformationBaseUrlDraft(value)
-                      }}
-                      onResetTransformationBaseUrlDraft={() => {
-                        callbacks.onResetTransformationBaseUrlDraft()
                       }}
                     />
                   </section>

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -510,41 +510,6 @@ const rerenderShellFromState = (): void => {
         }
       })
     },
-    onResetTranscriptionBaseUrlDraft: () => {
-      applyNonSecretAutosavePatch((current) => {
-        const provider = current.transcription.provider
-        return {
-          ...current,
-          transcription: {
-            ...current.transcription,
-            baseUrlOverrides: {
-              ...current.transcription.baseUrlOverrides,
-              [provider]: ''
-            }
-          }
-        }
-      })
-    },
-    onResetTransformationBaseUrlDraft: () => {
-      applyNonSecretAutosavePatch((current) => {
-        const defaultPreset =
-          current.transformation.presets.find((preset) => preset.id === current.transformation.defaultPresetId) ??
-          current.transformation.presets[0]
-        if (!defaultPreset) {
-          return current
-        }
-        return {
-          ...current,
-          transformation: {
-            ...current.transformation,
-            baseUrlOverrides: {
-              ...current.transformation.baseUrlOverrides,
-              [defaultPreset.provider]: ''
-            }
-          }
-        }
-      })
-    },
     onChangeShortcutDraft: (key, value) => {
       applyNonSecretAutosavePatch((current) => ({
         ...current,

--- a/src/renderer/settings-endpoint-overrides-react.test.tsx
+++ b/src/renderer/settings-endpoint-overrides-react.test.tsx
@@ -43,7 +43,6 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
           settings={DEFAULT_SETTINGS}
           transformationBaseUrlError=""
           onChangeTransformationBaseUrlDraft={vi.fn()}
-          onResetTransformationBaseUrlDraft={vi.fn()}
         />
       )
     })
@@ -66,7 +65,6 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
           settings={DEFAULT_SETTINGS}
           transformationBaseUrlError=""
           onChangeTransformationBaseUrlDraft={onChangeTransformationBaseUrlDraft}
-          onResetTransformationBaseUrlDraft={vi.fn()}
         />
       )
     })
@@ -89,7 +87,6 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
           settings={DEFAULT_SETTINGS}
           transformationBaseUrlError=""
           onChangeTransformationBaseUrlDraft={() => {}}
-          onResetTransformationBaseUrlDraft={() => {}}
         />
       )
     })
@@ -102,7 +99,6 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
           settings={DEFAULT_SETTINGS}
           transformationBaseUrlError="Transformation URL must use http:// or https://"
           onChangeTransformationBaseUrlDraft={() => {}}
-          onResetTransformationBaseUrlDraft={() => {}}
         />
       )
     })
@@ -110,12 +106,10 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
     expect(host.querySelector('#settings-error-transformation-base-url')?.textContent).toContain('must use http:// or https://')
   })
 
-  it('reset button calls onResetTransformationBaseUrlDraft', async () => {
+  it('does not render reset LLM URL control', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
-
-    const onResetTransformationBaseUrlDraft = vi.fn()
 
     await act(async () => {
       root?.render(
@@ -123,14 +117,10 @@ describe('SettingsEndpointOverridesReact (LLM URL only)', () => {
           settings={DEFAULT_SETTINGS}
           transformationBaseUrlError=""
           onChangeTransformationBaseUrlDraft={vi.fn()}
-          onResetTransformationBaseUrlDraft={onResetTransformationBaseUrlDraft}
         />
       )
     })
 
-    await act(async () => {
-      host.querySelector<HTMLButtonElement>('#settings-reset-transformation-base-url')?.click()
-    })
-    expect(onResetTransformationBaseUrlDraft).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('#settings-reset-transformation-base-url')).toBeNull()
   })
 })

--- a/src/renderer/settings-endpoint-overrides-react.tsx
+++ b/src/renderer/settings-endpoint-overrides-react.tsx
@@ -13,14 +13,12 @@ interface SettingsEndpointOverridesReactProps {
   settings: Settings
   transformationBaseUrlError: string
   onChangeTransformationBaseUrlDraft: (value: string) => void
-  onResetTransformationBaseUrlDraft: () => void
 }
 
 export const SettingsEndpointOverridesReact = ({
   settings,
   transformationBaseUrlError,
-  onChangeTransformationBaseUrlDraft,
-  onResetTransformationBaseUrlDraft
+  onChangeTransformationBaseUrlDraft
 }: SettingsEndpointOverridesReactProps) => {
   const defaultPreset =
     settings.transformation.presets.find((preset) => preset.id === settings.transformation.defaultPresetId) ??
@@ -53,19 +51,6 @@ export const SettingsEndpointOverridesReact = ({
       <p className="min-h-4 text-[10px] text-destructive" id="settings-error-transformation-base-url">
         {transformationBaseUrlError}
       </p>
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          id="settings-reset-transformation-base-url"
-          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
-          onClick={() => {
-            setTransformationBaseUrl('')
-            onResetTransformationBaseUrlDraft()
-          }}
-        >
-          Reset LLM URL to default
-        </button>
-      </div>
     </div>
   )
 }

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -45,8 +45,7 @@ const defaultProps = {
   onSelectTranscriptionProvider: vi.fn(),
   onSelectTranscriptionModel: vi.fn(),
   onSaveApiKey: vi.fn(async () => {}),
-  onChangeTranscriptionBaseUrlDraft: vi.fn(),
-  onResetTranscriptionBaseUrlDraft: vi.fn()
+  onChangeTranscriptionBaseUrlDraft: vi.fn()
 }
 
 describe('SettingsSttProviderFormReact', () => {
@@ -151,25 +150,18 @@ describe('SettingsSttProviderFormReact', () => {
     expect(onChangeTranscriptionBaseUrlDraft).toHaveBeenCalledWith('https://stt-proxy.local')
   })
 
-  it('reset STT URL button calls onResetTranscriptionBaseUrlDraft', async () => {
+  it('does not render reset STT URL control', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
-    const onResetTranscriptionBaseUrlDraft = vi.fn()
 
     await act(async () => {
       root?.render(
-        <SettingsSttProviderFormReact
-          {...defaultProps}
-          onResetTranscriptionBaseUrlDraft={onResetTranscriptionBaseUrlDraft}
-        />
+        <SettingsSttProviderFormReact {...defaultProps} />
       )
     })
 
-    await act(async () => {
-      host.querySelector<HTMLButtonElement>('#settings-reset-transcription-base-url')?.click()
-    })
-    expect(onResetTranscriptionBaseUrlDraft).toHaveBeenCalledTimes(1)
+    expect(host.querySelector('#settings-reset-transcription-base-url')).toBeNull()
   })
 
   it('shows save status message for the selected provider', async () => {

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -24,7 +24,6 @@ interface SettingsSttProviderFormReactProps {
   onSelectTranscriptionModel: (model: Settings['transcription']['model']) => void
   onSaveApiKey: (provider: ApiKeyProvider, candidateValue: string) => Promise<void>
   onChangeTranscriptionBaseUrlDraft: (value: string) => void
-  onResetTranscriptionBaseUrlDraft: () => void
 }
 
 const sttProviderOptions: Array<{ value: Settings['transcription']['provider']; label: string }> = [
@@ -42,8 +41,7 @@ export const SettingsSttProviderFormReact = ({
   onSelectTranscriptionProvider,
   onSelectTranscriptionModel,
   onSaveApiKey,
-  onChangeTranscriptionBaseUrlDraft,
-  onResetTranscriptionBaseUrlDraft
+  onChangeTranscriptionBaseUrlDraft
 }: SettingsSttProviderFormReactProps) => {
   const [selectedProvider, setSelectedProvider] = useState(settings.transcription.provider)
   const [selectedModel, setSelectedModel] = useState(settings.transcription.model)
@@ -189,19 +187,6 @@ export const SettingsSttProviderFormReact = ({
       <p className="min-h-4 text-[10px] text-destructive" id="settings-error-transcription-base-url">
         {baseUrlError}
       </p>
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          id="settings-reset-transcription-base-url"
-          className="h-7 rounded bg-secondary px-2 text-xs text-secondary-foreground transition-colors hover:bg-accent"
-          onClick={() => {
-            setBaseUrl('')
-            onResetTranscriptionBaseUrlDraft()
-          }}
-        >
-          Reset STT URL to default
-        </button>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary\n- remove STT and LLM URL reset-to-default controls from Settings UI\n- delete reset callback plumbing from AppShell and renderer callback wiring\n- keep direct URL edit behavior intact and align tests/docs with no-reset contract\n- update affected E2E contract test to manual clear flow\n\n## Tests\n- pnpm test -- src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/settings-endpoint-overrides-react.test.tsx src/renderer/app-shell-react.test.tsx src/renderer/renderer-app.test.ts\n- pnpm typecheck\n\nCloses #227