### PR TITLE
fix: #247 redact api key state across provider switch

### DIFF
--- a/docs/decisions/api-key-redaction-after-save.md
+++ b/docs/decisions/api-key-redaction-after-save.md
@@ -22,4 +22,5 @@ Use always-redacted display when a provider key is saved and no new draft is bei
 
 - saved-key presence remains explicit (`Saved`/`Not set`) without exposing plaintext;
 - users can still replace a key directly by typing a new draft;
-- renderer tests lock both STT-provider and Google-key redaction flows.
+- renderer tests lock both STT-provider and Google-key redaction flows;
+- provider-switch regression coverage ensures unsaved plaintext drafts do not leak between providers.

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -215,6 +215,61 @@ describe('SettingsSttProviderFormReact', () => {
     expect(rerenderedInput.value).toBe('••••••••')
   })
 
+  it('clears unsaved draft when switching providers so no stale plaintext leaks across tabs', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsSttProviderFormReact
+          {...defaultProps}
+          apiKeyStatus={{ groq: true, elevenlabs: true, google: false }}
+        />
+      )
+    })
+
+    const groqInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
+    await act(async () => { groqInput.focus() })
+    await act(async () => { setReactInputValue(groqInput, 'temporary-groq-draft') })
+    expect(groqInput.value).toBe('temporary-groq-draft')
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-provider')!
+    await act(async () => {
+      setReactSelectValue(providerSelect, 'elevenlabs')
+    })
+
+    const elevenLabsInput = host.querySelector<HTMLInputElement>('#settings-api-key-elevenlabs')!
+    expect(elevenLabsInput.value).toBe('••••••••')
+  })
+
+  it('shows redacted destination key when switching from unsaved source provider with a draft', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsSttProviderFormReact
+          {...defaultProps}
+          apiKeyStatus={{ groq: false, elevenlabs: true, google: false }}
+        />
+      )
+    })
+
+    const groqInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
+    await act(async () => { setReactInputValue(groqInput, 'unsaved-groq-draft') })
+    expect(groqInput.value).toBe('unsaved-groq-draft')
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-provider')!
+    await act(async () => {
+      setReactSelectValue(providerSelect, 'elevenlabs')
+    })
+
+    const elevenLabsInput = host.querySelector<HTMLInputElement>('#settings-api-key-elevenlabs')!
+    expect(elevenLabsInput.value).toBe('••••••••')
+  })
+
   it('does not call save while selected provider key is in redacted mode', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -87,6 +87,7 @@ export const SettingsSttProviderFormReact = ({
             // to avoid showing a stale key for the previous provider.
             setApiKeyValue('')
             setApiKeyVisible(false)
+            setIsEditingDraft(false)
             onSelectTranscriptionProvider(provider)
           }}
         >


### PR DESCRIPTION
## Summary
- reset isEditingDraft when STT provider selection changes
- prevent unsaved plaintext draft state from suppressing redaction on destination provider
- add regression tests for provider-switch redaction behavior
- update decision doc with provider-switch coverage note

## Testing
- pnpm vitest run src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/settings-api-keys-react.test.tsx
