### PR TITLE
fix: allow multiline profile user prompt (closes #334)

### DIFF
--- a/docs/decisions/issue-334-profile-user-prompt-multiline.md
+++ b/docs/decisions/issue-334-profile-user-prompt-multiline.md
@@ -1,0 +1,29 @@
+<!--
+Where: docs/decisions/issue-334-profile-user-prompt-multiline.md
+What: Decision record for issue #334 (profile user prompt multiline input).
+Why: Capture scope and rationale so future UI/validation changes stay consistent.
+-->
+
+# Issue 334: Profile User Prompt Multiline Input
+
+## Context
+- Ticket: https://github.com/massun-onibakuchi/speech-to-text-app/issues/334
+- Requirement:
+  - Profile User Prompt must allow multiple lines.
+  - Existing `{{text}}` placeholder validation must remain.
+
+## Decision
+- Change only the profile inline editor control `#profile-edit-user-prompt` from single-line `<input>` to multiline `<textarea rows={3}>`.
+- Keep `validateTransformationPresetDraft` unchanged so validation behavior remains:
+  - non-empty user prompt
+  - must include `{{text}}`
+  - legacy `{{input}}` normalization still applies
+
+## Rationale
+- The issue is UI input capability, not validation semantics.
+- Keeping validation unchanged minimizes regression risk in save/update flows.
+- Reusing existing textarea styling keeps visual consistency with the nearby system prompt field.
+
+## Consequences
+- User prompt templates can now include line breaks in the profile editor.
+- Existing tests for placeholder validation continue to protect current business logic.

--- a/docs/style-update.md
+++ b/docs/style-update.md
@@ -225,7 +225,7 @@ Must keep: circular `size-20` target, `focus-visible:ring-2 focus-visible:ring-r
   - Active: `border-primary/40 bg-primary/5`
   - Default badge: `bg-primary/10 text-primary border-primary/20 text-[10px] h-4`
   - Hover reveals (opacity-0 → group-hover:opacity-100): star, pencil, trash buttons
-- Edit form: title `Input h-7`, provider/model in `grid grid-cols-2 gap-2` Selects (`h-7`), system prompt `Textarea min-h-[60px] resize-none rows={3}`, user prompt `Input h-7 font-mono`
+- Edit form: title `Input h-7`, provider/model in `grid grid-cols-2 gap-2` Selects (`h-7`), system prompt `Textarea min-h-[60px] resize-none rows={3}`, user prompt `Textarea min-h-[60px] resize-none rows={3} font-mono`
 - Save/Cancel: `Button size="sm" h-7 text-xs` pair at bottom right
 - Add button: `Button variant="ghost" size="sm" h-7 text-xs gap-1` with `Plus size-3`
 - Profile footer: `text-[10px] font-mono text-muted-foreground` for `provider/model`

--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -272,6 +272,45 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(host.querySelector('#profile-edit-name')).toBeNull()
   })
 
+  it('persists multiline user prompt content when saving a profile draft', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    const firstCard = host.querySelector<HTMLDivElement>('[role="button"]')
+    firstCard?.click()
+    await flush()
+
+    const userPromptArea = host.querySelector<HTMLTextAreaElement>('#profile-edit-user-prompt')
+    expect(userPromptArea).not.toBeNull()
+    if (userPromptArea) {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
+      valueSetter?.call(userPromptArea, 'Line 1\nLine 2 {{text}}')
+      userPromptArea.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    saveBtn?.click()
+    await flush()
+
+    expect(cbs.onSavePresetDraft).toHaveBeenCalledWith('preset-a', {
+      name: 'Alpha',
+      model: 'gemini-2.5-flash',
+      systemPrompt: 'System A',
+      userPrompt: 'Line 1\nLine 2 {{text}}'
+    })
+  })
+
   it('closes form without calling onSavePresetDraft when Cancel is clicked', async () => {
     const host = document.createElement('div')
     document.body.append(host)
@@ -566,7 +605,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
     const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
     const modelTrigger = host.querySelector<HTMLElement>('#profile-edit-model')
     const systemPromptArea = host.querySelector<HTMLTextAreaElement>('#profile-edit-system-prompt')
-    const userPromptInput = host.querySelector<HTMLInputElement>('#profile-edit-user-prompt')
+    const userPromptInput = host.querySelector<HTMLTextAreaElement>('#profile-edit-user-prompt')
 
     expect(nameInput?.value).toBe('Alpha')
     expect(modelTrigger?.textContent).toContain('gemini-2.5-flash')
@@ -601,7 +640,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
 
     const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
     const systemPromptArea = host.querySelector<HTMLTextAreaElement>('#profile-edit-system-prompt')
-    const userPromptInput = host.querySelector<HTMLInputElement>('#profile-edit-user-prompt')
+    const userPromptInput = host.querySelector<HTMLTextAreaElement>('#profile-edit-user-prompt')
 
     expect(nameInput?.getAttribute('aria-invalid')).toBe('true')
     expect(nameInput?.getAttribute('aria-describedby')).toContain('profile-edit-name-error-')

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -268,21 +268,21 @@ const ProfileEditForm = ({
       )}
     </div>
 
-    {/* User prompt — Input h-7 font-mono per spec */}
+    {/* User prompt — Textarea min-h-[60px] font-mono for multiline templates */}
     <div className="flex flex-col gap-1">
       <label className="text-[10px] text-muted-foreground" htmlFor="profile-edit-user-prompt">
         User prompt <span className="opacity-60">(include {'{{text}}'})</span>
       </label>
-      <input
+      <textarea
         id="profile-edit-user-prompt"
-        type="text"
+        rows={3}
         value={draft.userPrompt}
         aria-invalid={userPromptError.length > 0}
         aria-describedby={userPromptError ? `profile-edit-user-prompt-error-${presetId}` : undefined}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
           onChangeDraft({ userPrompt: e.target.value })
         }}
-        className="h-7 rounded border border-input bg-background px-2 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="min-h-[60px] resize-none rounded border border-input bg-background px-2 py-1.5 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
       {userPromptError && (
         <p id={`profile-edit-user-prompt-error-${presetId}`} className="text-[10px] text-destructive">{userPromptError}</p>


### PR DESCRIPTION
## Summary
- switch profile inline editor user prompt (`#profile-edit-user-prompt`) from single-line input to multiline textarea
- keep existing `{{text}}` validation behavior unchanged
- add regression test covering multiline user prompt save payload
- update style doc and add issue decision record

## Testing
- pnpm vitest run src/renderer/profiles-panel-react.test.tsx src/renderer/settings-validation.test.ts

Closes #334