### PR TITLE
fix: remove inline settings status text for profile actions (#323)

### DIFF
--- a/src/renderer/settings-mutations.test.ts
+++ b/src/renderer/settings-mutations.test.ts
@@ -377,11 +377,12 @@ describe('createSettingsMutations profile persistence helpers', () => {
     ]
     const state = createState(settings)
 
+    const setSettingsSaveMessage = vi.fn()
     const mutations = createSettingsMutations({
       state,
       onStateChange: vi.fn(),
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
+      setSettingsSaveMessage,
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast: vi.fn(),
@@ -393,6 +394,55 @@ describe('createSettingsMutations profile persistence helpers', () => {
     await mutations.removeTransformationPresetAndSave('preset-a')
 
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(3)
+    expect(setSettingsSaveMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not emit inline save message when default profile is updated and saved', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+    const setSettingsSaveMessage = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage,
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.setDefaultTransformationPresetAndSave('preset-b')
+
+    expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
+    expect(setSettingsSaveMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not emit inline save message when adding a profile with immediate save', async () => {
+    const state = createState(structuredClone(DEFAULT_SETTINGS))
+    const setSettingsSaveMessage = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage,
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.addTransformationPresetAndSave()
+
+    expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
+    expect(setSettingsSaveMessage).not.toHaveBeenCalled()
   })
 })
 
@@ -507,7 +557,7 @@ describe('createSettingsMutations.addTransformationPreset', () => {
     expect(state.settings!.transformation.defaultPresetId).toBe(newPreset.id)
     expect(state.settings!.transformation.lastPickedPresetId).toBeNull()
     expect(onStateChange).toHaveBeenCalledOnce()
-    expect(setSettingsSaveMessage).toHaveBeenCalledWith('Profile added. Save settings to persist.')
+    expect(setSettingsSaveMessage).not.toHaveBeenCalled()
   })
 })
 
@@ -529,11 +579,12 @@ describe('createSettingsMutations.removeTransformationPreset', () => {
     )
     const onStateChange = vi.fn()
 
+    const setSettingsSaveMessage = vi.fn()
     const mutations = createSettingsMutations({
       state,
       onStateChange,
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
+      setSettingsSaveMessage,
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast: vi.fn(),
@@ -546,5 +597,6 @@ describe('createSettingsMutations.removeTransformationPreset', () => {
     expect(state.settings?.transformation.defaultPresetId).toBe('default-id')
     expect(state.settings?.transformation.lastPickedPresetId).toBeNull()
     expect(onStateChange).toHaveBeenCalledOnce()
+    expect(setSettingsSaveMessage).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -366,7 +366,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     }
     state.settings = buildSettingsWithAddedPreset(state.settings).nextSettings
     onStateChange()
-    setSettingsSaveMessage('Profile added. Save settings to persist.')
   }
 
   const removeTransformationPreset = (presetId: string): void => {
@@ -380,7 +379,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     }
     state.settings = removal.nextSettings
     onStateChange()
-    setSettingsSaveMessage('Profile removed. Save settings to persist.')
   }
 
   const setDefaultTransformationPresetAndSave = async (defaultPresetId: string): Promise<boolean> => {
@@ -392,7 +390,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
       onStateChange()
-      setSettingsSaveMessage('Default profile updated.')
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown default profile save error'
@@ -412,7 +409,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
       onStateChange()
-      setSettingsSaveMessage('Profile added.')
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown profile add error'
@@ -437,7 +433,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
       onStateChange()
-      setSettingsSaveMessage('Profile removed.')
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown profile remove error'


### PR DESCRIPTION
## Summary\n- remove inline  success updates from profile-action mutation paths\n- keep profile persistence behavior and error feedback intact\n- add/adjust mutation tests to assert no inline save message is emitted for profile actions\n\n## Issue\n- Closes #323\n\n## Scope\n- in scope: profile-action inline status text behavior in settings mutations\n- out of scope: autosave validation/errors and non-profile messaging\n\n## Tests\n- 
 RUN  v2.1.8 /workspace/.worktrees/issue-323-remove-inline-profile-status-text

 ✓ src/renderer/settings-mutations.test.ts (16 tests) 63ms
 ✓ src/renderer/app-shell-react.test.tsx (17 tests) 525ms
 ✓ src/renderer/renderer-app.test.ts (13 tests) 2043ms
   ✓ renderer app > autosave success shows toast and does not render inline success message 768ms
   ✓ renderer app > keeps the active tab when autosave fails for a valid shortcut update 768ms

 Test Files  3 passed (3)
      Tests  46 passed (46)
   Start at  05:36:54
   Duration  4.35s (transform 291ms, setup 0ms, collect 1.16s, tests 2.63s, environment 4.15s, prepare 402ms)