### PR TITLE
fix: move toast notifications to bottom-right (#322)

### DIFF
--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -259,6 +259,29 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.querySelector('[data-toast-tone="error"]')?.textContent).toContain('Error')
   })
 
+  it('anchors toast layer to bottom-right', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <AppShell
+        state={buildState({
+          toasts: [{ id: 1, message: 'Settings saved.', tone: 'success' }]
+        })}
+        callbacks={buildCallbacks()}
+      />
+    )
+    await flush()
+
+    const toastLayer = host.querySelector('#toast-layer')
+    const classTokens = (toastLayer?.className ?? '').split(/\s+/)
+    expect(classTokens).toContain('fixed')
+    expect(classTokens).toContain('bottom-4')
+    expect(classTokens).toContain('right-4')
+    expect(classTokens).not.toContain('top-4')
+  })
+
   it('does not render the non-API "Save Settings" button in Shortcuts or Settings tabs', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -467,7 +467,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
       {/* ── Toast overlay (fixed, pointer-events managed per item) ── */}
       <ul
         id="toast-layer"
-        className="fixed top-4 right-4 z-40 grid gap-[0.55rem] w-[min(360px,calc(100vw-2rem))] m-0 p-0 list-none pointer-events-none"
+        className="fixed bottom-4 right-4 z-40 grid gap-[0.55rem] w-[min(360px,calc(100vw-2rem))] m-0 p-0 list-none pointer-events-none"
         aria-live="polite"
         aria-atomic="false"
       >


### PR DESCRIPTION
## Summary\n- move  anchor from top-right to bottom-right\n- keep toast behavior unchanged (tone, dismiss, timing)\n- add dedicated class-contract test for bottom-right anchoring\n\n## Issue\n- Closes #322\n\n## Scope\n- in scope: toast layer placement classes\n- out of scope: toast creation, queueing, and timeout logic\n\n## Tests\n- 
 RUN  v2.1.8 /workspace/.worktrees/issue-322-toast-bottom-right

 ✓ src/renderer/app-shell-react.test.tsx (18 tests) 501ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  05:40:04
   Duration  1.79s (transform 153ms, setup 0ms, collect 383ms, tests 501ms, environment 590ms, prepare 74ms)