### PR TITLE
feat(settings): show autosave success via toast (#246)

### DIFF
--- a/docs/decisions/autosave-success-toast.md
+++ b/docs/decisions/autosave-success-toast.md
@@ -1,0 +1,23 @@
+<!--
+Where: docs/decisions/autosave-success-toast.md
+What: Decision record for autosave success feedback channel.
+Why: Issue #246 replaces inline autosave success text with toast feedback.
+-->
+
+# Decision: Autosave Success Uses Toast Feedback (#246)
+
+**Date**: 2026-03-01  
+**Status**: Accepted  
+**Ticket**: #246
+
+## Decision
+
+For non-secret settings autosave success:
+- emit toast text exactly `Settings autosaved.`;
+- do not set inline save-status message for success;
+- keep inline and toast error behavior for autosave failures.
+
+## Consequences
+
+- success feedback is consistent with other transient success actions;
+- failure states remain visible/actionable in inline status surfaces.

--- a/docs/settings-field-save-matrix.md
+++ b/docs/settings-field-save-matrix.md
@@ -14,13 +14,13 @@ Why: Define which fields autosave vs manual-save to keep behavior explicit and t
 ## Save Policy
 - Debounced autosave window for non-secret fields: `450ms`.
 - Autosave target: `window.speechToTextApi.setSettings(...)`.
-- Validation failure policy: block autosave in renderer for invalid non-API values, keep the last persisted valid snapshot unchanged, and surface inline + save feedback.
+- Validation failure policy: block autosave in renderer for invalid non-API values, keep the last persisted valid snapshot unchanged, and surface failure feedback.
 
 | Area | Field(s) | Save Mode | Notes |
 |---|---|---|---|
 | Output | `selectedTextSource`, destination toggles (`copyToClipboard`, `pasteAtCursor`) | Autosave | Applies on toggle/radio change. |
-| Speech-to-Text | provider, model, base URL override | Autosave | Provider/model changes persist immediately (debounced). Invalid base URL values are blocked by renderer validation and not persisted. |
-| LLM Transformation | base URL override (default preset provider) | Autosave | Invalid URL values are blocked by renderer validation and not persisted. |
+| Speech-to-Text | provider, model | Autosave | Provider/model changes persist immediately (debounced). |
+| LLM Transformation | default profile prompt/model edits | Manual Save | Profile edits remain explicit save actions. |
 | Audio Input | recording method, sample rate, audio device | Autosave | Device selection updates `autoDetectAudioSource` and `detectedAudioSource` before autosave. |
 | Shortcuts | all shortcut bindings | Autosave | No Enter-to-save coupling; edits persist automatically (debounced). |
 | API keys | provider API keys (Groq, ElevenLabs, Google) | Manual Save | Explicit provider-level `Save` action remains; includes connection validation before persistence. |
@@ -28,4 +28,5 @@ Why: Define which fields autosave vs manual-save to keep behavior explicit and t
 ## UI Contract
 - No non-API `Save Settings` control is rendered in Shortcuts or Settings tabs.
 - Enter key is not required for non-API settings persistence.
+- Autosave success feedback is toast-only (`Settings autosaved.`), not inline.
 - API key save controls remain manual and separate from autosave behavior.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -256,7 +256,7 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.textContent).not.toContain('Save Settings')
   })
 
-  it('renders settings save/autosave feedback message on shortcuts and settings tabs', async () => {
+  it('renders inline settings feedback only for non-success messages on shortcuts/settings tabs', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -272,12 +272,12 @@ describe('AppShell layout (STY-02)', () => {
 
     root.render(
       <AppShell
-        state={buildState({ activeTab: 'settings', settingsSaveMessage: 'Settings autosaved.' })}
+        state={buildState({ activeTab: 'settings', settingsSaveMessage: '' })}
         callbacks={buildCallbacks()}
       />
     )
     await flush()
-    expect(host.querySelector('[data-settings-save-message]')?.textContent).toContain('Settings autosaved.')
+    expect(host.querySelector('[data-settings-save-message]')).toBeNull()
   })
 
   it('does not render URL reset controls in Settings tab', async () => {

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -214,7 +214,7 @@ describe('renderer app', () => {
     expect(mountPoint.textContent).toContain('Recording is blocked because the Groq API key is missing.')
   })
 
-  it('autosaves non-API settings after field change without Enter or explicit save click', async () => {
+  it('autosave success shows toast and does not render inline success message', async () => {
     const mountPoint = document.createElement('div')
     mountPoint.id = 'app'
     document.body.append(mountPoint)
@@ -239,6 +239,11 @@ describe('renderer app', () => {
       'autosave dispatch after non-API settings change',
       () => harness.setSettingsSpy.mock.calls.length > beforeCalls
     )
+    await waitForCondition(
+      'autosave success toast',
+      () => (mountPoint.textContent ?? '').includes('Settings autosaved.')
+    )
+    expect(mountPoint.querySelector('[data-settings-save-message]')?.textContent ?? '').not.toContain('Settings autosaved.')
   })
 
   it('keeps the active tab when autosave fails for a valid shortcut update', async () => {

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -224,8 +224,9 @@ const runNonSecretAutosave = async (generation: number, nextSettings: Settings):
     }
     state.settings = saved
     state.persistedSettings = structuredClone(saved)
-    state.settingsSaveMessage = 'Settings autosaved.'
+    state.settingsSaveMessage = ''
     rerenderShellFromState()
+    addToast('Settings autosaved.', 'success')
   } catch (error) {
     if (generation !== state.autosaveGeneration) {
       return


### PR DESCRIPTION
Closes #246\n\nMoves autosave success feedback to toast text `Settings autosaved.` and removes inline success message behavior.\n\nValidation:\n- pnpm vitest src/renderer/renderer-app.test.ts src/renderer/app-shell-react.test.tsx src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-stt-provider-form-react.test.tsx