### PR TITLE
feat(settings): move Audio Input to dedicated tab (#251)

### DIFF
--- a/docs/decisions/audio-input-dedicated-tab.md
+++ b/docs/decisions/audio-input-dedicated-tab.md
@@ -1,0 +1,21 @@
+<!--
+Where: docs/decisions/audio-input-dedicated-tab.md
+What: Decision record for moving Audio Input controls to their own workspace tab.
+Why: Issue #251 requests dedicated IA placement for recording device controls.
+-->
+
+# Decision: Audio Input Gets Dedicated Tab (#251)
+
+**Date**: 2026-03-01  
+**Status**: Accepted  
+**Ticket**: #251
+
+## Decision
+
+Introduce `audio-input` as a first-class workspace tab adjacent to `shortcuts` and mount `SettingsRecordingReact` there.
+
+## Consequences
+
+- Settings tab no longer contains audio-input section;
+- recording method/sample-rate/device controls keep existing IDs and callback contracts;
+- tab model becomes: `activity | profiles | shortcuts | audio-input | settings`.

--- a/docs/decisions/shortcuts-dedicated-tab.md
+++ b/docs/decisions/shortcuts-dedicated-tab.md
@@ -16,7 +16,7 @@ The Settings tab was growing long. It contained four unrelated categories:
 
 1. Output matrix
 2. Speech-to-text provider config
-3. LLM transformation base URL override
+3. LLM transformation provider credentials
 4. Audio input device
 5. **Global keyboard shortcuts** (historical pre-#203 scope: start/stop/toggle recording, run transform, etc.)
 
@@ -24,11 +24,10 @@ The shortcuts section is conceptually distinct from the per-session tuning optio
 
 ## Decision
 
-Add a dedicated **Shortcuts** tab (4th in the tab rail, between Profiles and Settings) that hosts:
+Add a dedicated **Shortcuts** tab (between Profiles and Settings) that hosts:
 
 - `SettingsShortcutEditorReact` — per-shortcut text inputs with inline validation
-- `SettingsShortcutsReact` — read-only contract display (formatted keybind list)
-- `SettingsSaveReact` — Save / autosave message (Enter-key handler also wired)
+- (historical) `SettingsShortcutsReact` contract display, later removed in #245
 
 Remove the `<section data-settings-section="global-shortcuts">` block and the preceding `<hr>` from the Settings tab.
 
@@ -48,7 +47,7 @@ Remove the `<section data-settings-section="global-shortcuts">` block and the pr
 
 ## Impact
 
-- `AppTab` type gains `'shortcuts'` variant: `'activity' | 'profiles' | 'shortcuts' | 'settings'`
+- `AppTab` includes `'shortcuts'`; after #251 tab model is `'activity' | 'profiles' | 'shortcuts' | 'audio-input' | 'settings'`
 - All `#settings-shortcut-*` element IDs are **preserved unchanged** (no downstream breakage)
 - `onChangeShortcutDraft` / `handleSettingsEnterSaveKeydown` callbacks remain on `AppShellCallbacks` unchanged
 - E2E tests updated: shortcut-editor assertions navigate to `[data-route-tab="shortcuts"]`; autosave test navigates to Shortcuts tab before filling shortcut inputs

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -109,7 +109,7 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.querySelector('footer')).not.toBeNull()
   })
 
