### PR TITLE
fix: use fixed 50-char API key mask (issue #297)

### DIFF
--- a/docs/decisions/api-key-redaction-after-save.md
+++ b/docs/decisions/api-key-redaction-after-save.md
@@ -13,7 +13,7 @@ Why: Issue #247 requires saved keys to remain hidden by default in Settings.
 ## Decision
 
 Use always-redacted display when a provider key is saved and no new draft is being edited:
-- show masked value indicator (`••••••••`);
+- show fixed-length masked value indicator (`**************************************************`);
 - remove the visibility toggle entirely so persisted secrets can never be revealed in-app;
 - switch to editable draft mode when the user focuses/types to replace;
 - clear plaintext draft and return to redacted mode when save status becomes `Saved`.

--- a/docs/decisions/fixed-api-key-mask.md
+++ b/docs/decisions/fixed-api-key-mask.md
@@ -1,0 +1,26 @@
+<!--
+Where: docs/decisions/fixed-api-key-mask.md
+What: Decision record for fixed-length API key mask rendering.
+Why: Issue #297 requires non-inferable key length in masked UI state.
+-->
+
+# Decision: Fixed-Length API Key Mask
+
+## Status
+Accepted - March 1, 2026
+
+## Context
+Masked API key fields previously used a short decorative token, which did not represent a strict redaction contract across all forms.
+
+Issue #297 requires masked API keys to display as exactly 50 `*` characters so key length cannot be inferred from UI.
+
+## Decision
+- Introduce a shared renderer constant `FIXED_API_KEY_MASK`.
+- Set `FIXED_API_KEY_MASK` to 50 asterisks.
+- Reuse this constant in all masked API key fields (Google + STT provider forms).
+- Add tests to enforce the 50-character mask contract.
+
+## Consequences
+- Mask rendering is consistent across all provider forms.
+- UI no longer leaks key length via mask length.
+- Future redaction changes have a single source of truth.

--- a/src/renderer/api-key-mask.test.ts
+++ b/src/renderer/api-key-mask.test.ts
@@ -1,0 +1,15 @@
+/*
+Where: src/renderer/api-key-mask.test.ts
+What: Unit tests for fixed API key mask contract.
+Why: Issue #297 requires an exact constant-length redaction string.
+*/
+
+import { describe, expect, it } from 'vitest'
+import { FIXED_API_KEY_MASK } from './api-key-mask'
+
+describe('FIXED_API_KEY_MASK', () => {
+  it('is exactly 50 asterisks', () => {
+    expect(FIXED_API_KEY_MASK).toMatch(/^\*+$/)
+    expect(FIXED_API_KEY_MASK).toHaveLength(50)
+  })
+})

--- a/src/renderer/api-key-mask.ts
+++ b/src/renderer/api-key-mask.ts
@@ -1,0 +1,7 @@
+/*
+Where: src/renderer/api-key-mask.ts
+What: Shared fixed redaction string for masked API key input rendering.
+Why: Issue #297 requires a constant-length mask so saved key length cannot be inferred from UI.
+*/
+
+export const FIXED_API_KEY_MASK = '*'.repeat(50)

--- a/src/renderer/settings-api-keys-react.test.tsx
+++ b/src/renderer/settings-api-keys-react.test.tsx
@@ -11,6 +11,7 @@ Why: Guard that individual save/test callbacks fire correctly for the Google pro
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FIXED_API_KEY_MASK } from './api-key-mask'
 import { SettingsApiKeysReact } from './settings-api-keys-react'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -137,7 +138,7 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     })
 
     const input = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
-    expect(input.value).toBe('••••••••')
+    expect(input.value).toBe(FIXED_API_KEY_MASK)
     expect(host.querySelector('[data-api-key-visibility-toggle="google"]')).toBeNull()
     expect(host.querySelector('[data-api-key-save="google"]')).toBeNull()
   })
