### PR TITLE
fix: remove API key reveal toggle and update 247/278/280 plan status

### DIFF
--- a/docs/decisions/api-key-redaction-after-save.md
+++ b/docs/decisions/api-key-redaction-after-save.md
@@ -14,7 +14,7 @@ Why: Issue #247 requires saved keys to remain hidden by default in Settings.
 
 Use always-redacted display when a provider key is saved and no new draft is being edited:
 - show masked value indicator (`••••••••`);
-- disable visibility toggle while in redacted mode so unknown persisted secrets cannot be revealed;
+- remove the visibility toggle entirely so persisted secrets can never be revealed in-app;
 - switch to editable draft mode when the user focuses/types to replace;
 - clear plaintext draft and return to redacted mode when save status becomes `Saved`.
 

--- a/docs/decisions/stt-provider-unified-form.md
+++ b/docs/decisions/stt-provider-unified-form.md
@@ -17,7 +17,7 @@ Introduce **`SettingsSttProviderFormReact`** — a single, self-contained form t
 ```
 [ STT provider selector     ]
 [ STT model selector (filtered to provider's allowlist) ]
-[ <Provider> API key        ] [Show/Hide] [Save]
+[ <Provider> API key        ] [Save]
 ```
 
 Each other component is narrowed accordingly:
@@ -30,18 +30,17 @@ Each other component is narrowed accordingly:
 
 ## Key Contracts Preserved
 
-All element IDs and `data-*` test hooks remain identical to the pre-refactor structure so E2E selectors need only minor behavioural updates (e.g. select provider first before filling elevenlabs key):
+Core element IDs and save/status `data-*` hooks remain stable so E2E selectors need only minor behavioural updates (e.g. select provider first before filling elevenlabs key):
 
 - `#settings-transcription-provider` — provider select
 - `#settings-transcription-model` — model select
 - `#settings-api-key-{provider}` — provider-scoped key input (only the *selected* provider is rendered)
-- `[data-api-key-visibility-toggle="{provider}"]`
 - `[data-api-key-save="{provider}"]`
 - `#api-key-save-status-{provider}`
 
 ## Model List Derivation
 
-Provider changes automatically switch the model selector to the first entry in `STT_MODEL_ALLOWLIST[provider]` (defined in `shared/domain.ts`). The API key value and visibility are cleared on provider change to avoid stale key leakage.
+Provider changes automatically switch the model selector to the first entry in `STT_MODEL_ALLOWLIST[provider]` (defined in `shared/domain.ts`). The API key draft value is cleared on provider change to avoid stale key leakage.
 
 ## Navigation Hint Updates
 

--- a/docs/github-issues-247-278-280-work-plan.md
+++ b/docs/github-issues-247-278-280-work-plan.md
@@ -6,6 +6,17 @@ Why: Deliver small, feasible, risk-aware slices with strict completion gates bef
 
 # GitHub Issues Work Plan (#247, #278, #280) - March 1, 2026
 
+## Execution Status (Completed)
+- Completed on March 1, 2026 in strict order: `#247` -> `#278` -> `#280`.
+- Issue closure:
+  - #247 CLOSED
+  - #278 CLOSED
+  - #280 CLOSED
+- Merged PRs:
+  - #247: https://github.com/massun-onibakuchi/speech-to-text-app/pull/283 (`b8c1462b46f049f5c4e45697903e7bdbb40a6d5e`)
+  - #278: https://github.com/massun-onibakuchi/speech-to-text-app/pull/284 (`aa5ddf65b87635e4099090aeccb7c3971de5206d`)
+  - #280: https://github.com/massun-onibakuchi/speech-to-text-app/pull/285 (`b7bd859764b161aee8c006ac0f8f47833ff1d9e8`)
+
 ## Plan Rules
 - One ticket equals one PR.
 - Do not start the next ticket until the current ticket PR is merged to `main`.
@@ -56,13 +67,13 @@ Why: Deliver small, feasible, risk-aware slices with strict completion gates bef
 - Goal:
   - Show a clear "saved key exists" redacted state after save/reload without exposing plaintext keys.
 - Checklist:
