### PR TITLE
fix: #280 remove shortcuts Record button and title-click capture

### DIFF
--- a/docs/decisions/shortcut-capture-remove-record-button-and-title-trigger.md
+++ b/docs/decisions/shortcut-capture-remove-record-button-and-title-trigger.md
@@ -1,0 +1,25 @@
+<!--
+Where: docs/decisions/shortcut-capture-remove-record-button-and-title-trigger.md
+What: Decision record for shortcut capture trigger boundaries after removing the Record button.
+Why: Issue #280 requires preventing title-click recording and removing explicit Record controls.
+-->
+
+# Decision: Remove Record Button and Block Title-Click Capture (#280)
+
+**Date**: 2026-03-01  
+**Status**: Accepted  
+**Ticket**: #280
+
+## Decision
+
+Use a single control for capture: the shortcut input field itself.
+
+- Remove the `Record`/`Cancel` button from each shortcut row.
+- Render shortcut titles as non-label text so title clicks do not trigger input click/capture.
+- Keep capture start available from the shortcut input by mouse click and keyboard activation (`Enter`/`Space`).
+
+## Consequences
+
+- Shortcut tab UI is simpler and has one unambiguous capture entry point.
+- Clicking shortcut titles no longer starts recording.
+- Tests lock the no-record-button and no-title-trigger behavior.

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -282,7 +282,7 @@ describe('renderer app', () => {
     mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="shortcuts"]')?.click()
     await flush()
 
-    mountPoint.querySelector<HTMLButtonElement>('[data-shortcut-capture-toggle="toggleRecording"]')?.click()
+    mountPoint.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')?.click()
     await flush()
     mountPoint.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')?.dispatchEvent(
       new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', metaKey: true, bubbles: true, cancelable: true })
@@ -423,7 +423,7 @@ describe('renderer app', () => {
 
     mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="shortcuts"]')?.click()
     await flush()
-    mountPoint.querySelector<HTMLButtonElement>('[data-shortcut-capture-toggle="toggleRecording"]')?.click()
+    mountPoint.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')?.click()
     await flush()
     const captureInput = mountPoint.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')
 
@@ -465,7 +465,7 @@ describe('renderer app', () => {
 
     mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="shortcuts"]')?.click()
     await flush()
-    mountPoint.querySelector<HTMLButtonElement>('[data-shortcut-capture-toggle="toggleRecording"]')?.click()
+    mountPoint.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')?.click()
     await flush()
 
     mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')?.click()

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -189,6 +189,11 @@ export const SettingsShortcutEditorReact = ({
 
   const handleCaptureKeydown = (key: ShortcutKey, event: ReactKeyboardEvent<HTMLInputElement>): void => {
     if (capturingKey !== key) {
+      if (capturingKey === null && (event.key === 'Enter' || event.key === ' ')) {
+        event.preventDefault()
+        event.stopPropagation()
+        beginCapture(key)
+      }
       return
     }
 
@@ -247,48 +252,32 @@ export const SettingsShortcutEditorReact = ({
     <div className="space-y-3" ref={containerRef}>
       {SHORTCUT_FIELDS.map((field) => (
         <div className="space-y-1.5" key={field.key}>
-          <div className="flex items-end gap-2">
-            <label className="flex flex-1 flex-col gap-1.5 text-xs">
-              <span>{field.label}</span>
-              <input
-                id={field.inputId}
-                type="text"
-                className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
-                value={shortcutDraft[field.key]}
-                readOnly
-                ref={(element) => {
-                  inputRefs.current[field.key] = element
-                }}
-                onClick={() => {
-                  beginCapture(field.key)
-                }}
-                onKeyDown={(event) => {
-                  handleCaptureKeydown(field.key, event)
-                }}
-                onBlur={() => {
-                  if (capturingKey === field.key) {
-                    cancelCapture()
-                  }
-                }}
-                aria-describedby={field.errorId}
-                data-shortcut-capturing={capturingKey === field.key ? 'true' : 'false'}
-              />
-            </label>
-            <button
-              type="button"
-              className="h-8 rounded border border-input bg-background px-2 text-[11px] font-medium hover:bg-accent"
+          <div className="flex flex-col gap-1.5 text-xs">
+            <span id={`${field.inputId}-label`}>{field.label}</span>
+            <input
+              id={field.inputId}
+              type="text"
+              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              value={shortcutDraft[field.key]}
+              readOnly
+              ref={(element) => {
+                inputRefs.current[field.key] = element
+              }}
               onClick={() => {
+                beginCapture(field.key)
+              }}
+              onKeyDown={(event) => {
+                handleCaptureKeydown(field.key, event)
+              }}
+              onBlur={() => {
                 if (capturingKey === field.key) {
                   cancelCapture()
-                  return
                 }
-                beginCapture(field.key)
-                inputRefs.current[field.key]?.focus()
               }}
-              data-shortcut-capture-toggle={field.key}
-            >
-              {capturingKey === field.key ? 'Cancel' : 'Record'}
-            </button>
+              aria-labelledby={`${field.inputId}-label`}
+              aria-describedby={field.errorId}
+              data-shortcut-capturing={capturingKey === field.key ? 'true' : 'false'}
+            />
           </div>
           {capturingKey === field.key && (
             <p className="text-[10px] text-primary" data-shortcut-capture-hint={field.key}>


### PR DESCRIPTION
## Summary
- remove Record/Cancel button controls from shortcut rows
- prevent shortcut title text click from triggering capture by rendering non-label title text
- retain recording trigger on shortcut input field and add keyboard activation (Enter/Space)
- update renderer integration tests to start capture from input selectors
- add decision doc for trigger-boundary contract

## Testing
- pnpm vitest run src/renderer/settings-shortcut-editor-react.test.tsx src/renderer/renderer-app.test.ts
