### PR TITLE
fix: shortcut title/input horizontal row layout (issue #298)

### DIFF
--- a/docs/decisions/shortcuts-horizontal-row-layout.md
+++ b/docs/decisions/shortcuts-horizontal-row-layout.md
@@ -1,0 +1,30 @@
+<!--
+Where: docs/decisions/shortcuts-horizontal-row-layout.md
+What: Decision record for shortcut editor row alignment.
+Why: Issue #298 requires shortcut title and keybind input to appear side-by-side for faster editing.
+-->
+
+# Decision: Horizontal Shortcut Edit Rows
+
+## Status
+Accepted - March 1, 2026
+
+## Context
+Shortcut editor rows were vertically stacked (title above input), which reduced scan efficiency while editing multiple shortcuts.
+
+Issue #298 requires each row to place:
+- Shortcut title on the left
+- Keybind input on the right
+
+with stable alignment on normal desktop widths.
+
+## Decision
+- Use a two-column grid row per shortcut field:
+  - left column: bounded title width (`minmax(14rem, 20rem)`)
+  - right column: input (`minmax(0, 1fr)`)
+- Preserve all existing capture/validation behavior and selectors.
+- Add regression test for horizontal row structure.
+
+## Consequences
+- Shortcut editing is easier to scan and compare across rows.
+- Existing keyboard capture flow and IDs remain intact.

--- a/src/renderer/settings-shortcut-editor-react.test.tsx
+++ b/src/renderer/settings-shortcut-editor-react.test.tsx
@@ -26,6 +26,34 @@ afterEach(async () => {
 })
 
 describe('SettingsShortcutEditorReact', () => {
+  it('renders shortcut title and keybind input in one horizontal row', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsShortcutEditorReact
+          settings={DEFAULT_SETTINGS}
+          validationErrors={{}}
+          onChangeShortcutDraft={() => {}}
+        />
+      )
+    })
+
+    const label = host.querySelector<HTMLElement>('#settings-shortcut-toggle-recording-label')
+    const input = host.querySelector<HTMLInputElement>('#settings-shortcut-toggle-recording')
+    const row = label?.parentElement
+
+    expect(label).not.toBeNull()
+    expect(input).not.toBeNull()
+    expect(row?.className).toContain('grid')
+    expect(row?.className).toContain('items-center')
+    expect(row?.className).toContain('gap-3')
+    expect(label?.nextElementSibling).toBe(input)
+    expect(input?.className).toContain('w-full')
+  })
+
   it('captures a key combo from recording mode and propagates shortcut edits', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-shortcut-editor-react.tsx
+++ b/src/renderer/settings-shortcut-editor-react.tsx
@@ -252,12 +252,12 @@ export const SettingsShortcutEditorReact = ({
     <div className="space-y-3" ref={containerRef}>
       {SHORTCUT_FIELDS.map((field) => (
         <div className="space-y-1.5" key={field.key}>
-          <div className="flex flex-col gap-1.5 text-xs">
-            <span id={`${field.inputId}-label`}>{field.label}</span>
+          <div className="grid grid-cols-[minmax(14rem,20rem)_minmax(0,1fr)] items-center gap-3 text-xs">
+            <span className="text-muted-foreground" id={`${field.inputId}-label`}>{field.label}</span>
             <input
               id={field.inputId}
               type="text"
-              className="h-8 rounded border border-input bg-input px-2 text-xs font-mono"
+              className="h-8 w-full rounded border border-input bg-input px-2 text-xs font-mono"
               value={shortcutDraft[field.key]}
               readOnly
               ref={(element) => {


### PR DESCRIPTION
## Summary
Implements issue #298 by placing each shortcut title and keybind input in a single horizontal row.

## Changes
- Updated shortcut field row layout in `SettingsShortcutEditorReact`:
  - from vertical label/input stack to two-column row grid
  - left: bounded title column (`minmax(14rem, 20rem)`)
  - right: full-width keybind input (`w-full`)
- Preserved existing capture, duplicate detection, and validation behavior.
- Added regression test asserting one-row structure and class contract.
- Added decision note documenting the layout contract.

## Verification
- `pnpm test -- src/renderer/settings-shortcut-editor-react.test.tsx`
  - pass (`21` tests)
- `pnpm typecheck`
  - fails on pre-existing baseline files unrelated to this ticket:
    - `src/renderer/app-shell-react.test.tsx`
    - `src/renderer/app-shell-react.tsx`
    - `src/renderer/native-recording.test.ts`

## Rollback
Revert this PR commit to restore previous vertical shortcut field layout.

Closes #298
