### PR TITLE
fix: block recording shortcut actions during keybind capture (#250)

### DIFF
--- a/docs/decisions/shortcut-keybind-capture-mode.md
+++ b/docs/decisions/shortcut-keybind-capture-mode.md
@@ -6,7 +6,7 @@ Why: Align shortcut editing with explicit key capture, modifier requirement, and
 
 # Shortcut Keybind Capture Mode — Decision Record
 
-**Issue:** #202  
+**Issue:** #202, #250  
 **Date:** 2026-02-28  
 **Status:** Implemented
 
@@ -29,6 +29,10 @@ Use explicit recording-mode capture for shortcut fields in the Shortcuts tab:
 - active row shows a recording-state hint
 - `Escape` cancels capture mode; valid shortcut modifiers remain `Cmd/Ctrl/Opt/Shift`.
 
+While any shortcut row is in capture mode, renderer-side recording-command dispatch from
+global shortcuts is suppressed. This prevents existing hotkeys from starting/stopping
+recording while the user is editing shortcut bindings.
+
 ## Validation Contract
 
 - Save-time validation now also enforces at least one modifier per shortcut string.
@@ -38,3 +42,4 @@ Use explicit recording-mode capture for shortcut fields in the Shortcuts tab:
 
 - Shortcut editor inputs are now read-only capture targets instead of free-form text fields.
 - Captured shortcuts normalize to the renderer format consumed by hotkey mapping (`Cmd/Ctrl/Opt/Shift + key`).
+- Recording-command dispatch resumes immediately when capture mode exits.

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -84,6 +84,7 @@ export interface AppShellState {
 export interface AppShellCallbacks {
   onNavigate: (tab: AppTab) => void
   onRunRecordingCommand: (command: RecordingCommand) => void
+  onShortcutCaptureActiveChange: (isActive: boolean) => void
   onOpenSettings: () => void
   onSaveApiKey: (provider: ApiKeyProvider, candidateValue: string) => Promise<void>
   onRefreshAudioSources: () => Promise<void>
@@ -369,6 +370,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                   ) => {
                     callbacks.onChangeShortcutDraft(key, value)
                   }}
+                  onCaptureStateChange={callbacks.onShortcutCaptureActiveChange}
                 />
                 <SettingsShortcutsReact shortcuts={buildShortcutContract(uiState.settings)} />
               </section>

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -68,6 +68,7 @@ const state = {
   audioInputSources: [] as AudioInputSource[],
   audioSourceHint: '',
   hasCommandError: false,
+  isShortcutCaptureActive: false,
   settingsValidationErrors: {} as SettingsValidationErrors,
   persistedSettings: null as Settings | null,
   autosaveTimer: null as ReturnType<typeof setTimeout> | null,
@@ -421,6 +422,13 @@ const rerenderShellFromState = (): void => {
     onRunRecordingCommand: (command) => {
       void runRecordingCommandAction(command)
     },
+    onShortcutCaptureActiveChange: (isActive) => {
+      if (state.isShortcutCaptureActive === isActive) {
+        return
+      }
+      state.isShortcutCaptureActive = isActive
+      rerenderShellFromState()
+    },
     onOpenSettings: openSettingsRoute,
     onSaveApiKey: (provider, candidateValue) => mutations.saveApiKey(provider, candidateValue),
     onRefreshAudioSources: async () => {
@@ -576,6 +584,9 @@ const render = async (): Promise<void> => {
     wireIpcListeners({
       onCompositeTransformResult: (result) => applyCompositeResult(result),
       onRecordingCommand: (dispatch: RecordingCommandDispatch) => {
+        if (state.isShortcutCaptureActive && state.activeTab === 'shortcuts') {
+          return
+        }
         void handleRecordingCommandDispatch(buildRecordingDeps(), dispatch)
       },
       onHotkeyError: (notification: HotkeyErrorNotification) => {
@@ -629,6 +640,7 @@ export const stopRendererAppForTests = (): void => {
   state.audioInputSources = []
   state.audioSourceHint = ''
   state.hasCommandError = false
+  state.isShortcutCaptureActive = false
   state.settingsValidationErrors = {}
   state.persistedSettings = null
   state.autosaveGeneration = 0

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -22,6 +22,7 @@ interface SettingsShortcutEditorReactProps {
   settings: Settings
   validationErrors: Partial<Record<ShortcutKey, string>>
   onChangeShortcutDraft: (key: ShortcutKey, value: string) => void
+  onCaptureStateChange?: (isActive: boolean) => void
 }
 
 interface ShortcutFieldConfig {
@@ -82,9 +83,12 @@ const buildShortcutDraftFromSettings = (settings: Settings): Record<ShortcutKey,
 export const SettingsShortcutEditorReact = ({
   settings,
   validationErrors,
-  onChangeShortcutDraft
+  onChangeShortcutDraft,
+  onCaptureStateChange
 }: SettingsShortcutEditorReactProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const onCaptureStateChangeRef = useRef(onCaptureStateChange)
+  const lastCaptureActiveRef = useRef(false)
   const [shortcutDraft, setShortcutDraft] = useState<Record<ShortcutKey, string>>(buildShortcutDraftFromSettings(settings))
   const [capturingKey, setCapturingKey] = useState<ShortcutKey | null>(null)
   const [captureErrors, setCaptureErrors] = useState<Partial<Record<ShortcutKey, string>>>({})
@@ -102,6 +106,22 @@ export const SettingsShortcutEditorReact = ({
     settings.shortcuts.pickTransformation,
     settings.shortcuts.changeTransformationDefault
   ])
+
+  useEffect(() => {
+    onCaptureStateChangeRef.current = onCaptureStateChange
+  }, [onCaptureStateChange])
+
+  useEffect(
+    () => {
+      const isCaptureActive = capturingKey !== null
+      if (lastCaptureActiveRef.current === isCaptureActive) {
+        return
+      }
+      lastCaptureActiveRef.current = isCaptureActive
+      onCaptureStateChangeRef.current?.(isCaptureActive)
+    },
+    [capturingKey]
+  )
 
   const beginCapture = (key: ShortcutKey): void => {
     setCapturingKey(key)


### PR DESCRIPTION
## Summary
- suppress renderer recording-command dispatch while shortcut capture is active in the Shortcuts tab
- propagate capture state from `SettingsShortcutEditorReact` through `AppShell` into renderer orchestration
- add regression tests for suppression/resume behavior and capture-state transitions
- update shortcut capture decision doc with the suppression contract

## Testing
- pnpm vitest run src/renderer/settings-shortcut-editor-react.test.tsx src/renderer/renderer-app.test.ts src/renderer/app-shell-react.test.tsx src/renderer/native-recording.test.ts

Closes #250
