### PR TITLE
fix: remove home/recording helper text (issue #294)

### DIFF
--- a/docs/decisions/remove-home-and-recording-helper-text.md
+++ b/docs/decisions/remove-home-and-recording-helper-text.md
@@ -1,0 +1,27 @@
+<!--
+Where: docs/decisions/remove-home-and-recording-helper-text.md
+What: Decision record for removing low-value instructional helper copy from Home and Recording settings UI.
+Why: Issue #294 requests cleaner panels without redundant instructional text or leftover spacing.
+-->
+
+# Decision: Remove Home/Recording Helper Text
+
+## Status
+Accepted - March 1, 2026
+
+## Context
+Two helper strings added visual noise without adding actionable value for current v1 workflows:
+- Home idle helper text: `Click to record`
+- Recording helper text in settings: `Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.`
+
+Issue #294 requires these texts to be removed without introducing spacing regressions.
+
+## Decision
+- Remove idle helper text from the Home recording panel.
+- Remove the recording helper paragraph from the recording settings component (all section modes).
+- Keep existing functional controls, blocked-state messaging, and command behavior unchanged.
+
+## Consequences
+- Home and settings panels are less verbose and visually cleaner.
+- Layout remains stable because only text nodes were removed; control structure is unchanged.
+- Tests are updated to enforce absence of removed strings.

--- a/docs/style-update.md
+++ b/docs/style-update.md
@@ -184,7 +184,7 @@ Three states only — `idle`, `recording`, `processing`:
 
 | State | Button | Icon | Label |
 |---|---|---|---|
-| `idle` | `bg-primary size-20 rounded-full` | `Mic size-7` | `text-sm text-muted-foreground` "Click to record" |
+| `idle` | `bg-primary size-20 rounded-full` | `Mic size-7` | no helper text label |
 | `recording` | `bg-recording size-20 rounded-full` | `Square size-7 fill-current` | `font-mono text-lg text-recording tabular-nums` timer + Cancel link |
 | `processing` | `bg-muted size-20 opacity-60 cursor-not-allowed` | `Mic size-7` | `text-sm text-muted-foreground animate-pulse` "Processing..." |
 

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -144,9 +144,7 @@ test('shows Home operational cards and hides Session Activity panel by default',
   await expect(page.getByRole('button', { name: 'Start recording' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Cancel recording' })).toHaveCount(0)
   await expect(page.getByRole('button', { name: 'Transform' })).toHaveCount(0)
-  await expect(
-    page.locator('article').filter({ has: page.getByRole('heading', { name: 'Recording Controls' }) }).getByText('Click to record')
-  ).toBeVisible()
+  await expect(page.getByText('Click to record')).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Processing History' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Session Activity' })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Shortcut Contract' })).toHaveCount(0)
@@ -475,7 +473,7 @@ test('records and stops with fake microphone audio fixture smoke @macos', async 
     await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Start recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toHaveCount(0)
-    await expect(page.getByText('Click to record')).toBeVisible()
+    await expect(page.getByText('Click to record')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Cancel recording' })).toHaveCount(0)
 
     let observedSubmission = false
@@ -758,7 +756,7 @@ test('records and stops with deterministic synthetic microphone stream and repor
     await expect(page.getByRole('log', { name: 'Activity feed' }).getByText('Recording captured and queued for transcription.')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Start recording' })).toBeVisible()
     await expect(page.getByRole('timer')).toHaveCount(0)
-    await expect(page.getByText('Click to record')).toBeVisible()
+    await expect(page.getByText('Click to record')).toHaveCount(0)
     await expect(page.getByRole('button', { name: 'Cancel recording' })).toHaveCount(0)
 
     let observedSubmission = false

--- a/src/renderer/home-react.test.tsx
+++ b/src/renderer/home-react.test.tsx
@@ -34,7 +34,7 @@ afterEach(() => {
 })
 
 describe('HomeReact recording button (STY-03)', () => {
-  it('renders idle state with Mic icon and "Click to record" label', async () => {
+  it('renders idle state with Mic icon and without helper text label', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -56,8 +56,8 @@ describe('HomeReact recording button (STY-03)', () => {
     const btn = host.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')
     expect(btn).not.toBeNull()
     expect(btn?.disabled).toBe(false)
-    // Idle label
-    expect(host.textContent).toContain('Click to record')
+    // No idle helper text label per issue #294
+    expect(host.textContent).not.toContain('Click to record')
     expect(host.querySelector('[aria-label="Open settings panel"]')).toBeNull()
     // No timer in idle state
     expect(host.querySelector('[role="timer"]')).toBeNull()
@@ -94,7 +94,7 @@ describe('HomeReact recording button (STY-03)', () => {
     expect(host.querySelector('[role="timer"]')).not.toBeNull()
     // Cancel affordance present
     expect(host.querySelector('[aria-label="Cancel recording"]')).not.toBeNull()
-    // No "Click to record" label during recording
+    // Idle helper text remains removed while recording state is active
     expect(host.textContent).not.toContain('Click to record')
   })
 
@@ -194,6 +194,7 @@ describe('HomeReact recording button (STY-03)', () => {
 
     // Blocked reason shown via role="alert"
     expect(host.querySelector('[role="alert"]')).not.toBeNull()
+    expect(host.textContent).toContain('Recording is blocked because the Groq API key is missing')
 
     // Open Settings deep-link works
     const openSettingsButton = host.querySelector<HTMLButtonElement>('button')

--- a/src/renderer/home-react.tsx
+++ b/src/renderer/home-react.tsx
@@ -194,11 +194,11 @@ export const HomeReact = ({
           <span className="text-sm text-muted-foreground animate-pulse" role="status">
             Processing...
           </span>
-        ) : (
+        ) : recordingBlocked ? (
           <span className="text-sm text-muted-foreground">
-            {recordingBlocked ? recordingBlocked.reason.split('.')[0] : 'Click to record'}
+            {recordingBlocked.reason.split('.')[0]}
           </span>
-        )}
+        ) : null}
 
         {/* Cancel affordance — recording state only per spec section 6.1 */}
         {isRecording && (

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -162,7 +162,7 @@ describe('renderer app', () => {
     expect(mountPoint.querySelector('[data-route-tab="settings"]')).not.toBeNull()
     expect(mountPoint.textContent).toContain('Speech-to-Text v1')
     // STY-03: "Recording Controls" heading removed; recording is indicated by the
-    // circular button with aria-label and the "Click to record" label below it.
+    // circular button with aria-label.
     expect(mountPoint.querySelector('[aria-label="Start recording"]')).not.toBeNull()
     expect(mountPoint.textContent).not.toContain('Shortcut Contract')
   })

--- a/src/renderer/settings-recording-react.test.tsx
+++ b/src/renderer/settings-recording-react.test.tsx
@@ -67,6 +67,7 @@ describe('SettingsRecordingReact', () => {
     expect(host.querySelector<HTMLElement>('#settings-audio-sources-message')?.textContent).toContain('Detected 1 selectable')
     expect(host.querySelector<HTMLElement>('#settings-help-stt-language')?.textContent).toContain('auto-detect')
     expect(host.querySelector<HTMLElement>('#settings-help-stt-language')?.textContent).toContain('outputLanguage')
+    expect(host.textContent).not.toContain('Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.')
 
     const method = host.querySelector<HTMLSelectElement>('#settings-recording-method')
     await act(async () => {
@@ -160,6 +161,7 @@ describe('SettingsRecordingReact', () => {
     expect(host.querySelectorAll('#settings-recording-device')).toHaveLength(1)
     expect(host.querySelectorAll('#settings-help-stt-language')).toHaveLength(1)
     expect(host.querySelectorAll('#settings-audio-sources-message')).toHaveLength(1)
+    expect(host.textContent).not.toContain('Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.')
   })
 
   // Issue #255: style regression guard — selects must use the standardized token class set.

--- a/src/renderer/settings-recording-react.tsx
+++ b/src/renderer/settings-recording-react.tsx
@@ -85,7 +85,6 @@ export const SettingsRecordingReact = ({
       {showLegacyHeading && (
         <>
           <h3>Recording</h3>
-          <p className="text-[11px] text-muted-foreground">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
         </>
       )}
       {renderSpeechToTextControls && (
@@ -133,9 +132,6 @@ export const SettingsRecordingReact = ({
       )}
       {renderAudioControls && (
         <>
-          {!showLegacyHeading && (
-            <p className="text-[11px] text-muted-foreground">Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.</p>
-          )}
           <label className="flex flex-col gap-2 text-xs">
             <span className="text-muted-foreground">Recording method</span>
             <select


### PR DESCRIPTION
## Summary
Implements issue #294 by removing the two requested helper strings and keeping layout stable.

## Changes
- Remove Home idle helper text `Click to record` from recording controls panel.
- Remove settings helper paragraph:
  - `Recording is enabled in v1. If capture fails, verify microphone permission and audio device availability.`
- Keep blocked-state alert and Open Settings deep-link behavior unchanged.
- Update tests and e2e assertions to enforce absence of removed strings.
- Update style spec and add decision record documenting the contract change.

## Files
- `src/renderer/home-react.tsx`
- `src/renderer/settings-recording-react.tsx`
- `src/renderer/home-react.test.tsx`
- `src/renderer/settings-recording-react.test.tsx`
- `e2e/electron-ui.e2e.ts`
- `docs/style-update.md`
- `docs/decisions/remove-home-and-recording-helper-text.md`

## Verification
- `pnpm test -- src/renderer/home-react.test.tsx src/renderer/settings-recording-react.test.tsx src/renderer/renderer-app.test.ts`
  - pass
- `pnpm typecheck`
  - fails on pre-existing baseline files unrelated to this ticket:
    - `src/renderer/app-shell-react.test.tsx`
    - `src/renderer/app-shell-react.tsx`
    - `src/renderer/native-recording.test.ts`

## Rollback
Revert this PR commit to restore previous helper text behavior.

Closes #294
