### PR TITLE
Style #252: align transformation picker popup with app tokens

### DIFF
--- a/docs/decisions/transformation-picker-style-alignment.md
+++ b/docs/decisions/transformation-picker-style-alignment.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/transformation-picker-style-alignment.md
+What: Decision record for transformation picker pop-up style alignment.
+Why: Keep pick/change-default profile menu visuals consistent with app tokens while preserving behavior (#252).
+-->
+
+# Decision: Align transformation picker pop-up styling with app token patterns
+
+- Date: 2026-03-01
+- Status: Accepted
+- Related issue: #252
+
+## Context
+- The transformation picker pop-up used a light-theme card/menu style that diverged from the app's dark token system.
+- Behavior (pick profile / cancel) was correct; only visual consistency and focus/selection treatment needed alignment.
+
+## Decision
+- Keep picker behavior and navigation flow unchanged.
+- Update `buildPickerHtml` style tokens to app-aligned dark surfaces, border, muted text, accent hover/selected state, and explicit focus-visible ring.
+- Keep existing keyboard behavior (`ArrowUp`, `ArrowDown`, `Enter`, `Escape`) and ARIA roles (`listbox`, `option`).
+
+## Consequences
+- Pick and change-default pop-up flows retain existing business logic and side effects.
+- Pop-up menu visual states now match app spacing and token direction.
+- Style regressions are covered by picker HTML assertions in `profile-picker-service.test.ts`.

--- a/src/main/services/profile-picker-service.test.ts
+++ b/src/main/services/profile-picker-service.test.ts
@@ -95,6 +95,15 @@ describe('buildPickerHtml', () => {
     expect(html).toContain('Focused on open')
     expect(html).toContain('Pick and run')
   })
+
+  it('uses app-aligned menu styling tokens and interactive item states', () => {
+    const html = buildPickerHtml([makePreset('a', 'Alpha'), makePreset('b', 'Beta')], 'a')
+    expect(html).toContain('color-scheme: dark;')
+    expect(html).toContain('--card: #212833;')
+    expect(html).toContain('.item:hover,')
+    expect(html).toContain('.item[aria-selected="true"]')
+    expect(html).toContain('.item:focus-visible')
+  })
 })
 
 describe('ProfilePickerService', () => {

--- a/src/main/services/profile-picker-service.ts
+++ b/src/main/services/profile-picker-service.ts
@@ -95,22 +95,29 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], focusedPreset
     <title>Pick Transformation Profile</title>
     <style>
       :root {
-        color-scheme: light;
-        font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+        color-scheme: dark;
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+        --background: #1a1f28;
+        --card: #212833;
+        --border: #36404f;
+        --text: #f3f4f6;
+        --muted: #9aa6b2;
+        --accent: #2f3b4a;
+        --focus: #44d17d;
       }
       body {
         margin: 0;
-        background: #f4f6f9;
-        color: #0f172a;
+        background: var(--background);
+        color: var(--text);
       }
       .shell {
         padding: 12px;
       }
       .card {
-        background: #ffffff;
-        border: 1px solid #d8dee9;
+        background: var(--card);
+        border: 1px solid var(--border);
         border-radius: 12px;
-        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.16);
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
         overflow: hidden;
       }
       .title {
@@ -123,7 +130,7 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], focusedPreset
         margin: 0;
         padding: 0 14px 10px;
         font-size: 12px;
-        color: #64748b;
+        color: var(--muted);
       }
       .list {
         list-style: none;
@@ -136,17 +143,22 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], focusedPreset
         display: block;
         width: 100%;
         border: 0;
-        border-top: 1px solid #edf2f7;
-        background: #ffffff;
-        color: #0f172a;
+        border-top: 1px solid var(--border);
+        background: transparent;
+        color: var(--text);
         text-align: left;
         padding: 10px 14px;
         font-size: 13px;
         cursor: pointer;
+        transition: background-color 120ms ease-in-out;
       }
       .item:hover,
       .item[aria-selected="true"] {
-        background: #dbeafe;
+        background: var(--accent);
+      }
+      .item:focus-visible {
+        outline: 2px solid var(--focus);
+        outline-offset: -2px;
       }
       .item-name {
         display: block;
@@ -156,7 +168,7 @@ const buildPickerHtml = (presets: readonly TransformationPreset[], focusedPreset
         display: block;
         margin-top: 2px;
         font-size: 11px;
-        color: #475569;
+        color: var(--muted);
       }
     </style>
   </head>


### PR DESCRIPTION
## Issue
- Closes #252

## Summary
- align profile picker popup visual tokens/states with app style direction
- preserve existing pick/change-default behavior and keyboard flow
- add picker style-state test assertions

## Out of Scope
- no command routing or preset-selection business logic changes

## Verification
- `pnpm test -- src/main/services/profile-picker-service.test.ts src/renderer/shell-chrome-react.test.tsx`

## Docs
- `docs/decisions/transformation-picker-style-alignment.md`