### PR TITLE
Style #255: unify select-like control styling across tabs

### DIFF
--- a/docs/decisions/select-control-style-unification.md
+++ b/docs/decisions/select-control-style-unification.md
@@ -1,0 +1,28 @@
+<!--
+Where: docs/decisions/select-control-style-unification.md
+What: Decision record for select-like control style unification across renderer tabs.
+Why: Remove legacy style drift and keep one canonical select implementation path (#255).
+-->
+
+# Decision: Use one shared select-control class token across Audio Input, Profiles, and Settings
+
+- Date: 2026-03-01
+- Status: Accepted
+- Related issue: #255
+
+## Context
+- Select controls in Audio Input, Profiles, and Settings used different class combinations (`h-7` vs `h-8`, `bg-background` vs `bg-input`, mixed focus-ring rules).
+- The visual drift increased maintenance cost and produced inconsistent hover/focus/disabled states.
+
+## Decision
+- Introduce `src/renderer/select-control.ts` as the single source of select-like styling tokens.
+- Use `SELECT_CONTROL_CLASS` for standard selects and `SELECT_CONTROL_MONO_CLASS` for mono text variants.
+- Remove per-component ad-hoc select class branches in:
+  - `SettingsRecordingReact`
+  - `SettingsSttProviderFormReact`
+  - `ProfilesPanelReact`
+
+## Consequences
+- Select controls now share a consistent token/state baseline across all in-scope tabs.
+- Future select updates happen in one place, reducing divergence risk.
+- Business logic and selection handlers remain unchanged (style-only refactor).

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -50,6 +50,7 @@ const buildState = (overrides: Partial<AppShellState> = {}): AppShellState => ({
 const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCallbacks => ({
   onNavigate: vi.fn(),
   onRunRecordingCommand: vi.fn(),
+  onShortcutCaptureActiveChange: vi.fn(),
   onOpenSettings: vi.fn(),
   onSaveApiKey: vi.fn().mockResolvedValue(undefined),
   onRefreshAudioSources: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -386,6 +386,12 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
                     onSelectRecordingDevice={(deviceId: string) => {
                       callbacks.onSelectRecordingDevice(deviceId)
                     }}
+                    onSelectTranscriptionProvider={(provider: Settings['transcription']['provider']) => {
+                      callbacks.onSelectTranscriptionProvider(provider)
+                    }}
+                    onSelectTranscriptionModel={(model: Settings['transcription']['model']) => {
+                      callbacks.onSelectTranscriptionModel(model)
+                    }}
                   />
                 </section>
               </section>

--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -478,6 +478,31 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(userPromptInput?.value).toBe('User {{text}}')
   })
 
+  it('uses the shared select style classes for provider and model controls', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...buildCallbacks()}
+      />
+    )
+    await flush()
+
+    const firstCard = host.querySelector<HTMLDivElement>('[role="button"]')
+    firstCard?.click()
+    await flush()
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#profile-edit-provider')
+    const modelSelect = host.querySelector<HTMLSelectElement>('#profile-edit-model')
+    expect(providerSelect?.className).toContain('focus-visible:ring-ring')
+    expect(providerSelect?.className).toContain('bg-input')
+    expect(modelSelect?.className).toContain('focus-visible:ring-ring')
+    expect(modelSelect?.className).toContain('bg-input')
+  })
+
   it('wires validation errors to form controls with aria attributes', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -19,6 +19,7 @@ import { Pencil, Plus, Star, Trash2 } from 'lucide-react'
 import type { Settings, TransformationPreset } from '../shared/domain'
 import type { SettingsValidationErrors } from './settings-validation'
 import { cn } from './lib/utils'
+import { SELECT_CONTROL_CLASS } from './select-control'
 
 // Local draft type — mirrors editable fields from TransformationPreset.
 interface EditDraft {
@@ -210,7 +211,7 @@ const ProfileEditForm = ({
           id="profile-edit-provider"
           value="google"
           disabled
-          className="h-7 rounded border border-input bg-background px-2 text-xs disabled:opacity-60"
+          className={SELECT_CONTROL_CLASS}
         >
           <option value="google">google</option>
         </select>
@@ -225,7 +226,7 @@ const ProfileEditForm = ({
           onChange={(e: ChangeEvent<HTMLSelectElement>) => {
             onChangeDraft({ model: e.target.value as TransformationPreset['model'] })
           }}
-          className="h-7 rounded border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={SELECT_CONTROL_CLASS}
         >
           <option value="gemini-2.5-flash">gemini-2.5-flash</option>
         </select>

--- a/src/renderer/select-control.ts
+++ b/src/renderer/select-control.ts
@@ -1,0 +1,11 @@
+/*
+Where: src/renderer/select-control.ts
+What: Shared select-like control class tokens for renderer form surfaces.
+Why: Enforce one canonical select styling path across Audio Input, Profiles, and Settings tabs.
+*/
+
+const SELECT_CONTROL_BASE =
+  'rounded border border-input bg-input px-2 text-xs text-foreground transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
+
+export const SELECT_CONTROL_CLASS = `h-8 ${SELECT_CONTROL_BASE}`
+export const SELECT_CONTROL_MONO_CLASS = `${SELECT_CONTROL_CLASS} font-mono`

--- a/src/renderer/settings-recording-react.test.tsx
+++ b/src/renderer/settings-recording-react.test.tsx
@@ -161,4 +161,34 @@ describe('SettingsRecordingReact', () => {
     expect(host.querySelectorAll('#settings-help-stt-language')).toHaveLength(1)
     expect(host.querySelectorAll('#settings-audio-sources-message')).toHaveLength(1)
   })
+
+  it('applies one shared select style path across speech-to-text and audio-input controls', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsRecordingReact
+          settings={DEFAULT_SETTINGS}
+          audioInputSources={[{ id: 'system_default', label: 'System Default Microphone' }]}
+          audioSourceHint="Detected 0 selectable microphone source(s)."
+          onRefreshAudioSources={vi.fn().mockResolvedValue(undefined)}
+          onSelectRecordingMethod={vi.fn()}
+          onSelectRecordingSampleRate={vi.fn()}
+          onSelectRecordingDevice={vi.fn()}
+          onSelectTranscriptionProvider={vi.fn()}
+          onSelectTranscriptionModel={vi.fn()}
+        />
+      )
+    })
+
+    const selectNodes = Array.from(host.querySelectorAll('select'))
+    expect(selectNodes.length).toBeGreaterThan(0)
+    for (const selectNode of selectNodes) {
+      expect(selectNode.className).toContain('focus-visible:ring-ring')
+      expect(selectNode.className).toContain('border-input')
+      expect(selectNode.className).toContain('bg-input')
+    }
+  })
 })

