### PR TITLE
fix(main): disable macOS maximize button and set dark backgroundColor (#295)

### DIFF
--- a/src/main/core/window-manager.test.ts
+++ b/src/main/core/window-manager.test.ts
@@ -85,6 +85,30 @@ describe('WindowManager', () => {
     delete process.env.ELECTRON_RENDERER_URL
   })
 
+  describe('createMainWindow — macOS options', () => {
+    it('sets maximizable:false and backgroundColor on darwin', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin', writable: true })
+      try {
+        const manager = new WindowManager()
+        manager.createMainWindow()
+        const opts = mocks.BrowserWindow.mock.calls[0][0]
+        expect(opts.maximizable).toBe(false)
+        expect(opts.backgroundColor).toBe('#1a1a1f')
+      } finally {
+        Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
+      }
+    })
+
+    it('does not set macOS-specific options on non-darwin', () => {
+      // CI runs on linux; platform is already non-darwin — no stub needed.
+      const manager = new WindowManager()
+      manager.createMainWindow()
+      const opts = mocks.BrowserWindow.mock.calls[0][0]
+      expect(opts.maximizable).toBeUndefined()
+      expect(opts.backgroundColor).toBeUndefined()
+    })
+  })
+
   it('hides the main window instead of closing it when user closes the window', () => {
     const manager = new WindowManager()
     manager.createMainWindow()

--- a/src/main/core/window-manager.ts
+++ b/src/main/core/window-manager.ts
@@ -21,10 +21,20 @@ export class WindowManager {
       return this.mainWindow
     }
 
+    // macOS: disable the green zoom/maximize button and set a dark background to
+    // avoid a white flash before the renderer paints. backgroundColor matches the
+    // app's --background token (oklch(0.13 0.005 260) ≈ #1a1a1f).
+    // NOTE: backgroundColor does NOT change the native title-bar strip color;
+    // that requires titleBarStyle:'hiddenInset' + renderer drag region (out of scope).
+    const macosOptions = process.platform === 'darwin'
+      ? { maximizable: false, backgroundColor: '#1a1a1f' }
+      : {}
+
     this.mainWindow = new BrowserWindow({
       width: 1120,
       height: 760,
       show: true,
+      ...macosOptions,
       webPreferences: {
         preload: join(__dirname, '../preload/index.js'),
         contextIsolation: true,


### PR DESCRIPTION
## Summary

- `maximizable: false` on `darwin` — grays out the green zoom button, making it non-interactive
- `backgroundColor: '#1a1a1f'` on `darwin` — matches `--background` token (`oklch(0.13 0.005 260)`), eliminates white flash before renderer paints
- Both options are platform-guarded (`process.platform === 'darwin'`); no change on Windows/Linux

## Known limitation

`backgroundColor` affects only the window content area flash before renderer paint. It does **not** change the native macOS title-bar strip color (the system chrome bar). Achieving a fully unified black bar requires `titleBarStyle: 'hiddenInset'` + renderer-side `-webkit-app-region: drag` — out of scope per issue #295 notes ("no custom frameless title-bar").

## Test plan

- [x] `window-manager.test.ts` — darwin test stubs `process.platform`; asserts `maximizable: false` and `backgroundColor: '#1a1a1f'`
- [x] Non-darwin test confirms neither option is set on Linux/Windows
- [x] All 4 window-manager tests pass
- [x] Pre-existing `typecheck` failure in `native-recording.test.ts` is unrelated to this PR (confirmed on `main` baseline)
- [ ] Manual macOS: green zoom button grayed out; red/yellow traffic lights functional; no white flash on window show

## Rollback

Revert the `macosOptions` conditional block in `window-manager.ts` and remove the two new test cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)