### PR TITLE
style: #255 standardize select controls across Audio Input, Profiles, Settings

### DIFF
--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -514,4 +514,35 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(userPromptInput?.getAttribute('aria-invalid')).toBe('true')
     expect(userPromptInput?.getAttribute('aria-describedby')).toContain('profile-edit-user-prompt-error-')
   })
+
+  // Issue #255: style regression guard — edit-form selects must use w-full, rounded-md, bg-input/30.
+  it('renders edit-form provider and model selects with standardized token classes', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...buildCallbacks()}
+      />
+    )
+    await flush()
+
+    // Open the edit form
+    const firstCard = host.querySelector<HTMLDivElement>('[role="button"]')
+    firstCard?.click()
+    await flush()
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#profile-edit-provider')!
+    const modelSelect = host.querySelector<HTMLSelectElement>('#profile-edit-model')!
+
+    for (const [id, el] of [['provider', providerSelect], ['model', modelSelect]] as const) {
+      expect(el.className, `${id} should have w-full`).toContain('w-full')
+      expect(el.className, `${id} should have rounded-md`).toContain('rounded-md')
+      expect(el.className, `${id} should have bg-input/30`).toContain('bg-input/30')
+    }
+    // Model select has hover/focus; provider is disabled so no hover/focus required
+    expect(modelSelect.className).toContain('focus-visible:ring-2')
+  })
 })

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -210,7 +210,7 @@ const ProfileEditForm = ({
           id="profile-edit-provider"
           value="google"
           disabled
-          className="h-7 rounded border border-input bg-background px-2 text-xs disabled:opacity-60"
+          className="w-full h-7 rounded-md border border-input bg-input/30 px-2 text-xs disabled:opacity-60"
         >
           <option value="google">google</option>
         </select>
@@ -225,7 +225,7 @@ const ProfileEditForm = ({
           onChange={(e: ChangeEvent<HTMLSelectElement>) => {
             onChangeDraft({ model: e.target.value as TransformationPreset['model'] })
           }}
-          className="h-7 rounded border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="w-full h-7 rounded-md border border-input bg-input/30 hover:bg-input/50 px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
         >
           <option value="gemini-2.5-flash">gemini-2.5-flash</option>
         </select>

--- a/src/renderer/settings-recording-react.test.tsx
+++ b/src/renderer/settings-recording-react.test.tsx
@@ -161,4 +161,46 @@ describe('SettingsRecordingReact', () => {
     expect(host.querySelectorAll('#settings-help-stt-language')).toHaveLength(1)
     expect(host.querySelectorAll('#settings-audio-sources-message')).toHaveLength(1)
   })
+
+  // Issue #255: style regression guard — selects must use the standardized token class set.
+  it('renders all selects with standardized token classes and labels with muted-foreground', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsRecordingReact
+          settings={DEFAULT_SETTINGS}
+          audioInputSources={[{ id: 'system_default', label: 'System Default Microphone' }]}
+          audioSourceHint="hint"
+          onRefreshAudioSources={vi.fn().mockResolvedValue(undefined)}
+          onSelectRecordingMethod={vi.fn()}
+          onSelectRecordingSampleRate={vi.fn()}
+          onSelectRecordingDevice={vi.fn()}
+          onSelectTranscriptionProvider={vi.fn()}
+          onSelectTranscriptionModel={vi.fn()}
+        />
+      )
+    })
+
+    const selectIds = [
+      '#settings-transcription-provider',
+      '#settings-transcription-model',
+      '#settings-recording-method',
+      '#settings-recording-sample-rate',
+      '#settings-recording-device'
+    ]
+    for (const id of selectIds) {
+      const el = host.querySelector<HTMLSelectElement>(id)!
+      expect(el.className, `${id} should have w-full`).toContain('w-full')
+      expect(el.className, `${id} should have rounded-md`).toContain('rounded-md')
+      expect(el.className, `${id} should have bg-input/30`).toContain('bg-input/30')
+      expect(el.className, `${id} should have focus-visible:ring-2`).toContain('focus-visible:ring-2')
+    }
+
+    // Wrapping labels should have gap-2 and label spans should carry text-muted-foreground
+    const labelSpans = host.querySelectorAll<HTMLSpanElement>('label > span.text-muted-foreground')
+    expect(labelSpans.length).toBeGreaterThanOrEqual(5)
+  })
 })

--- a/src/renderer/settings-recording-react.tsx
+++ b/src/renderer/settings-recording-react.tsx
@@ -3,6 +3,7 @@ Where: src/renderer/settings-recording-react.tsx
 What: React-rendered Settings recording controls section.
 Why: Continue Settings migration to React while preserving selectors and behavior parity.
      Migrated from .ts (createElement) to .tsx (JSX) as part of the project-wide TSX migration.