-  - [ ] Remove reveal behavior for persisted keys.
-  - [ ] Persisted key shows redacted representation rather than ambiguous empty input.
-  - [ ] Editing a saved key re-enters draft state; switching away without saving restores redacted display.
-  - [ ] Plaintext draft is cleared after successful save.
-  - [ ] Save/validation behavior remains unchanged.
-  - [ ] Tests added/updated.
-  - [ ] Docs updated.
+  - [x] Remove reveal behavior for persisted keys.
+  - [x] Persisted key shows redacted representation rather than ambiguous empty input.
+  - [x] Editing a saved key re-enters draft state; switching away without saving restores redacted display.
+  - [x] Plaintext draft is cleared after successful save.
+  - [x] Save/validation behavior remains unchanged.
+  - [x] Tests added/updated.
+  - [x] Docs updated.
 - Tasks (step-by-step):
   1. Audit current key field state flow in renderer key settings components.
   2. Define rendering states: `not_set`, `dirty_draft`, `saved_redacted`.
@@ -90,11 +101,11 @@ Why: Deliver small, feasible, risk-aware slices with strict completion gates bef
 - Goal:
   - Ensure starting any keybind recording session resets previous error/conflict message immediately.
 - Checklist:
-  - [ ] On new recording start, old error state is cleared first.
-  - [ ] Error only appears for current failed attempt.
-  - [ ] No regressions in duplicate/conflict detection.
-  - [ ] Tests added/updated.
-  - [ ] Docs updated.
+  - [x] On new recording start, old error state is cleared first.
+  - [x] Error only appears for current failed attempt.
+  - [x] No regressions in duplicate/conflict detection.
+  - [x] Tests added/updated.
+  - [x] Docs updated.
 - Tasks (step-by-step):
   1. Trace keybind recording state lifecycle and error source ownership.
   2. Add a deterministic "clear error on start" transition at recording begin event.
@@ -118,15 +129,15 @@ Why: Deliver small, feasible, risk-aware slices with strict completion gates bef
 
 ### #280 - [P2] Remove Record button and prevent title-click recording
 - Goal:
-  - Limit recording start to the dedicated edit/pencil icon control, remove explicit `Record` button, and block title text from triggering capture.
+  - Limit recording start to the shortcut input field control, remove explicit `Record` button, and block title text from triggering capture.
 - Checklist:
-  - [ ] `Record` button removed from shortcuts UI.
-  - [ ] Clicking shortcut title no longer starts recording.
-  - [ ] Intended recording trigger still functions.
-  - [ ] Tests added/updated.
-  - [ ] Docs updated.
+  - [x] `Record` button removed from shortcuts UI.
+  - [x] Clicking shortcut title no longer starts recording.
+  - [x] Intended recording trigger still functions.
+  - [x] Tests added/updated.
+  - [x] Docs updated.
 - Tasks (step-by-step):
-  1. Confirm issue #280 accepted trigger path (dedicated edit/pencil icon), then identify handlers wired to title, `Record` button, and accepted trigger.
+  1. Confirm issue #280 accepted trigger path (shortcut input field, keyboard-activatable), then identify handlers wired to title, `Record` button, and accepted trigger.
   2. Remove `Record` button rendering and related handlers.
   3. Ensure title text is non-interactive for recording start.
   4. Keep intended trigger accessible and keyboard-usable.

--- a/src/renderer/settings-api-keys-react.test.tsx
+++ b/src/renderer/settings-api-keys-react.test.tsx
@@ -53,7 +53,7 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     expect(host.querySelector('#settings-api-key-elevenlabs')).toBeNull()
   })
 
-  it('toggles visibility and calls save callback for google', async () => {
+  it('calls save callback for google without rendering a visibility toggle', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -76,13 +76,8 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     })
 
     const input = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
-    const toggle = host.querySelector<HTMLButtonElement>('[data-api-key-visibility-toggle="google"]')!
     expect(input.type).toBe('password')
-
-    await act(async () => { toggle.click() })
-    expect(input.type).toBe('text')
-    await act(async () => { toggle.click() })
-    expect(input.type).toBe('password')
+    expect(host.querySelector('[data-api-key-visibility-toggle="google"]')).toBeNull()
 
     await act(async () => { setReactInputValue(input, 'my-google-key') })
 
@@ -131,10 +126,9 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     })
 
     const input = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
-    const toggle = host.querySelector<HTMLButtonElement>('[data-api-key-visibility-toggle="google"]')!
     const saveButton = host.querySelector<HTMLButtonElement>('[data-api-key-save="google"]')!
     expect(input.value).toBe('••••••••')
