### PR TITLE
Fix #268: clear stale shortcut capture errors when switching fields

### DIFF
--- a/docs/decisions/shortcut-capture-stale-error-lifecycle.md
+++ b/docs/decisions/shortcut-capture-stale-error-lifecycle.md
@@ -1,0 +1,23 @@
+<!--
+Where: docs/decisions/shortcut-capture-stale-error-lifecycle.md
+What: Decision record for clearing stale shortcut capture errors across fields.
+Why: Prevent prior-field validation errors from persisting into a new capture session (#268).
+-->
+
+# Decision: Clear stale shortcut capture errors when switching fields
+
+- Date: 2026-03-01
+- Status: Accepted
+- Related issue: #268
+
+## Context
+- Shortcut capture errors are rendered per field, but a prior failed capture on one field could remain visible after starting capture on another field.
+- This created stale/irrelevant feedback and made the new active field appear invalid before capture input.
+
+## Decision
+- Starting a new `recording(newFieldId)` session resets capture error state to the new field only.
+- Validation errors for the currently active field are preserved while that field remains in-session.
+
+## Consequences
+- Error visibility remains scoped to the active capture session.
+- Starting capture on a different field clears stale error text immediately.

--- a/src/renderer/settings-shortcut-editor-react.test.tsx
+++ b/src/renderer/settings-shortcut-editor-react.test.tsx
@@ -509,4 +509,40 @@ describe('SettingsShortcutEditorReact', () => {
     expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('shortcut is required')
   })
 
+  it('clears stale capture error when recording starts on a different shortcut field', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsShortcutEditorReact
+          settings={DEFAULT_SETTINGS}
+          validationErrors={{}}
+          onChangeShortcutDraft={() => {}}
+        />
+      )
+    })
+
+    const runTransformInput = host.querySelector<HTMLInputElement>('#settings-shortcut-run-transform')
+    const toggleRecordingInput = host.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')
+    expect(runTransformInput).not.toBeNull()
+    expect(toggleRecordingInput).not.toBeNull()
+
+    await act(async () => {
+      runTransformInput?.click()
+    })
+    await act(async () => {
+      runTransformInput?.dispatchEvent(new KeyboardEvent('keydown', { key: '9', bubbles: true, cancelable: true }))
+    })
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('at least one modifier key')
+
+    await act(async () => {
+      toggleRecordingInput?.click()
+    })
+
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toBe('')
+    expect(host.querySelector('[data-shortcut-capture-hint="toggleRecording"]')).not.toBeNull()
+  })
+
 })

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -130,7 +130,7 @@ export const SettingsShortcutEditorReact = ({
 
   const beginCapture = (key: ShortcutKey): void => {
     setCaptureState({ status: 'recording', fieldId: key })
-    setCaptureErrors((previous) => ({ ...previous, [key]: '' }))
+    setCaptureErrors({ [key]: '' })
   }
 
   const cancelCapture = useCallback((): void => {


### PR DESCRIPTION
## Issue
- Closes #268

## Summary
- reset capture error state when entering `recording(newFieldId)`
- preserve in-session validation messaging for the same field
- add focused test for invalid combo on field A then recording on field B

## Dependency
- stacked on top of #267 state-contract branch

## Verification
- `pnpm test -- src/renderer/shortcut-capture.test.ts src/renderer/settings-shortcut-editor-react.test.tsx src/renderer/settings-recording-react.test.tsx`

## Docs
- `docs/decisions/shortcut-capture-stale-error-lifecycle.md`