### PR TITLE
fix: remove top-left shell title text (#318)

### DIFF
--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -160,7 +160,7 @@ describe('renderer app', () => {
     expect(mountPoint.querySelector('[data-route-tab="activity"]')).not.toBeNull()
     expect(mountPoint.querySelector('[data-route-tab="audio-input"]')).not.toBeNull()
     expect(mountPoint.querySelector('[data-route-tab="settings"]')).not.toBeNull()
-    expect(mountPoint.textContent).toContain('Speech-to-Text v1')
+    expect(mountPoint.textContent).not.toContain('Speech-to-Text v1')
     // STY-03: "Recording Controls" heading removed; recording is indicated by the
     // circular button with aria-label.
     expect(mountPoint.querySelector('[aria-label="Start recording"]')).not.toBeNull()

--- a/src/renderer/shell-chrome-react.test.tsx
+++ b/src/renderer/shell-chrome-react.test.tsx
@@ -30,7 +30,7 @@ describe('ShellChromeReact', () => {
     window.electronPlatform = 'linux'
   })
 
-  it('renders app name and ready state dot when not recording', async () => {
+  it('omits app title text and renders ready state dot when not recording', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -38,7 +38,7 @@ describe('ShellChromeReact', () => {
     root.render(<ShellChromeReact isRecording={false} />)
     await flush()
 
-    expect(host.textContent).toContain('Speech-to-Text v1')
+    expect(host.textContent).not.toContain('Speech-to-Text v1')
     expect(host.textContent).toContain('Ready')
     expect(host.textContent).not.toContain('Recording')
   })
@@ -53,6 +53,7 @@ describe('ShellChromeReact', () => {
 
     expect(host.textContent).toContain('Recording')
     expect(host.textContent).not.toContain('Ready')
+    expect(host.textContent).not.toContain('Speech-to-Text v1')
   })
 
   it('renders header element with logo icon', async () => {

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -1,6 +1,6 @@
 /*
  * Where: src/renderer/shell-chrome-react.tsx
- * What: Compact app header bar — logo, app name, recording state dot.
+ * What: Compact app header bar — logo and recording state dot.
  * Why: STY-02 re-architecture moves the tab rail into the right workspace panel;
  *      the header is now a fixed visual anchor that shows global recording state.
  *
@@ -29,12 +29,11 @@ export const ShellChromeReact = ({ isRecording }: ShellChromeReactProps) => {
         isDarwin ? 'pl-[var(--traffic-light-clearance)]' : 'pr-[var(--titlebar-overlay-clearance)]'
       )}
     >
-      {/* Logo + App name */}
+      {/* Logo */}
       <div className="flex items-center gap-2 app-region-no-drag">
         <div className="size-6 rounded-md bg-primary/10 flex items-center justify-center">
           <AudioWaveform className="size-3.5 text-primary" aria-hidden="true" />
         </div>
-        <span className="text-sm font-semibold tracking-tight">Speech-to-Text v1</span>
       </div>
 
       {/* Recording state dot: provides persistent global recording feedback per spec section 5.3 */}


### PR DESCRIPTION
## Summary\n- remove `Speech-to-Text v1` text from the left side of the shell header\n- keep logo icon, drag region classes, and recording status unchanged\n- update component + integration tests to assert title text absence\n\n## Issue\n- Closes #318\n\n## Scope\n- in scope: shell header text removal only\n- out of scope: tray tooltip/app metadata/title tags\n\n## Tests\n- `pnpm vitest run src/renderer/shell-chrome-react.test.tsx src/renderer/renderer-app.test.ts`