### PR TITLE
fix: rename audio tab label to Audio (#320)

### DIFF
--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -125,6 +125,12 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.querySelectorAll('[role="tab"]').length).toBe(5)
     expect(host.querySelector('[data-route-tab="activity"]')?.getAttribute('aria-pressed')).toBe('true')
     expect(host.querySelector('[data-route-tab="settings"]')?.getAttribute('aria-pressed')).toBe('false')
+    expect(host.querySelector('[data-route-tab="activity"]')?.textContent).toContain('Activity')
+    expect(host.querySelector('[data-route-tab="profiles"]')?.textContent).toContain('Profiles')
+    expect(host.querySelector('[data-route-tab="shortcuts"]')?.textContent).toContain('Shortcuts')
+    expect(host.querySelector('[data-route-tab="audio-input"]')?.textContent).toContain('Audio')
+    expect(host.querySelector('[data-route-tab="audio-input"]')?.textContent).not.toContain('Audio Input')
+    expect(host.querySelector('[data-route-tab="settings"]')?.textContent).toContain('Settings')
   })
 
   it('renders Settings IA sections without audio input section', async () => {

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -254,7 +254,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               className="flex items-center rounded-none border-b-2 border-transparent px-4 py-2.5 text-xs transition-colors text-muted-foreground hover:text-foreground data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
             >
               <Mic className="size-3.5 mr-1.5" aria-hidden="true" />
-              Audio Input
+              Audio
             </TabsTrigger>
             <TabsTrigger
               value="settings"


### PR DESCRIPTION
## Summary\n- rename the  tab label from  to \n- keep route key and tab behavior unchanged\n- add explicit tab-label assertions to ensure no other tab labels changed\n\n## Issue\n- Closes #320\n\n## Scope\n- in scope: tab label text only\n- out of scope: section header copy () and other UI labels\n\n## Tests\n- 
 RUN  v2.1.8 /workspace/.worktrees/issue-320-rename-audio-tab

 ✓ src/renderer/app-shell-react.test.tsx (18 tests) 501ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  05:44:02
   Duration  1.79s (transform 149ms, setup 0ms, collect 386ms, tests 501ms, environment 585ms, prepare 70ms)