### PR TITLE
feat(309,310): custom titlebar chrome and frameless profile picker

### DIFF
--- a/src/main/core/window-manager.test.ts
+++ b/src/main/core/window-manager.test.ts
@@ -86,26 +86,36 @@ describe('WindowManager', () => {
   })
 
   describe('createMainWindow — macOS options', () => {
-    it('sets maximizable:false and backgroundColor on darwin', () => {
+    it('sets custom titlebar options and backgroundColor on darwin', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', writable: true })
       try {
         const manager = new WindowManager()
         manager.createMainWindow()
-        const opts = mocks.BrowserWindow.mock.calls[0][0]
-        expect(opts.maximizable).toBe(false)
+        const firstCall = mocks.BrowserWindow.mock.calls[0]
+        expect(firstCall).toBeDefined()
+        const opts = firstCall?.[0] as Record<string, unknown>
+        expect(opts.titleBarStyle).toBe('hiddenInset')
+        expect(opts.trafficLightPosition).toEqual({ x: 13, y: 13 })
         expect(opts.backgroundColor).toBe('#1a1a1f')
       } finally {
         Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
       }
     })
 
-    it('does not set macOS-specific options on non-darwin', () => {
+    it('sets hidden titlebar overlay options on non-darwin', () => {
       // CI runs on linux; platform is already non-darwin — no stub needed.
       const manager = new WindowManager()
       manager.createMainWindow()
-      const opts = mocks.BrowserWindow.mock.calls[0][0]
-      expect(opts.maximizable).toBeUndefined()
-      expect(opts.backgroundColor).toBeUndefined()
+      const firstCall = mocks.BrowserWindow.mock.calls[0]
+      expect(firstCall).toBeDefined()
+      const opts = firstCall?.[0] as Record<string, unknown>
+      expect(opts.titleBarStyle).toBe('hidden')
+      expect(opts.titleBarOverlay).toEqual({
+        color: '#1a1a1f',
+        symbolColor: '#f0f0f0',
+        height: 40
+      })
+      expect(opts.backgroundColor).toBe('#1a1a1f')
     })
   })
 

--- a/src/main/core/window-manager.ts
+++ b/src/main/core/window-manager.ts
@@ -21,20 +21,27 @@ export class WindowManager {
       return this.mainWindow
     }
 
-    // macOS: disable the green zoom/maximize button and set a dark background to
-    // avoid a white flash before the renderer paints. backgroundColor matches the
-    // app's --background token (oklch(0.13 0.005 260) ≈ #1a1a1f).
-    // NOTE: backgroundColor does NOT change the native title-bar strip color;
-    // that requires titleBarStyle:'hiddenInset' + renderer drag region (out of scope).
-    const macosOptions = process.platform === 'darwin'
-      ? { maximizable: false, backgroundColor: '#1a1a1f' }
-      : {}
+    const titlebarOptions = process.platform === 'darwin'
+      ? {
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 13, y: 13 },
+          backgroundColor: '#1a1a1f'
+        }
+      : {
+          titleBarStyle: 'hidden' as const,
+          titleBarOverlay: {
+            color: '#1a1a1f',
+            symbolColor: '#f0f0f0',
+            height: 40
+          },
+          backgroundColor: '#1a1a1f'
+        }
 
     this.mainWindow = new BrowserWindow({
       width: 1120,
       height: 760,
       show: true,
-      ...macosOptions,
+      ...titlebarOptions,
       webPreferences: {
         preload: join(__dirname, '../preload/index.js'),
         contextIsolation: true,

--- a/src/main/services/profile-picker-service.test.ts
+++ b/src/main/services/profile-picker-service.test.ts
@@ -172,7 +172,9 @@ describe('ProfilePickerService', () => {
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
         useContentSize: true,
-        height: buildPickerWindowHeight(2)
+        height: buildPickerWindowHeight(2),
+        frame: false,
+        backgroundColor: '#1a1a1f'
       })
     )
     expect(focusBridge.captureFrontmostAppId).toHaveBeenCalledOnce()

--- a/src/main/services/profile-picker-service.ts
+++ b/src/main/services/profile-picker-service.ts
@@ -26,6 +26,7 @@ export interface PickerBrowserWindowOptions {
   autoHideMenuBar: boolean
   show: boolean
   frame: boolean
+  backgroundColor?: string
   title: string
   webPreferences: {
     contextIsolation: boolean
@@ -332,7 +333,8 @@ export class ProfilePickerService {
       alwaysOnTop: true,
       autoHideMenuBar: true,
       show: false,
-      frame: true,
+      frame: false,
+      backgroundColor: '#1a1a1f',
       title: 'Pick Transformation Profile',
       webPreferences: {
         contextIsolation: true,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,3 +53,4 @@ const api: IpcApi = {
 }
 
 contextBridge.exposeInMainWorld('speechToTextApi', api)
+contextBridge.exposeInMainWorld('electronPlatform', process.platform)

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -7,5 +7,6 @@ export {}
 declare global {
   interface Window {
     speechToTextApi: IpcApi
+    electronPlatform: string
   }
 }

--- a/src/renderer/shell-chrome-react.test.tsx
+++ b/src/renderer/shell-chrome-react.test.tsx
@@ -9,7 +9,7 @@
 // @vitest-environment jsdom
 
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ShellChromeReact } from './shell-chrome-react'
 
 const flush = async (): Promise<void> =>
@@ -26,6 +26,10 @@ afterEach(() => {
 })
 
 describe('ShellChromeReact', () => {
+  beforeEach(() => {
+    window.electronPlatform = 'linux'
+  })
+
   it('renders app name and ready state dot when not recording', async () => {
     const host = document.createElement('div')
     document.body.append(host)
@@ -62,5 +66,45 @@ describe('ShellChromeReact', () => {
     expect(host.querySelector('header')).not.toBeNull()
     // Logo container uses bg-primary/10 class
     expect(host.querySelector('.\\[bg-primary\\/10\\]') ?? host.querySelector('[class*="bg-primary"]')).not.toBeNull()
+  })
+
+  it('adds drag-region classes to the header and no-drag classes to child groups', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ShellChromeReact isRecording={false} />)
+    await flush()
+
+    const header = host.querySelector('header')
+    expect(header?.className).toContain('app-region-drag')
+    expect(header?.className).toContain('select-none')
+    expect(host.querySelectorAll('.app-region-no-drag').length).toBe(2)
+  })
+
+  it('uses macOS traffic-light clearance padding when platform is darwin', async () => {
+    window.electronPlatform = 'darwin'
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ShellChromeReact isRecording={false} />)
+    await flush()
+
+    const header = host.querySelector('header')
+    expect(header?.className).toContain('pl-[var(--traffic-light-clearance)]')
+  })
+
+  it('uses non-darwin overlay clearance padding on the right side', async () => {
+    window.electronPlatform = 'linux'
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(<ShellChromeReact isRecording={false} />)
+    await flush()
+
+    const header = host.querySelector('header')
+    expect(header?.className).toContain('pr-[var(--titlebar-overlay-clearance)]')
   })
 })

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -18,28 +18,38 @@ interface ShellChromeReactProps {
   isRecording: boolean
 }
 
-export const ShellChromeReact = ({ isRecording }: ShellChromeReactProps) => (
-  <header className="flex items-center justify-between border-b px-4 py-2 bg-card/50">
-    {/* Logo + App name */}
-    <div className="flex items-center gap-2">
-      <div className="size-6 rounded-md bg-primary/10 flex items-center justify-center">
-        <AudioWaveform className="size-3.5 text-primary" aria-hidden="true" />
-      </div>
-      <span className="text-sm font-semibold tracking-tight">Speech-to-Text v1</span>
-    </div>
+export const ShellChromeReact = ({ isRecording }: ShellChromeReactProps) => {
+  const isDarwin = window.electronPlatform === 'darwin'
 
-    {/* Recording state dot: provides persistent global recording feedback per spec section 5.3 */}
-    <div className="flex items-center gap-1.5" aria-live="polite" aria-atomic="true">
-      <span
-        className={cn(
-          'size-2 rounded-full',
-          isRecording ? 'bg-recording animate-pulse' : 'bg-success'
-        )}
-        aria-hidden="true"
-      />
-      <span className="text-[10px] text-muted-foreground">
-        {isRecording ? 'Recording' : 'Ready'}
-      </span>
-    </div>
-  </header>
-)
+  return (
+    <header
+      className={cn(
+        'flex items-center justify-between border-b px-4 py-2 bg-card/50',
+        'app-region-drag select-none',
+        isDarwin ? 'pl-[var(--traffic-light-clearance)]' : 'pr-[var(--titlebar-overlay-clearance)]'
+      )}
+    >
+      {/* Logo + App name */}
+      <div className="flex items-center gap-2 app-region-no-drag">
+        <div className="size-6 rounded-md bg-primary/10 flex items-center justify-center">
+          <AudioWaveform className="size-3.5 text-primary" aria-hidden="true" />
+        </div>
+        <span className="text-sm font-semibold tracking-tight">Speech-to-Text v1</span>
+      </div>
+
+      {/* Recording state dot: provides persistent global recording feedback per spec section 5.3 */}
+      <div className="flex items-center gap-1.5 app-region-no-drag" aria-live="polite" aria-atomic="true">
+        <span
+          className={cn(
+            'size-2 rounded-full',
+            isRecording ? 'bg-recording animate-pulse' : 'bg-success'
+          )}
+          aria-hidden="true"
+        />
+        <span className="text-[10px] text-muted-foreground">
+          {isRecording ? 'Recording' : 'Ready'}
+        </span>
+      </div>
+    </header>
+  )
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -159,3 +159,18 @@
     min-height: 100%;
   }
 }
+
+:root {
+  --traffic-light-clearance: 78px;
+  --titlebar-overlay-clearance: 140px;
+}
+
+.app-region-drag {
+  app-region: drag;
+  -webkit-app-region: drag;
+}
+
+.app-region-no-drag {
+  app-region: no-drag;
+  -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
## Summary
- make profile picker frameless and set dark background color to prevent white flash
- configure platform-specific main window titlebar chrome (macOS hiddenInset traffic lights, non-mac titleBarOverlay)
- expose platform through preload bridge for renderer layout adjustments
- add draggable header classes and platform-specific titlebar clearance styles
- update main/renderer tests for new titlebar and drag-region contracts

## Validation
- pnpm vitest run src/main/core/window-manager.test.ts src/main/services/profile-picker-service.test.ts src/renderer/shell-chrome-react.test.tsx