-  it('renders three tab buttons — activity, profiles, settings', async () => {
+  it('renders tab buttons for activity, profiles, shortcuts, audio input, and settings', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -117,13 +117,13 @@ describe('AppShell layout (STY-02)', () => {
     root.render(<AppShell state={buildState()} callbacks={buildCallbacks()} />)
     await flush()
 
-    const tabs = ['activity', 'profiles', 'shortcuts', 'settings'] satisfies AppTab[]
+    const tabs = ['activity', 'profiles', 'shortcuts', 'audio-input', 'settings'] satisfies AppTab[]
     for (const tab of tabs) {
       expect(host.querySelector(`[data-route-tab="${tab}"]`)).not.toBeNull()
     }
   })
 
-  it('renders Settings IA sections in STY-06a order', async () => {
+  it('renders Settings IA sections without audio input section', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -131,15 +131,15 @@ describe('AppShell layout (STY-02)', () => {
     root.render(<AppShell state={buildState({ activeTab: 'settings' })} callbacks={buildCallbacks()} />)
     await flush()
 
-    const sectionOrder = Array.from(host.querySelectorAll('[data-settings-section]')).map((node) =>
+    const settingsPanel = host.querySelector('[data-tab-panel="settings"]')
+    const sectionOrder = Array.from(settingsPanel?.querySelectorAll('[data-settings-section]') ?? []).map((node) =>
       node.getAttribute('data-settings-section')
     )
     // global-shortcuts section moved to dedicated Shortcuts tab (#200)
     expect(sectionOrder).toEqual([
       'output',
       'speech-to-text',
-      'llm-transformation',
-      'audio-input'
+      'llm-transformation'
     ])
   })
 
@@ -203,10 +203,22 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.querySelector('[data-tab-panel="shortcuts"] #settings-shortcut-toggle-recording')).not.toBeNull()
     expect(host.querySelector('[data-tab-panel="settings"] #settings-shortcut-toggle-recording')).toBeNull()
     // Settings section list does not include global-shortcuts
-    const settingsSections = Array.from(host.querySelectorAll('[data-settings-section]')).map((n) =>
-      n.getAttribute('data-settings-section')
-    )
+    const settingsSections = Array.from(
+      host.querySelectorAll('[data-tab-panel="settings"] [data-settings-section]')
+    ).map((n) => n.getAttribute('data-settings-section'))
     expect(settingsSections).not.toContain('global-shortcuts')
+  })
+
+  it('renders Audio Input controls only in the Audio Input tab panel', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<AppShell state={buildState({ activeTab: 'audio-input' })} callbacks={buildCallbacks()} />)
+    await flush()
+
+    expect(host.querySelector('[data-tab-panel="audio-input"] [data-settings-section="audio-input"]')).not.toBeNull()
+    expect(host.querySelector('[data-tab-panel="settings"] [data-settings-section="audio-input"]')).toBeNull()
   })
 
   it('shows null settings error state when settings are unavailable', async () => {

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -50,7 +50,7 @@ export interface ToastItem {
 }
 
 // UI-local tab model — does not affect business state or IPC contracts.
-export type AppTab = 'activity' | 'profiles' | 'shortcuts' | 'settings'
+export type AppTab = 'activity' | 'profiles' | 'shortcuts' | 'audio-input' | 'settings'
 
 // Shortcut key union used in onChangeShortcutDraft; mirrors the shortcuts object keys.
 type ShortcutKey =
@@ -278,6 +278,13 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               onNavigate={callbacks.onNavigate}
             />
             <TabButton
+              tab="audio-input"
+              activeTab={uiState.activeTab}
+              icon={Mic}
+              label="Audio Input"
+              onNavigate={callbacks.onNavigate}
+            />
+            <TabButton
               tab="settings"
               activeTab={uiState.activeTab}
               icon={SettingsIcon}
@@ -374,6 +381,45 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
             </div>
           </div>
 
+          {/* Audio Input tab */}
+          <div
+            data-tab-panel="audio-input"
+            className={cn(
+              'flex flex-1 flex-col overflow-y-auto',
+              uiState.activeTab !== 'audio-input' && 'hidden'
+            )}
+          >
+            <div className="p-4">
+              <section className="mt-4 space-y-4" data-settings-form>
+                <section data-settings-section="audio-input">
+                  <SettingsSectionHeader icon={Mic} title="Audio Input" />
+                  <SettingsRecordingReact
+                    section="audio-input"
+                    settings={uiState.settings}
+                    audioInputSources={uiState.audioInputSources.length > 0 ? uiState.audioInputSources : [SYSTEM_DEFAULT_AUDIO_SOURCE]}
+                    audioSourceHint={uiState.audioSourceHint}
+                    onRefreshAudioSources={callbacks.onRefreshAudioSources}
+                    onSelectRecordingMethod={(method: Settings['recording']['method']) => {
+                      callbacks.onSelectRecordingMethod(method)
+                    }}
+                    onSelectRecordingSampleRate={(sampleRateHz: Settings['recording']['sampleRateHz']) => {
+                      callbacks.onSelectRecordingSampleRate(sampleRateHz)
+                    }}
+                    onSelectRecordingDevice={(deviceId: string) => {
+                      callbacks.onSelectRecordingDevice(deviceId)
+                    }}
+                    onSelectTranscriptionProvider={(provider: Settings['transcription']['provider']) => {
+                      callbacks.onSelectTranscriptionProvider(provider)
+                    }}
+                    onSelectTranscriptionModel={(model: Settings['transcription']['model']) => {
+                      callbacks.onSelectTranscriptionModel(model)
+                    }}
+                  />
+                </section>
+              </section>
+            </div>
+          </div>
+
           {/* Settings tab */}
           <div
             data-tab-panel="settings"
@@ -430,35 +476,6 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                     />
                   </section>
                 </section>
-
-                <hr className="my-4 border-border" />
-
-                <section data-settings-section="audio-input">
-                  <SettingsSectionHeader icon={Mic} title="Audio Input" />
-                  <SettingsRecordingReact
-                    section="audio-input"
-                    settings={uiState.settings}
-                    audioInputSources={uiState.audioInputSources.length > 0 ? uiState.audioInputSources : [SYSTEM_DEFAULT_AUDIO_SOURCE]}
-                    audioSourceHint={uiState.audioSourceHint}
-                    onRefreshAudioSources={callbacks.onRefreshAudioSources}
-                    onSelectRecordingMethod={(method: Settings['recording']['method']) => {
-                      callbacks.onSelectRecordingMethod(method)
-                    }}
-                    onSelectRecordingSampleRate={(sampleRateHz: Settings['recording']['sampleRateHz']) => {
-                      callbacks.onSelectRecordingSampleRate(sampleRateHz)
-                    }}
-                    onSelectRecordingDevice={(deviceId: string) => {
-                      callbacks.onSelectRecordingDevice(deviceId)
-                    }}
-                    onSelectTranscriptionProvider={(provider: Settings['transcription']['provider']) => {
-                      callbacks.onSelectTranscriptionProvider(provider)
-                    }}
-                    onSelectTranscriptionModel={(model: Settings['transcription']['model']) => {
-                      callbacks.onSelectTranscriptionModel(model)
-                    }}
-                  />
-                </section>
-
               </section>
             </div>
           </div>

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -158,6 +158,7 @@ describe('renderer app', () => {
     // Keep route-tab selectors as an explicit UI contract for navigation tests/e2e flows.
     // New tab model: activity | profiles | settings (replaces home | settings).
     expect(mountPoint.querySelector('[data-route-tab="activity"]')).not.toBeNull()
+    expect(mountPoint.querySelector('[data-route-tab="audio-input"]')).not.toBeNull()
     expect(mountPoint.querySelector('[data-route-tab="settings"]')).not.toBeNull()
     expect(mountPoint.textContent).toContain('Speech-to-Text v1')
     // STY-03: "Recording Controls" heading removed; recording is indicated by the
@@ -181,6 +182,25 @@ describe('renderer app', () => {
     expect(harness.onRecordingCommandSpy).toHaveBeenCalledTimes(1)
     expect(harness.onCompositeTransformStatusSpy).toHaveBeenCalledTimes(1)
     expect(harness.onHotkeyErrorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders recording controls in the Audio Input tab panel', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const harness = buildIpcHarness()
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForBoot()
+
+    mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="audio-input"]')?.click()
+    await flush()
+
+    expect(mountPoint.querySelector('[data-tab-panel="audio-input"] [data-settings-section="audio-input"]')).not.toBeNull()
+    expect(mountPoint.querySelector('[data-tab-panel="settings"] [data-settings-section="audio-input"]')).toBeNull()
   })
 
   it('refreshes API key status when navigating to activity tab', async () => {


### PR DESCRIPTION
Closes #251\n\nAdds a dedicated `audio-input` tab next to Shortcuts and moves recording device controls out of the Settings tab panel.\n\nValidation:\n- pnpm vitest src/renderer/app-shell-react.test.tsx src/renderer/renderer-app.test.ts