### PR TITLE
fix: left-align output labels while keeping toggles in place (#319)

### DIFF
--- a/src/renderer/settings-output-react.test.tsx
+++ b/src/renderer/settings-output-react.test.tsx
@@ -156,4 +156,40 @@ describe('SettingsOutputReact', () => {
       pasteAtCursor: initialPasteChecked
     })
   })
+
+  it('renders destination labels with text-left and keeps switches after labels', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    await act(async () => {
+      root?.render(
+        <SettingsOutputReact
+          settings={DEFAULT_SETTINGS}
+          onChangeOutputSelection={vi.fn()}
+        />
+      )
+    })
+
+    const copyCard = host.querySelector<HTMLElement>('[data-output-destination-card="copy"]')
+    const pasteCard = host.querySelector<HTMLElement>('[data-output-destination-card="paste"]')
+    expect(copyCard).not.toBeNull()
+    expect(pasteCard).not.toBeNull()
+
+    const copyLabelBlock = copyCard?.querySelector<HTMLElement>('.text-left')
+    const copySwitch = copyCard?.querySelector<HTMLElement>('#settings-output-copy')
+    expect(copyLabelBlock?.textContent).toContain('Copy to clipboard')
+    expect(copyLabelBlock?.className).toContain('text-left')
+    expect(copySwitch).not.toBeNull()
+    const copySwitchAfterLabel = (copyLabelBlock?.compareDocumentPosition(copySwitch as Node) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING
+    expect(copySwitchAfterLabel).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+
+    const pasteLabelBlock = pasteCard?.querySelector<HTMLElement>('.text-left')
+    const pasteSwitch = pasteCard?.querySelector<HTMLElement>('#settings-output-paste')
+    expect(pasteLabelBlock?.textContent).toContain('Paste at cursor')
+    expect(pasteLabelBlock?.className).toContain('text-left')
+    expect(pasteSwitch).not.toBeNull()
+    const pasteSwitchAfterLabel = (pasteLabelBlock?.compareDocumentPosition(pasteSwitch as Node) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING
+    expect(pasteSwitchAfterLabel).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
 })

--- a/src/renderer/settings-output-react.tsx
+++ b/src/renderer/settings-output-react.tsx
@@ -127,6 +127,10 @@ export const SettingsOutputReact = ({
           })
         }}
       >
+        <div className="flex flex-col text-left">
+          <span className="text-xs text-foreground">Copy to clipboard</span>
+          <span className="text-[10px] text-muted-foreground">Keep output ready for paste</span>
+        </div>
         <Switch
           id="settings-output-copy"
           aria-label="Copy to clipboard"
@@ -138,10 +142,6 @@ export const SettingsOutputReact = ({
             applySelection(selectedTextSource, { copyToClipboard: checked, pasteAtCursor: pasteChecked })
           }}
         />
-        <div className="flex flex-col">
-          <span className="text-xs text-foreground">Copy to clipboard</span>
-          <span className="text-[10px] text-muted-foreground">Keep output ready for paste</span>
-        </div>
       </div>
       <div
         className={cn(
@@ -156,6 +156,10 @@ export const SettingsOutputReact = ({
           })
         }}
       >
+        <div className="flex flex-col text-left">
+          <span className="text-xs text-foreground">Paste at cursor</span>
+          <span className="text-[10px] text-muted-foreground">Insert output into focused field</span>
+        </div>
         <Switch
           id="settings-output-paste"
           aria-label="Paste at cursor"
@@ -167,10 +171,6 @@ export const SettingsOutputReact = ({
             applySelection(selectedTextSource, { copyToClipboard: copyChecked, pasteAtCursor: checked })
           }}
         />
-        <div className="flex flex-col">
-          <span className="text-xs text-foreground">Paste at cursor</span>
-          <span className="text-[10px] text-muted-foreground">Insert output into focused field</span>
-        </div>
       </div>
       {!copyChecked && !pasteChecked && (
         <p id="settings-output-destinations-warning" className="mt-2 text-[10px] text-warning">


### PR DESCRIPTION
## Summary\n- move output destination label blocks before switch controls in both destination cards\n- keep destination card click behavior and switch handlers unchanged\n- add tests asserting  label wrappers and switch ordering in each card\n\n## Issue\n- Closes #319\n\n## Scope\n- in scope: settings output destination card label alignment\n- out of scope: output destination logic, state wiring, and copy/paste semantics\n\n## Tests\n- 
 RUN  v2.1.8 /workspace/.worktrees/issue-319-left-align-output-labels

 ✓ src/renderer/settings-output-react.test.tsx (4 tests) 92ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  05:33:28
   Duration  1.22s (transform 67ms, setup 0ms, collect 218ms, tests 92ms, environment 584ms, prepare 83ms)