### PR TITLE
fix: #278 clear stale keybind error before new recording

### DIFF
--- a/docs/decisions/shortcut-capture-clear-stale-error-on-start.md
+++ b/docs/decisions/shortcut-capture-clear-stale-error-on-start.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/shortcut-capture-clear-stale-error-on-start.md
+What: Decision record for clearing shortcut capture errors when a new recording session starts.
+Why: Issue #278 requires stale keybind errors to be reset before any new capture attempt.
+-->
+
+# Decision: Clear Stale Keybind Error on New Recording Start (#278)
+
+**Date**: 2026-03-01  
+**Status**: Accepted  
+**Ticket**: #278
+
+## Decision
+
+When shortcut capture starts for any field, reset prior capture errors immediately.
+
+- Clear the in-memory capture error map at `beginCapture`.
+- Show capture errors only for the currently active capture attempt.
+- Keep prop-driven validation errors unchanged.
+
+## Consequences
+
+- Users do not see stale errors from a previous field while recording a new shortcut.
+- Current-attempt failures still show normally and immediately.
+- Regression tests lock cross-field stale-error clearing behavior.

--- a/src/renderer/settings-shortcut-editor-react.test.tsx
+++ b/src/renderer/settings-shortcut-editor-react.test.tsx
@@ -99,6 +99,74 @@ describe('SettingsShortcutEditorReact', () => {
     expect(onChangeShortcutDraft).not.toHaveBeenCalledWith('runTransform', expect.anything())
   })
 
+  it('clears stale capture error when recording starts for a different shortcut', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsShortcutEditorReact
+          settings={DEFAULT_SETTINGS}
+          validationErrors={{}}
+          onChangeShortcutDraft={() => {}}
+        />
+      )
+    })
+
+    const runTransformInput = host.querySelector<HTMLInputElement>('#settings-shortcut-run-transform')
+    await act(async () => {
+      runTransformInput?.click()
+    })
+    await act(async () => {
+      runTransformInput?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '9', bubbles: true, cancelable: true })
+      )
+    })
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('at least one modifier key')
+
+    const toggleRecordingInput = host.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')
+    await act(async () => {
+      toggleRecordingInput?.click()
+    })
+
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toBe('')
+  })
+
+  it('clears stale capture error when starting a different shortcut via Record button', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsShortcutEditorReact
+          settings={DEFAULT_SETTINGS}
+          validationErrors={{}}
+          onChangeShortcutDraft={() => {}}
+        />
+      )
+    })
+
+    const runTransformInput = host.querySelector<HTMLInputElement>('#settings-shortcut-run-transform')
+    await act(async () => {
+      runTransformInput?.click()
+    })
+    await act(async () => {
+      runTransformInput?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '9', bubbles: true, cancelable: true })
+      )
+    })
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('at least one modifier key')
+
+    const toggleRecordButton = host.querySelector<HTMLButtonElement>('[data-shortcut-capture-toggle="toggleRecording"]')
+    await act(async () => {
+      toggleRecordButton?.click()
+    })
+
+    expect(host.querySelector('#settings-error-run-transform')?.textContent).toBe('')
+  })
+
   it('does not start capture mode when field is focused via keyboard navigation', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -130,7 +130,7 @@ export const SettingsShortcutEditorReact = ({
 
   const beginCapture = (key: ShortcutKey): void => {
     setCaptureState({ status: 'recording', fieldId: key })
-    setCaptureErrors((previous) => ({ ...previous, [key]: '' }))
+    setCaptureErrors({})
   }
 
   const cancelCapture = useCallback((): void => {


### PR DESCRIPTION
## Summary
- clear existing shortcut capture errors whenever a new capture session starts
- prevent stale error text from a previous field while recording a different shortcut
- add regression tests for input-click and Record-button capture start paths
- add decision doc for stale-error reset contract

## Testing
- pnpm vitest run src/renderer/settings-shortcut-editor-react.test.tsx