-    expect(toggle.disabled).toBe(true)
+    expect(host.querySelector('[data-api-key-visibility-toggle="google"]')).toBeNull()
     expect(saveButton.disabled).toBe(true)
   })
 
@@ -166,6 +160,33 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
           onSaveApiKey={vi.fn(async () => {})}
         />
       )
+    })
+
+    const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
+    expect(rerenderedInput.value).toBe('••••••••')
+  })
+
+  it('returns to redacted indicator when focused saved field blurs without draft text', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsApiKeysReact
+          apiKeyStatus={{ groq: false, elevenlabs: false, google: true }}
+          apiKeySaveStatus={{ groq: '', elevenlabs: '', google: '' }}
+          onSaveApiKey={vi.fn(async () => {})}
+        />
+      )
+    })
+
+    const input = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
+    await act(async () => { input.focus() })
+    expect(input.value).toBe('')
+
+    await act(async () => {
+      input.blur()
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-google')!

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -5,7 +5,6 @@ Why: Issue #197 — STT provider API keys moved to SettingsSttProviderFormReact;
      now handles only the Google key so the LLM section has the same cohesive provider-form shape.
 */
 
-import { Eye, EyeOff } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot } from '../shared/ipc'
@@ -24,7 +23,6 @@ export const SettingsApiKeysReact = ({
   onSaveApiKey
 }: SettingsApiKeysReactProps) => {
   const [value, setValue] = useState('')
-  const [visible, setVisible] = useState(false)
   const [savePending, setSavePending] = useState(false)
   const [isEditingDraft, setIsEditingDraft] = useState(false)
   const hasSavedKey = apiKeyStatus.google
@@ -33,7 +31,6 @@ export const SettingsApiKeysReact = ({
   useEffect(() => {
     if (apiKeySaveStatus.google.startsWith('Saved')) {
       setValue('')
-      setVisible(false)
       setIsEditingDraft(false)
     }
   }, [apiKeySaveStatus.google])
@@ -50,7 +47,7 @@ export const SettingsApiKeysReact = ({
         <div className="mt-2 flex items-center gap-2">
           <input
             id="settings-api-key-google"
-            type={isSavedRedacted ? 'password' : visible ? 'text' : 'password'}
+            type="password"
             autoComplete="off"
             placeholder={isSavedRedacted ? 'Saved key hidden. Type to replace.' : 'Enter Google Gemini API key'}
             value={isSavedRedacted ? '••••••••' : value}
@@ -61,6 +58,11 @@ export const SettingsApiKeysReact = ({
                 setValue('')
               }
             }}
+            onBlur={() => {
+              if (value.trim().length === 0) {
+                setIsEditingDraft(false)
+              }
+            }}
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
               if (!isEditingDraft) {
                 setIsEditingDraft(true)
@@ -68,18 +70,6 @@ export const SettingsApiKeysReact = ({
               setValue(event.target.value)
             }}
           />
-          <button
-            type="button"
-            data-api-key-visibility-toggle="google"
-            className="rounded bg-secondary p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            aria-label={visible ? 'Hide Google Gemini API key' : 'Show Google Gemini API key'}
-            disabled={isSavedRedacted}
-            onClick={() => { setVisible((v) => !v) }}
-          >
-            {visible
-              ? <EyeOff className="size-3.5" aria-hidden="true" />
-              : <Eye className="size-3.5" aria-hidden="true" />}
-          </button>
         </div>
       </label>
       <div className="flex items-center gap-2">

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -174,10 +174,9 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const input = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
-    const toggle = host.querySelector<HTMLButtonElement>('[data-api-key-visibility-toggle="groq"]')!
     const saveButton = host.querySelector<HTMLButtonElement>('[data-api-key-save="groq"]')!
     expect(input.value).toBe('••••••••')
-    expect(toggle.disabled).toBe(true)
+    expect(host.querySelector('[data-api-key-visibility-toggle="groq"]')).toBeNull()
     expect(saveButton.disabled).toBe(true)
   })
 
@@ -209,6 +208,32 @@ describe('SettingsSttProviderFormReact', () => {
           apiKeySaveStatus={{ groq: 'Saved.', elevenlabs: '', google: '' }}
         />
       )
+    })
+
+    const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
+    expect(rerenderedInput.value).toBe('••••••••')
+  })
+
+  it('returns to redacted indicator when focused saved field blurs without draft text', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsSttProviderFormReact
+          {...defaultProps}
+          apiKeyStatus={{ groq: true, elevenlabs: false, google: false }}
+        />
+      )
+    })
+
+    const input = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
+    await act(async () => { input.focus() })
+    expect(input.value).toBe('')
+
+    await act(async () => {
+      input.blur()
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -5,7 +5,6 @@ Why: Issue #197 — replace separate per-provider API key sections with one cohe
      so that model options, API key, and base URL all follow the selected provider.
 */
 
-import { Eye, EyeOff } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import {
@@ -41,7 +40,6 @@ export const SettingsSttProviderFormReact = ({
   const [selectedProvider, setSelectedProvider] = useState(settings.transcription.provider)
   const [selectedModel, setSelectedModel] = useState(settings.transcription.model)
   const [apiKeyValue, setApiKeyValue] = useState('')
-  const [apiKeyVisible, setApiKeyVisible] = useState(false)
   const [savePending, setSavePending] = useState(false)
   const [isEditingDraft, setIsEditingDraft] = useState(false)
 
@@ -50,7 +48,6 @@ export const SettingsSttProviderFormReact = ({
     setSelectedProvider(settings.transcription.provider)
     setSelectedModel(settings.transcription.model)
     setApiKeyValue('')
-    setApiKeyVisible(false)
     setIsEditingDraft(false)
   }, [settings.transcription.provider, settings.transcription.model])
 
@@ -59,7 +56,6 @@ export const SettingsSttProviderFormReact = ({
   useEffect(() => {
     if (selectedProviderSaveStatus.startsWith('Saved')) {
       setApiKeyValue('')
-      setApiKeyVisible(false)
       setIsEditingDraft(false)
     }
   }, [selectedProviderSaveStatus])
@@ -83,10 +79,9 @@ export const SettingsSttProviderFormReact = ({
             const nextModel = STT_MODEL_ALLOWLIST[provider][0]
             setSelectedProvider(provider)
             setSelectedModel(nextModel)
-            // Clear API key value and visibility when provider changes
+            // Clear API key draft when provider changes
             // to avoid showing a stale key for the previous provider.
             setApiKeyValue('')
-            setApiKeyVisible(false)
             setIsEditingDraft(false)
             onSelectTranscriptionProvider(provider)
           }}
@@ -127,7 +122,7 @@ export const SettingsSttProviderFormReact = ({
         <div className="mt-2 flex items-center gap-2">
           <input
             id={`settings-api-key-${selectedProvider}`}
-            type={isSavedRedacted ? 'password' : apiKeyVisible ? 'text' : 'password'}
+            type="password"
             autoComplete="off"
             placeholder={isSavedRedacted ? 'Saved key hidden. Type to replace.' : `Enter ${providerLabel} API key`}
             value={isSavedRedacted ? '••••••••' : apiKeyValue}
@@ -144,19 +139,12 @@ export const SettingsSttProviderFormReact = ({
                 setApiKeyValue('')
               }
             }}
+            onBlur={() => {
+              if (apiKeyValue.trim().length === 0) {
+                setIsEditingDraft(false)
+              }
+            }}
           />
-          <button
-            type="button"
-            data-api-key-visibility-toggle={selectedProvider}
-            className="rounded bg-secondary p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            aria-label={apiKeyVisible ? `Hide ${providerLabel} API key` : `Show ${providerLabel} API key`}
-            disabled={isSavedRedacted}
-            onClick={() => { setApiKeyVisible((v) => !v) }}
-          >
-            {apiKeyVisible
-              ? <EyeOff className="size-3.5" aria-hidden="true" />
-              : <Eye className="size-3.5" aria-hidden="true" />}
-          </button>
         </div>
       </label>
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove API key visibility/reveal eye toggles from STT and Google settings forms
- keep API keys always password-masked and redacted when saved
- add blur regression coverage to restore redacted mode when user focuses then leaves without typing
- update decision docs to match no-toggle behavior
- update docs/github-issues-247-278-280-work-plan.md with completed execution status and closed-ticket evidence

## Validation
- pnpm vitest run src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/settings-api-keys-react.test.tsx
- sub-agent review run (no high/medium findings)
- claude review run (low findings addressed)
