### PR TITLE
fix(activity): handle delayed terminal history for transformed output (#249)

### DIFF
--- a/docs/decisions/transformed-output-terminal-activity.md
+++ b/docs/decisions/transformed-output-terminal-activity.md
@@ -21,8 +21,9 @@ Why: Prevent regressions where successful transformed captures fail to append th
   - Transcript fallback when transformed is selected but transformed text is missing.
   - Transformed fallback when transcript is selected but transcript text is missing.
 - Exactly one terminal Activity entry is appended for the capture completion path.
+- When no terminal history record appears in the initial polling window, the renderer emits the existing info notice and continues bounded follow-up polling to catch delayed terminal outcomes.
 
 ## Consequences
 - Activity behavior remains consistent with output source selection.
-- Successful transformed captures keep visible terminal feedback in Activity.
-- Regression coverage now asserts resolver fallback behavior and polling-path terminal projection (`pollRecordingOutcome`) for transformed-source captures.
+- Successful transformed captures keep visible terminal feedback in Activity even when terminal history arrives after the initial poll window.
+- Regression coverage now asserts resolver fallback behavior, initial poll timeout notice, and delayed-terminal projection behavior in `pollRecordingOutcome`.


### PR DESCRIPTION
## Summary
- keep existing selected-text-source terminal mapping from #266
- add bounded follow-up polling after the initial history timeout notice so delayed terminal records are still projected to Activity
- refactor poll logic for explicit  outcomes to avoid false timeout messaging on fetch errors
- add regression tests for delayed arrival, full miss path, and follow-up polling error behavior
- update decision doc contract for delayed-terminal polling

## Testing
- pnpm vitest run src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts

Closes #249