@@ -173,7 +174,7 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
-    expect(rerenderedInput.value).toBe('••••••••')
+    expect(rerenderedInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   it('returns to redacted indicator when focused saved field blurs without draft text', async () => {
@@ -200,7 +201,7 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-google')!
-    expect(rerenderedInput.value).toBe('••••••••')
+    expect(rerenderedInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   it('does not call save when blurred after focusing a saved field without draft text', async () => {

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -8,6 +8,7 @@ Why: Issue #197 — STT provider API keys moved to SettingsSttProviderFormReact;
 import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot } from '../shared/ipc'
+import { FIXED_API_KEY_MASK } from './api-key-mask'
 
 interface SettingsApiKeysReactProps {
   apiKeyStatus: ApiKeyStatusSnapshot
@@ -49,7 +50,7 @@ export const SettingsApiKeysReact = ({
             type="password"
             autoComplete="off"
             placeholder={isSavedRedacted ? 'Saved key hidden. Type to replace.' : 'Enter Google Gemini API key'}
-            value={isSavedRedacted ? '••••••••' : value}
+            value={isSavedRedacted ? FIXED_API_KEY_MASK : value}
             className="h-8 flex-1 rounded border border-input bg-input px-2 text-xs font-mono text-foreground"
             onFocus={() => {
               if (isSavedRedacted) {

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -11,6 +11,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS, STT_MODEL_ALLOWLIST } from '../shared/domain'
+import { FIXED_API_KEY_MASK } from './api-key-mask'
 import { SettingsSttProviderFormReact } from './settings-stt-provider-form-react'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -174,7 +175,7 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const input = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
-    expect(input.value).toBe('••••••••')
+    expect(input.value).toBe(FIXED_API_KEY_MASK)
     expect(host.querySelector('[data-api-key-visibility-toggle="groq"]')).toBeNull()
     expect(host.querySelector('[data-api-key-save="groq"]')).toBeNull()
   })
@@ -210,7 +211,7 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
-    expect(rerenderedInput.value).toBe('••••••••')
+    expect(rerenderedInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   it('returns to redacted indicator when focused saved field blurs without draft text', async () => {
@@ -236,7 +237,7 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const rerenderedInput = host.querySelector<HTMLInputElement>('#settings-api-key-groq')!
-    expect(rerenderedInput.value).toBe('••••••••')
+    expect(rerenderedInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   it('clears unsaved draft when switching providers so no stale plaintext leaks across tabs', async () => {
@@ -264,7 +265,7 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const elevenLabsInput = host.querySelector<HTMLInputElement>('#settings-api-key-elevenlabs')!
-    expect(elevenLabsInput.value).toBe('••••••••')
+    expect(elevenLabsInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   it('shows redacted destination key when switching from unsaved source provider with a draft', async () => {
@@ -291,7 +292,7 @@ describe('SettingsSttProviderFormReact', () => {
     })
 
     const elevenLabsInput = host.querySelector<HTMLInputElement>('#settings-api-key-elevenlabs')!
-    expect(elevenLabsInput.value).toBe('••••••••')
+    expect(elevenLabsInput.value).toBe(FIXED_API_KEY_MASK)
   })
 
   // Issue #255: style regression guard — provider/model selects must use standardized token classes.

--- a/src/renderer/settings-stt-provider-form-react.tsx
+++ b/src/renderer/settings-stt-provider-form-react.tsx
@@ -13,6 +13,7 @@ import {
   type Settings
 } from '../shared/domain'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot } from '../shared/ipc'
+import { FIXED_API_KEY_MASK } from './api-key-mask'
 
 interface SettingsSttProviderFormReactProps {
   settings: Settings
@@ -129,7 +130,7 @@ export const SettingsSttProviderFormReact = ({
             type="password"
             autoComplete="off"
             placeholder={isSavedRedacted ? 'Saved key hidden. Type to replace.' : `Enter ${providerLabel} API key`}
-            value={isSavedRedacted ? '••••••••' : apiKeyValue}
+            value={isSavedRedacted ? FIXED_API_KEY_MASK : apiKeyValue}
             className="h-8 flex-1 rounded border border-input bg-input px-2 text-xs font-mono text-foreground"
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
               if (!isEditingDraft) {


### PR DESCRIPTION
## Summary
Implements issue #297 by enforcing a fixed 50-character API key mask in all redacted API key inputs.

## Changes
- Added shared mask constant:
  - `src/renderer/api-key-mask.ts`
  - `FIXED_API_KEY_MASK = '*'.repeat(50)`
- Updated redacted display in:
  - `SettingsApiKeysReact` (Google key)
  - `SettingsSttProviderFormReact` (STT provider key)
- Added mask contract unit test:
  - `src/renderer/api-key-mask.test.ts`
- Updated component tests to assert shared fixed mask usage.
- Added decision record and aligned existing redaction ADR wording.

## Verification
- `pnpm test -- src/renderer/api-key-mask.test.ts src/renderer/settings-api-keys-react.test.tsx src/renderer/settings-stt-provider-form-react.test.tsx`
  - pass
- `pnpm typecheck`
  - fails on pre-existing baseline files unrelated to this ticket:
    - `src/renderer/app-shell-react.test.tsx`
    - `src/renderer/app-shell-react.tsx`
    - `src/renderer/native-recording.test.ts`

## Rollback
Revert this PR commit to restore previous 8-character redaction token behavior.

Closes #297
