### PR TITLE
feat(activity): show transient copy success confirmation (#229)

### DIFF
--- a/docs/decisions/activity-copy-success-confirmation-state.md
+++ b/docs/decisions/activity-copy-success-confirmation-state.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/activity-copy-success-confirmation-state.md
+What: Decision record for temporary visual confirmation after Activity copy action succeeds.
+Why: Ticket #229 adds explicit copy success feedback without changing activity data contracts.
+-->
+
+# Decision: Activity Copy Success Confirmation State
+
+## Status
+Accepted - February 28, 2026
+
+## Context
+The Activity tab copy action had no clear success acknowledgment. Users could click copy with no immediate visual confirmation.
+
+## Decision
+- Add per-activity-item transient copy-success UI state.
+- Switch copy button icon from copy to checkmark only when clipboard write succeeds.
+- Auto-reset the confirmation after a short timeout (`1500ms`).
+- Keep failure behavior unchanged: no false success indication on clipboard errors.
+- Manage timers at feed level and clear them on unmount.
+
+## Consequences
+- Copy success is explicit and immediate.
+- Repeated copy clicks extend the confirmation window for the latest action.
+- Timer cleanup prevents stale state updates after unmount.

--- a/src/renderer/activity-feed-react.test.tsx
+++ b/src/renderer/activity-feed-react.test.tsx
@@ -8,21 +8,41 @@
 // @vitest-environment jsdom
 
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActivityItem } from './activity-feed'
 import { ActivityFeedReact } from './activity-feed-react'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 const flush = async (): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, 0)
   })
 
+const flushWithFakeTimers = async (): Promise<void> => {
+  await act(async () => {
+    vi.advanceTimersByTime(0)
+    await Promise.resolve()
+  })
+}
+
 let root: Root | null = null
+let writeTextSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  writeTextSpy = vi.fn(async () => {})
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextSpy },
+    configurable: true
+  })
+})
 
 afterEach(() => {
   root?.unmount()
   root = null
   document.body.innerHTML = ''
+  vi.useRealTimers()
 })
 
 const makeItem = (overrides: Partial<ActivityItem>): ActivityItem => ({
@@ -154,5 +174,137 @@ describe('ActivityFeedReact (STY-04)', () => {
     const log = host.querySelector('[role="log"]')
     expect(log).not.toBeNull()
     expect(log?.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('shows copied confirmation on successful copy and resets after timeout', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ActivityFeedReact activity={[makeItem({ id: 99, message: 'Copy me' })]} />)
+    await flush()
+
+    const button = host.querySelector<HTMLButtonElement>('button[aria-label="Copy message"]')
+    vi.useFakeTimers()
+    expect(button?.getAttribute('data-copy-state')).toBe('idle')
+    await act(async () => {
+      button?.click()
+    })
+    await flushWithFakeTimers()
+
+    expect(writeTextSpy).toHaveBeenCalledWith('Copy me')
+    expect(button?.getAttribute('data-copy-state')).toBe('copied')
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    await flushWithFakeTimers()
+    expect(button?.getAttribute('data-copy-state')).toBe('idle')
+  })
+
+  it('does not show copied confirmation when clipboard write fails', async () => {
+    writeTextSpy = vi.fn(async () => {
+      throw new Error('clipboard unavailable')
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextSpy },
+      configurable: true
+    })
+
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ActivityFeedReact activity={[makeItem({ id: 100, message: 'No copy' })]} />)
+    await flush()
+
+    const button = host.querySelector<HTMLButtonElement>('button[aria-label="Copy message"]')
+    button?.click()
+    await flush()
+
+    expect(writeTextSpy).toHaveBeenCalledWith('No copy')
+    expect(button?.getAttribute('data-copy-state')).toBe('idle')
+  })
+
+  it('keeps confirmation until the latest timer after rapid recopy', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ActivityFeedReact activity={[makeItem({ id: 101, message: 'Rapid copy' })]} />)
+    await flush()
+
+    const button = host.querySelector<HTMLButtonElement>('button[aria-label="Copy message"]')
+    vi.useFakeTimers()
+    await act(async () => {
+      button?.click()
+    })
+    await flushWithFakeTimers()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+      button?.click()
+    })
+    await flushWithFakeTimers()
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+    await flushWithFakeTimers()
+    expect(button?.getAttribute('data-copy-state')).toBe('copied')
+
+    await act(async () => {
+      vi.advanceTimersByTime(900)
+    })
+    await flushWithFakeTimers()
+    expect(button?.getAttribute('data-copy-state')).toBe('idle')
+  })
+
+  it('clears pending copy-reset timer on unmount', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ActivityFeedReact activity={[makeItem({ id: 102, message: 'Unmount copy' })]} />)
+    await flush()
+
+    vi.useFakeTimers()
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    await act(async () => {
+      host.querySelector<HTMLButtonElement>('button[aria-label="Copy message"]')?.click()
+    })
+    await flushWithFakeTimers()
+    root?.unmount()
+    root = null
+    vi.runAllTimers()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  it('keeps copy confirmation state isolated to the copied row', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ActivityFeedReact
+        activity={[
+          makeItem({ id: 201, message: 'First row' }),
+          makeItem({ id: 202, message: 'Second row' })
+        ]}
+      />
+    )
+    await flush()
+
+    const buttons = host.querySelectorAll<HTMLButtonElement>('button[aria-label="Copy message"]')
+    expect(buttons).toHaveLength(2)
+    vi.useFakeTimers()
+
+    await act(async () => {
+      buttons[0].click()
+    })
+    await flushWithFakeTimers()
+
+    expect(buttons[0].getAttribute('data-copy-state')).toBe('copied')
+    expect(buttons[1].getAttribute('data-copy-state')).toBe('idle')
   })
 })


### PR DESCRIPTION
## Summary\n- add per-activity-item copy success confirmation state in Activity tab\n- show checkmark only after successful clipboard write and auto-reset to copy icon after 1.5s\n- clean up timers on unmount and prune stale state/timers when activity rows change\n- add tests for success/reset, failure path, rapid recopy timing, unmount cleanup, and row isolation\n- add decision record for the behavior contract\n\n## Tests\n- pnpm test -- src/renderer/activity-feed-react.test.tsx\n- pnpm typecheck\n\nCloses #229