--- a/src/renderer/settings-recording-react.tsx
+++ b/src/renderer/settings-recording-react.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import { STT_MODEL_ALLOWLIST, type Settings } from '../shared/domain'
 import type { AudioInputSource } from '../shared/ipc'
+import { SELECT_CONTROL_CLASS, SELECT_CONTROL_MONO_CLASS } from './select-control'
 
 interface SettingsRecordingReactProps {
   settings: Settings
@@ -91,7 +92,7 @@ export const SettingsRecordingReact = ({
             <span>STT provider</span>
             <select
               id="settings-transcription-provider"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CONTROL_CLASS}
               value={selectedProvider}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const provider = event.target.value as Settings['transcription']['provider']
@@ -110,7 +111,7 @@ export const SettingsRecordingReact = ({
             <span>STT model</span>
             <select
               id="settings-transcription-model"
-              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              className={SELECT_CONTROL_MONO_CLASS}
               value={selectedModel}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const model = event.target.value as Settings['transcription']['model']
@@ -134,7 +135,7 @@ export const SettingsRecordingReact = ({
             <span>Recording method</span>
             <select
               id="settings-recording-method"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CONTROL_CLASS}
               value={selectedRecordingMethod}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const method = event.target.value as Settings['recording']['method']
@@ -151,7 +152,7 @@ export const SettingsRecordingReact = ({
             <span>Sample rate</span>
             <select
               id="settings-recording-sample-rate"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CONTROL_CLASS}
               value={String(selectedSampleRate)}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const sampleRate = Number(event.target.value) as Settings['recording']['sampleRateHz']
@@ -168,7 +169,7 @@ export const SettingsRecordingReact = ({
             <span>Audio source</span>
             <select
               id="settings-recording-device"
-              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              className={SELECT_CONTROL_MONO_CLASS}
               value={selectedRecordingDevice}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const deviceId = event.target.value

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -236,4 +236,21 @@ describe('SettingsSttProviderFormReact', () => {
     await act(async () => { saveButton.click() })
     expect(onSaveApiKey).not.toHaveBeenCalled()
   })
+
+  it('uses shared select styling for provider/model controls', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(<SettingsSttProviderFormReact {...defaultProps} />)
+    })
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-provider')
+    const modelSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-model')
+    expect(providerSelect?.className).toContain('focus-visible:ring-ring')
+    expect(providerSelect?.className).toContain('bg-input')
+    expect(modelSelect?.className).toContain('focus-visible:ring-ring')
+    expect(modelSelect?.className).toContain('bg-input')
+  })
 })

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -13,6 +13,7 @@ import {
   type Settings
 } from '../shared/domain'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot } from '../shared/ipc'
+import { SELECT_CONTROL_CLASS, SELECT_CONTROL_MONO_CLASS } from './select-control'
 
 interface SettingsSttProviderFormReactProps {
   settings: Settings
@@ -76,7 +77,7 @@ export const SettingsSttProviderFormReact = ({
         <span>STT provider</span>
         <select
           id="settings-transcription-provider"
-          className="h-8 rounded border border-input bg-input px-2 text-xs"
+          className={SELECT_CONTROL_CLASS}
           value={selectedProvider}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const provider = event.target.value as Settings['transcription']['provider']
@@ -101,7 +102,7 @@ export const SettingsSttProviderFormReact = ({
         <span>STT model</span>
         <select
           id="settings-transcription-model"
-          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+          className={SELECT_CONTROL_MONO_CLASS}
           value={selectedModel}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const model = event.target.value as Settings['transcription']['model']


### PR DESCRIPTION
## Issue
- Closes #255

## Summary
- add shared select token module (`src/renderer/select-control.ts`)
- apply single canonical select style path across Audio Input, Profiles, and Settings controls
- keep selection/event behavior unchanged

## Out of Scope
- no shortcut-capture or recording-finalization logic changes

## Verification
- `pnpm test -- src/renderer/settings-recording-react.test.tsx src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/profiles-panel-react.test.tsx src/renderer/app-shell-react.test.tsx`

## Docs
- `docs/decisions/select-control-style-unification.md`