+     Issue #255: standardized select-like controls to app design-token pattern.
 */
 
 import { useEffect, useState } from 'react'
@@ -35,6 +36,11 @@ const sttProviderOptions: Array<{ value: Settings['transcription']['provider']; 
   { value: 'groq', label: 'Groq' },
   { value: 'elevenlabs', label: 'ElevenLabs' }
 ]
+
+// Shared class set for all select-like controls per issue #255 / style-update.md §4.
+// w-full: stretch to section width; rounded-md: matches --radius; bg-input/30 + hover: semi-transparent input surface.
+const SELECT_CLS = 'w-full h-8 rounded-md border border-input bg-input/30 hover:bg-input/50 px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors'
+const SELECT_MONO_CLS = `${SELECT_CLS} font-mono`
 
 export const SettingsRecordingReact = ({
   settings,
@@ -87,11 +93,11 @@ export const SettingsRecordingReact = ({
           <p className="text-[11px] text-muted-foreground" id="settings-help-stt-language">
             STT language defaults to auto-detect. Advanced override: set `transcription.outputLanguage` in the settings file to an ISO language code (for example `en` or `ja`).
           </p>
-          <label className="flex flex-col gap-1.5 text-xs">
-            <span>STT provider</span>
+          <label className="flex flex-col gap-2 text-xs">
+            <span className="text-muted-foreground">STT provider</span>
             <select
               id="settings-transcription-provider"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CLS}
               value={selectedProvider}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const provider = event.target.value as Settings['transcription']['provider']
@@ -106,11 +112,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="flex flex-col gap-1.5 text-xs">
-            <span>STT model</span>
+          <label className="flex flex-col gap-2 text-xs">
+            <span className="text-muted-foreground">STT model</span>
             <select
               id="settings-transcription-model"
-              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              className={SELECT_MONO_CLS}
               value={selectedModel}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const model = event.target.value as Settings['transcription']['model']
@@ -130,11 +136,11 @@ export const SettingsRecordingReact = ({
           {!showLegacyHeading && (
             <p className="text-[11px] text-muted-foreground">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
           )}
-          <label className="flex flex-col gap-1.5 text-xs">
-            <span>Recording method</span>
+          <label className="flex flex-col gap-2 text-xs">
+            <span className="text-muted-foreground">Recording method</span>
             <select
               id="settings-recording-method"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CLS}
               value={selectedRecordingMethod}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const method = event.target.value as Settings['recording']['method']
@@ -147,11 +153,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="flex flex-col gap-1.5 text-xs">
-            <span>Sample rate</span>
+          <label className="flex flex-col gap-2 text-xs">
+            <span className="text-muted-foreground">Sample rate</span>
             <select
               id="settings-recording-sample-rate"
-              className="h-8 rounded border border-input bg-input px-2 text-xs"
+              className={SELECT_CLS}
               value={String(selectedSampleRate)}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const sampleRate = Number(event.target.value) as Settings['recording']['sampleRateHz']
@@ -164,11 +170,11 @@ export const SettingsRecordingReact = ({
               ))}
             </select>
           </label>
-          <label className="flex flex-col gap-1.5 text-xs">
-            <span>Audio source</span>
+          <label className="flex flex-col gap-2 text-xs">
+            <span className="text-muted-foreground">Audio source</span>
             <select
               id="settings-recording-device"
-              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              className={SELECT_MONO_CLS}
               value={selectedRecordingDevice}
               onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                 const deviceId = event.target.value

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -295,6 +295,30 @@ describe('SettingsSttProviderFormReact', () => {
     expect(elevenLabsInput.value).toBe('••••••••')
   })
 
+  // Issue #255: style regression guard — provider/model selects must use standardized token classes.
+  it('renders provider and model selects with standardized token classes and muted-foreground labels', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(<SettingsSttProviderFormReact {...defaultProps} />)
+    })
+
+    const providerSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-provider')!
+    const modelSelect = host.querySelector<HTMLSelectElement>('#settings-transcription-model')!
+
+    for (const [id, el] of [['provider', providerSelect], ['model', modelSelect]] as const) {
+      expect(el.className, `${id} should have w-full`).toContain('w-full')
+      expect(el.className, `${id} should have rounded-md`).toContain('rounded-md')
+      expect(el.className, `${id} should have bg-input/30`).toContain('bg-input/30')
+      expect(el.className, `${id} should have focus-visible:ring-2`).toContain('focus-visible:ring-2')
+    }
+
+    const mutedSpans = host.querySelectorAll<HTMLSpanElement>('label > span.text-muted-foreground')
+    expect(mutedSpans.length).toBeGreaterThanOrEqual(2)
+  })
+
   it('does not call save while selected provider key is in redacted mode', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -3,6 +3,7 @@ Where: src/renderer/settings-stt-provider-form-react.tsx
 What: Unified STT provider form — provider, model, API key, and base URL in one section.
 Why: Issue #197 — replace separate per-provider API key sections with one cohesive provider form
      so that model options, API key, and base URL all follow the selected provider.
+     Issue #255: standardized select-like controls to app design-token pattern.
 */
 
 import { useEffect, useState } from 'react'
@@ -28,6 +29,10 @@ const sttProviderOptions: Array<{ value: Settings['transcription']['provider']; 
 ]
 
 const statusText = (saved: boolean): string => (saved ? 'Saved' : 'Not set')
+
+// Shared select class set per issue #255 / style-update.md §4.
+const SELECT_CLS = 'w-full h-8 rounded-md border border-input bg-input/30 hover:bg-input/50 px-2 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors'
+const SELECT_MONO_CLS = `${SELECT_CLS} font-mono`
 
 export const SettingsSttProviderFormReact = ({
   settings,
@@ -68,11 +73,11 @@ export const SettingsSttProviderFormReact = ({
   return (
     <div className="space-y-3">
       {/* Provider selector */}
-      <label className="flex flex-col gap-1.5 text-xs">
-        <span>STT provider</span>
+      <label className="flex flex-col gap-2 text-xs">
+        <span className="text-muted-foreground">STT provider</span>
         <select
           id="settings-transcription-provider"
-          className="h-8 rounded border border-input bg-input px-2 text-xs"
+          className={SELECT_CLS}
           value={selectedProvider}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const provider = event.target.value as Settings['transcription']['provider']
@@ -93,11 +98,11 @@ export const SettingsSttProviderFormReact = ({
       </label>
 
       {/* Model selector — filtered to selected provider's allowlist */}
-      <label className="flex flex-col gap-1.5 text-xs">
-        <span>STT model</span>
+      <label className="flex flex-col gap-2 text-xs">
+        <span className="text-muted-foreground">STT model</span>
         <select
           id="settings-transcription-model"
-          className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+          className={SELECT_MONO_CLS}
           value={selectedModel}
           onChange={(event: ChangeEvent<HTMLSelectElement>) => {
             const model = event.target.value as Settings['transcription']['model']


### PR DESCRIPTION
Closes #255

## Summary

- Applies consistent field pattern to all native `<select>` elements in Audio Input, Profiles, and Settings tabs
- No new dependencies (Path A: native select + improved Tailwind tokens)
- Zero behavior changes — only class name updates

## Files changed

| File | Selects updated |
|------|----------------|
| `settings-recording-react.tsx` | 5 (provider, model, method, sample-rate, device) |
| `settings-stt-provider-form-react.tsx` | 2 (provider, model) |
| `profiles-panel-react.tsx` | 2 (provider, model in ProfileEditForm) |

## Token changes (per `style-update.md §4`)

| Token | Before | After |
|-------|--------|-------|
| Width | missing | `w-full` |
| Radius | `rounded` | `rounded-md` (matches `--radius: 0.5rem`) |
| Background | `bg-input` | `bg-input/30 hover:bg-input/50` |
| Focus ring | missing | `focus-visible:ring-2 focus-visible:ring-ring` |
| Gap | `gap-1.5` | `gap-2` |
| Label color | missing | `<span className="text-muted-foreground">` |

Profiles edit-form labels kept at `text-[10px]` (correct per spec §6.4 — not changed).
Wrapping-label DOM pattern preserved throughout (no `htmlFor` restructuring).

## Out of scope

- Output radio cards, API key inputs, shortcut editor, toggle switches
- Business logic, IPC contracts, recording behavior

## Test plan

- [ ] `pnpm test -- src/renderer/settings-recording-react.test.tsx src/renderer/settings-stt-provider-form-react.test.tsx src/renderer/profiles-panel-react.test.tsx` → 33 tests pass
- [ ] 1 pre-existing failure in `settings-shortcut-editor-react.test.tsx` (unrelated, exists on `main`)
- [ ] 4 pre-existing typecheck errors in `app-shell-react`, `native-recording` (unrelated, exist on `main`)
- [ ] Shared `SELECT_CLS` / `SELECT_MONO_CLS` constants prevent class drift across selects

🤖 Generated with [Claude Code](https://claude.com/claude-code)