### PR TITLE
fix(activity): append transformed terminal output to Activity contract (#249)

### DIFF
--- a/docs/decisions/transformed-output-terminal-activity.md
+++ b/docs/decisions/transformed-output-terminal-activity.md
@@ -1,0 +1,28 @@
+<!--
+Where: docs/decisions/transformed-output-terminal-activity.md
+What: Decision record for terminal Activity projection when output source is transformed text.
+Why: Prevent regressions where successful transformed captures fail to append their final Activity entry.
+-->
+
+# Decision: Terminal Activity must follow selected output source for successful captures
+
+- Date: 2026-03-01
+- Status: Accepted
+- Related issue: #249
+
+## Context
+- The renderer polls capture history after `submitRecordedAudio` and appends one terminal Activity entry for each completed capture.
+- Users reported missing final Activity entries when `output.selectedTextSource` is `transformed`.
+
+## Decision
+- On successful capture terminal status, the renderer resolves the Activity message using the selected source:
+  - `transformed` when transformed text is present.
+  - `transcript` when transcript is selected.
+  - Transcript fallback when transformed is selected but transformed text is missing.
+  - Transformed fallback when transcript is selected but transcript text is missing.
+- Exactly one terminal Activity entry is appended for the capture completion path.
+
+## Consequences
+- Activity behavior remains consistent with output source selection.
+- Successful transformed captures keep visible terminal feedback in Activity.
+- Regression coverage now asserts resolver fallback behavior and polling-path terminal projection (`pollRecordingOutcome`) for transformed-source captures.

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -202,7 +202,8 @@ export const resolveSuccessfulRecordingMessage = (
   return 'Transcription complete.'
 }
 
-const pollRecordingOutcome = async (deps: NativeRecordingDeps, capturedAt: string): Promise<void> => {
+// Exported for focused regression coverage of terminal-activity projection behavior.
+export const pollRecordingOutcome = async (deps: NativeRecordingDeps, capturedAt: string): Promise<void> => {
   const { addActivity, addTerminalActivity, addToast, logError } = deps
   const attempts = 8
   for (let attempt = 0; attempt < attempts; attempt += 1) {


### PR DESCRIPTION
## Summary
- lock terminal Activity message projection for successful captures to follow `output.selectedTextSource`
- add regression tests for transformed selection and transcript fallback in `pollRecordingOutcome`
- extend resolver tests for both-source fallback behavior and document the contract decision

## Tests
- npm run test -- src/renderer/native-recording.test.ts
- npm run test -- src/renderer/renderer-app.test.ts

Closes #249