### PR TITLE
docs(shortcuts): remove shortcut-contract table formatting from docs/spec (#223)

### DIFF
--- a/docs/decisions/shortcut-contract-doc-table-removal.md
+++ b/docs/decisions/shortcut-contract-doc-table-removal.md
@@ -1,0 +1,24 @@
+<!--
+Where: docs/decisions/shortcut-contract-doc-table-removal.md
+What: Decision record for removing shortcut-contract table formatting from docs/spec artifacts.
+Why: Ticket #223 requests removal of Shortcut Contract tables while preserving clear shortcut guidance.
+-->
+
+# Decision: Remove Shortcut Contract Tables from Docs/Spec
+
+## Status
+Accepted - February 28, 2026
+
+## Context
+Shortcut guidance in docs included a table-oriented presentation for dedicated-tab rationale and wording that referred to shortcut contract table UI. The change request for #223 is to remove Shortcut Contract tables from docs/spec while keeping guidance clear.
+
+## Decision
+- Replace shortcut-contract table formatting with concise narrative guidance.
+- Keep shortcut behavior descriptions and selectors/callback notes intact.
+- Keep unrelated tables (for non-shortcut topics) unchanged.
+
+## Audit Evidence
+Run from repo root:
+- `rg -n "formatted keybind table|\|\s*Criterion\s*\|\s*Before\s*\|\s*After\s*\|" docs specs -S -g '!docs/github-issues-220-229-work-plan.md' -g '!docs/decisions/shortcut-contract-doc-table-removal.md'`
+
+Expected result after this change: no hits for that pattern in docs/spec.

--- a/docs/decisions/shortcuts-dedicated-tab.md
+++ b/docs/decisions/shortcuts-dedicated-tab.md
@@ -18,7 +18,7 @@ The Settings tab was growing long. It contained four unrelated categories:
 2. Speech-to-text provider config
 3. LLM transformation base URL override
 4. Audio input device
-5. **Global keyboard shortcuts** (start/stop/toggle recording, run transform, etc.)
+5. **Global keyboard shortcuts** (historical pre-#203 scope: start/stop/toggle recording, run transform, etc.)
 
 The shortcuts section is conceptually distinct from the per-session tuning options above it. Users configure shortcuts infrequently and separately from provider credentials or output routing. Having it at the bottom of a long scrollable Settings panel made it easy to overlook.
 
@@ -27,20 +27,18 @@ The shortcuts section is conceptually distinct from the per-session tuning optio
 Add a dedicated **Shortcuts** tab (4th in the tab rail, between Profiles and Settings) that hosts:
 
 - `SettingsShortcutEditorReact` — per-shortcut text inputs with inline validation
-- `SettingsShortcutsReact` — read-only contract display (formatted keybind table)
+- `SettingsShortcutsReact` — read-only contract display (formatted keybind list)
 - `SettingsSaveReact` — Save / autosave message (Enter-key handler also wired)
 
 Remove the `<section data-settings-section="global-shortcuts">` block and the preceding `<hr>` from the Settings tab.
 
 ## Rationale
 
-| Criterion | Before | After |
-|---|---|---|
-| Settings tab length | Long (5 sections + Save) | Shorter (4 sections + Save) |
-| Discoverability of shortcuts | Buried at bottom of Settings | Dedicated tab label visible at all times |
-| Keyboard navigation | Enter-to-save worked | Enter-to-save preserved in Shortcuts tab |
-| IDs / callback contracts | — | Unchanged — no breaking changes |
-| Test coverage | Verified in app-shell test | Verified with new dedicated placement test |
+- Settings tab length is reduced by moving shortcut controls to a dedicated tab.
+- Shortcut discoverability improves because the tab label is always visible.
+- Keyboard navigation behavior remains unchanged (`Enter` save behavior preserved).
+- IDs and callback contracts remain unchanged (no breaking selector or callback change).
+- Test coverage remains explicit through app-shell placement and navigation assertions.
 
 ## Alternatives Considered
 

--- a/docs/decisions/shortcuts-remove-start-stop-recording.md
+++ b/docs/decisions/shortcuts-remove-start-stop-recording.md
@@ -39,6 +39,6 @@ This ensures existing settings files load safely and the persisted contract conv
 ## Impact
 
 - Shortcuts UI no longer renders start/stop input fields.
-- Shortcut Contract panel no longer lists start/stop actions.
+- Shortcut list guidance no longer includes start/stop actions.
 - Global hotkey registration no longer attempts start/stop bindings.
 - Existing start/stop recording commands remain available through runtime command paths (non-shortcut flows).


### PR DESCRIPTION
## Summary
- remove shortcut-contract table formatting from docs/spec artifacts and replace with concise narrative guidance
- align shortcut wording with post-#203 behavior (start/stop removal reflected as historical context)
- add decision record documenting scope and grep-audit approach for #223

## Audit Commands
- rg -n "formatted keybind table|\|\s*Criterion\s*\|\s*Before\s*\|\s*After\s*\|" docs specs -S -g '!docs/github-issues-220-229-work-plan.md' -g '!docs/decisions/shortcut-contract-doc-table-removal.md'

## Audit Result
- no matches

Closes #223