### PR TITLE
fix: move Add profile below existing profiles (#321)

### DIFF
--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -481,6 +481,52 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(cbs.onAddPreset).toHaveBeenCalledTimes(1)
   })
 
+  it('renders Add profile directly after the profile list items in the same scroll region', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...buildCallbacks()}
+      />
+    )
+    await flush()
+
+    const listContainer = host.querySelector<HTMLElement>('[role="list"]')
+    const addBtn = host.querySelector<HTMLButtonElement>('#profiles-panel-add')
+    expect(listContainer).not.toBeNull()
+    expect(addBtn).not.toBeNull()
+    expect(addBtn?.closest('[role="list"]')).toBe(listContainer)
+
+    const listItems = Array.from(host.querySelectorAll('[role="listitem"]'))
+    const lastListItem = listItems[listItems.length - 1]
+    const addIsAfterLastItem = (lastListItem?.compareDocumentPosition(addBtn as Node) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING
+    expect(addIsAfterLastItem).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it('renders Add profile in the list container even when there are no profile items', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings({ presets: [], defaultPresetId: 'missing-default' })}
+        {...buildCallbacks()}
+      />
+    )
+    await flush()
+
+    const listContainer = host.querySelector<HTMLElement>('[role="list"]')
+    const addBtn = host.querySelector<HTMLButtonElement>('#profiles-panel-add')
+    expect(host.querySelectorAll('[role="listitem"]').length).toBe(0)
+    expect(listContainer).not.toBeNull()
+    expect(addBtn).not.toBeNull()
+    expect(addBtn?.closest('[role="list"]')).toBe(listContainer)
+  })
+
   it('renders provider/model metadata in font-mono footer per spec section 6.4', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -428,19 +428,18 @@ export const ProfilesPanelReact = ({
             </div>
           )
         })}
-      </div>
-
-      {/* Add profile — pinned to bottom, dashed ghost style */}
-      <div className="border-t p-3">
-        <button
-          type="button"
-          id="profiles-panel-add"
-          onClick={() => { void onAddPreset() }}
-          className="flex h-7 w-full items-center justify-center gap-1 rounded border border-dashed border-border text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <Plus className="size-3" />
-          Add profile
-        </button>
+        {/* Add profile — in profiles flow directly below existing profile cards */}
+        <div className="mt-1 border-t pt-3">
+          <button
+            type="button"
+            id="profiles-panel-add"
+            onClick={() => { void onAddPreset() }}
+            className="flex h-7 w-full items-center justify-center gap-1 rounded border border-dashed border-border text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Plus className="size-3" />
+            Add profile
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary\n- move  into the profiles list flow so it appears directly below existing profile items\n- remove fixed bottom add-profile container\n- preserve add-profile behavior and selector\n- add DOM-order and empty-list regression tests\n\n## Issue\n- Closes #321\n\n## Scope\n- in scope: profiles tab add-button placement only\n- out of scope: profile card business logic and save behavior\n\n## Tests\n- 
 RUN  v2.1.8 /workspace/.worktrees/issue-321-move-add-profile

 ✓ src/renderer/profiles-panel-react.test.tsx (23 tests) 269ms

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  05:30:52
   Duration  1.44s (transform 88ms, setup 0ms, collect 276ms, tests 269ms, environment 584ms, prepare 74ms)