### PR TITLE
test: fix shortcut stale-error test and add picker --text token assertion

### DIFF
--- a/src/main/services/profile-picker-service.test.ts
+++ b/src/main/services/profile-picker-service.test.ts
@@ -104,6 +104,7 @@ describe('buildPickerHtml', () => {
     expect(html).toContain('--card: #1e1e25;')
     expect(html).toContain('--background: #1a1a1f;')
     expect(html).toContain('--border: #363641;')
+    expect(html).toContain('--text: #f2f2f2;')
     expect(html).toContain('--muted: #898990;')
     expect(html).toContain('--accent: #2b2b34;')
     expect(html).toContain('--focus: #44c97b;')

--- a/src/renderer/settings-shortcut-editor-react.test.tsx
+++ b/src/renderer/settings-shortcut-editor-react.test.tsx
@@ -134,40 +134,6 @@ describe('SettingsShortcutEditorReact', () => {
     expect(host.querySelector('#settings-error-run-transform')?.textContent).toBe('')
   })
 
-  it('clears stale capture error when starting a different shortcut via Record button', async () => {
-    const host = document.createElement('div')
-    document.body.append(host)
-    root = createRoot(host)
-
-    await act(async () => {
-      root?.render(
-        <SettingsShortcutEditorReact
-          settings={DEFAULT_SETTINGS}
-          validationErrors={{}}
-          onChangeShortcutDraft={() => {}}
-        />
-      )
-    })
-
-    const runTransformInput = host.querySelector<HTMLInputElement>('#settings-shortcut-run-transform')
-    await act(async () => {
-      runTransformInput?.click()
-    })
-    await act(async () => {
-      runTransformInput?.dispatchEvent(
-        new KeyboardEvent('keydown', { key: '9', bubbles: true, cancelable: true })
-      )
-    })
-    expect(host.querySelector('#settings-error-run-transform')?.textContent).toContain('at least one modifier key')
-
-    const toggleRecordButton = host.querySelector<HTMLButtonElement>('[data-shortcut-capture-toggle="toggleRecording"]')
-    await act(async () => {
-      toggleRecordButton?.click()
-    })
-
-    expect(host.querySelector('#settings-error-run-transform')?.textContent).toBe('')
-  })
-
   it('does not start capture mode when field is focused via keyboard navigation', async () => {
     const host = document.createElement('div')
     document.body.append(host)


### PR DESCRIPTION
## Summary

- **Remove** pre-existing failing test `'clears stale capture error when starting a different shortcut via Record button'` in `settings-shortcut-editor-react.test.tsx`. The test referenced a `[data-shortcut-capture-toggle]` button that the component intentionally does not render (this absence is guarded by `'does not render Record buttons in shortcut editor'`). The stale-error clearing behavior is fully covered by the existing test at line 103 which uses the input-click path.
- **Add** `--text: #f2f2f2` assertion to `profile-picker-service.test.ts` to close a gap flagged by the peer codex review: the `--text` token was updated in #252 but had no corresponding test assertion.

## Out of scope

- No production code changes — tests only.
- No changes to shortcut editor or picker service logic.

## Test plan

- [x] `pnpm test` — 73 files pass, 536 tests pass, 4 skipped, 1 todo
- [x] Codex peer review completed — confirms removal was correct; `--text` gap identified and closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)