### PR TITLE
Fix #267: cancel shortcut capture on focus loss

### DIFF
--- a/docs/decisions/shortcut-capture-focus-cancel-state-contract.md
+++ b/docs/decisions/shortcut-capture-focus-cancel-state-contract.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/shortcut-capture-focus-cancel-state-contract.md
+What: Decision record for shortcut-capture focus-loss cancellation state contract.
+Why: Define deterministic cancel behavior for #267.
+-->
+
+# Decision: Shortcut capture uses a focus-loss cancel contract
+
+- Date: 2026-03-01
+- Status: Accepted
+- Related issue: #267
+
+## State contract
+- Canonical states are `idle`, `recording(fieldId)`, `canceled(fieldId)`, `committed(fieldId)`, and `error(fieldId)`.
+- Only `recording(fieldId)` is capture-active and intercepts key input.
+- `canceled`, `committed`, and `error` are terminal states for a capture session and are not capture-active.
+
+## Cancel transition rules
+- Outside click during `recording(fieldId)` cancels capture in the same render cycle.
+- `window.blur` during `recording(fieldId)` cancels capture in the same render cycle.
+- Active input `blur` during `recording(fieldId)` cancels capture in the same render cycle.
+
+## Consequences
+- Shortcut capture cannot remain stuck in `Recording...` after focus leaves the active shortcut input.
+- Downstream shortcut handling can rely on one capture-active source of truth.

--- a/src/renderer/settings-shortcut-editor-react.test.tsx
+++ b/src/renderer/settings-shortcut-editor-react.test.tsx
@@ -179,6 +179,34 @@ describe('SettingsShortcutEditorReact', () => {
     expect(host.querySelector('[data-shortcut-capture-hint="runTransform"]')).toBeNull()
   })
 
+  it('cancels capture mode on active field blur in the same render tick', async () => {
+    const host = document.createElement('div')
+    const outsideInput = document.createElement('input')
+    document.body.append(host, outsideInput)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsShortcutEditorReact
+          settings={DEFAULT_SETTINGS}
+          validationErrors={{}}
+          onChangeShortcutDraft={() => {}}
+        />
+      )
+    })
+
+    const runTransformInput = host.querySelector<HTMLInputElement>('#settings-shortcut-run-transform')
+    await act(async () => {
+      runTransformInput?.click()
+    })
+    expect(host.querySelector('[data-shortcut-capture-hint="runTransform"]')).not.toBeNull()
+
+    await act(async () => {
+      runTransformInput?.dispatchEvent(new FocusEvent('blur', { bubbles: true, relatedTarget: outsideInput }))
+    })
+    expect(host.querySelector('[data-shortcut-capture-hint="runTransform"]')).toBeNull()
+  })
+
   it('cancels capture mode when window loses focus', async () => {
     const host = document.createElement('div')
     document.body.append(host)
@@ -480,4 +508,5 @@ describe('SettingsShortcutEditorReact', () => {
     expect(host.querySelector('#settings-error-toggle-recording')?.textContent).toContain('shortcut is required')
     expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('shortcut is required')
   })
+
 })


### PR DESCRIPTION
## Issue
- Closes #267

## Summary
- cancel active shortcut capture on outside click, window blur, and active-field blur
- keep one capture state source (`idle|recording(fieldId)|canceled|committed|error`)
- clear `Recording...` indicator in the same render cycle on cancel transitions

## Out of Scope
- no shortcut validation-lifecycle changes across fields (#268)

## Verification
- `pnpm test -- src/renderer/shortcut-capture.test.ts src/renderer/settings-shortcut-editor-react.test.tsx src/renderer/settings-recording-react.test.tsx`

## Docs
- `docs/decisions/shortcut-capture-focus-cancel-state-contract.md`