### PR TITLE
fix: keep default profile unchanged on add (#349)

### DIFF
--- a/docs/decisions/default-profile-stability-on-add-and-delete-fallback-toast.md
+++ b/docs/decisions/default-profile-stability-on-add-and-delete-fallback-toast.md
@@ -1,0 +1,35 @@
+<!--
+Where: docs/decisions/default-profile-stability-on-add-and-delete-fallback-toast.md
+What: Decision record for default profile behavior when adding/removing profiles.
+Why: Issue #349 requires stable default selection unless the user explicitly changes it.
+-->
+
+# Decision: Keep Default Profile Stable on Add/Edit; Notify on Default-Delete Fallback
+
+## Status
+Accepted - March 5, 2026
+
+## Context
+
+Issue #349 reports that adding a new profile automatically changes the default profile, which is unexpected and violates user intent.
+
+Current requirement:
+- Creating a profile must not change default profile.
+- Editing a profile must not change default profile.
+- Deleting a non-default profile must not change default profile.
+- Deleting the current default profile must assign the top-listed remaining profile as fallback and notify the user.
+
+## Decision
+
+- Keep `transformation.defaultPresetId` unchanged when adding profiles.
+- Keep default unchanged for edit operations (already true via explicit save of target profile fields only).
+- When deleting profiles:
+  - if deleted profile is non-default, keep default unchanged.
+  - if deleted profile is default, assign first remaining profile as fallback.
+- Emit a toast only when fallback assignment happens due to deleting the current default profile.
+
+## Consequences
+
+- Default profile changes only from explicit user action (set default) or mandatory fallback on default deletion.
+- Add-profile flow no longer has hidden side effects on runtime profile selection.
+- Tests that previously encoded "add => new default" behavior are updated to the new contract.

--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -481,6 +481,49 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(cbs.onAddPreset).toHaveBeenCalledTimes(1)
   })
 
+  it('auto-opens the newly added profile editor even when default profile stays unchanged', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    const initialSettings = buildSettings({ defaultPresetId: 'preset-a' })
+    root.render(
+      <ProfilesPanelReact
+        settings={initialSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+
+    const addedSettings = buildSettings({
+      defaultPresetId: 'preset-a',
+      presets: [
+        ...initialSettings.transformation.presets,
+        {
+          ...PRESET_A,
+          id: 'preset-c',
+          name: 'Gamma',
+          systemPrompt: 'System C',
+          userPrompt: 'User C {{text}}'
+        }
+      ]
+    })
+    root.render(
+      <ProfilesPanelReact
+        settings={addedSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    expect(nameInput).not.toBeNull()
+    expect(nameInput?.value).toBe('Gamma')
+  })
+
   it('renders Add profile directly after the profile list items in the same scroll region', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -329,19 +329,17 @@ export const ProfilesPanelReact = ({
   // Local form draft — isolated from settings to support Cancel without persisting.
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null)
 
-  // Auto-open edit form when a new preset is added (detected by length increase).
-  // addTransformationPreset() auto-sets defaultPresetId to the new preset's id.
-  const prevPresetCountRef = useRef(presets.length)
+  // Auto-open edit form when a new preset is added (detected by id diff).
+  const prevPresetIdsRef = useRef(new Set(presets.map((preset) => preset.id)))
   useEffect(() => {
-    if (presets.length > prevPresetCountRef.current) {
-      const newPreset = presets.find((p) => p.id === defaultPresetId)
-      if (newPreset) {
-        setEditingPresetId(newPreset.id)
-        setEditDraft(buildDraft(newPreset))
-      }
+    const prevIds = prevPresetIdsRef.current
+    const newPreset = presets.find((preset) => !prevIds.has(preset.id))
+    if (newPreset) {
+      setEditingPresetId(newPreset.id)
+      setEditDraft(buildDraft(newPreset))
     }
-    prevPresetCountRef.current = presets.length
-  }, [presets.length, presets, defaultPresetId])
+    prevPresetIdsRef.current = new Set(presets.map((preset) => preset.id))
+  }, [presets])
 
   // Close edit form if the editing preset was removed externally.
   useEffect(() => {

--- a/src/renderer/settings-mutations.test.ts
+++ b/src/renderer/settings-mutations.test.ts
@@ -444,6 +444,58 @@ describe('createSettingsMutations profile persistence helpers', () => {
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
     expect(setSettingsSaveMessage).not.toHaveBeenCalled()
   })
+
+  it('does not change default profile when adding a profile with immediate save', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.addTransformationPresetAndSave()
+
+    const savedSettings = vi.mocked(window.speechToTextApi.setSettings).mock.calls[0]?.[0] as Settings
+    expect(savedSettings.transformation.defaultPresetId).toBe('preset-a')
+  })
+
+  it('shows fallback toast when deleting the current default profile', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+    const addToast = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast,
+      logError: vi.fn()
+    })
+
+    await mutations.removeTransformationPresetAndSave('preset-a')
+
+    expect(addToast).toHaveBeenCalledWith('The default profile was deleted, so "Beta" is now the default profile.', 'info')
+  })
 })
 
 describe('createSettingsMutations.saveTransformationPresetDraft', () => {
@@ -533,8 +585,21 @@ describe('createSettingsMutations.saveTransformationPresetDraft', () => {
 })
 
 describe('createSettingsMutations.addTransformationPreset', () => {
-  it('selects the new profile as default and keeps pick-and-run memory unchanged', () => {
-    const state = createState(structuredClone(DEFAULT_SETTINGS))
+  it('keeps current default profile unchanged and keeps pick-and-run memory unchanged', () => {
+    const state = createState(
+      structuredClone({
+        ...DEFAULT_SETTINGS,
+        transformation: {
+          ...DEFAULT_SETTINGS.transformation,
+          defaultPresetId: 'preset-a',
+          lastPickedPresetId: null,
+          presets: [
+            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+          ]
+        }
+      })
+    )
     const onStateChange = vi.fn()
     const setSettingsSaveMessage = vi.fn()
 
@@ -550,11 +615,11 @@ describe('createSettingsMutations.addTransformationPreset', () => {
     })
 
     const beforeCount = state.settings!.transformation.presets.length
+    const defaultBefore = state.settings!.transformation.defaultPresetId
     mutations.addTransformationPreset()
 
     expect(state.settings!.transformation.presets).toHaveLength(beforeCount + 1)
-    const newPreset = state.settings!.transformation.presets.at(-1)!
-    expect(state.settings!.transformation.defaultPresetId).toBe(newPreset.id)
+    expect(state.settings!.transformation.defaultPresetId).toBe(defaultBefore)
     expect(state.settings!.transformation.lastPickedPresetId).toBeNull()
     expect(onStateChange).toHaveBeenCalledOnce()
     expect(setSettingsSaveMessage).not.toHaveBeenCalled()
@@ -598,5 +663,38 @@ describe('createSettingsMutations.removeTransformationPreset', () => {
     expect(state.settings?.transformation.lastPickedPresetId).toBeNull()
     expect(onStateChange).toHaveBeenCalledOnce()
     expect(setSettingsSaveMessage).not.toHaveBeenCalled()
+  })
+
+  it('shows fallback toast when removing the current default profile without immediate save', () => {
+    const state = createState(
+      structuredClone({
+        ...DEFAULT_SETTINGS,
+        transformation: {
+          ...DEFAULT_SETTINGS.transformation,
+          defaultPresetId: 'default-id',
+          lastPickedPresetId: null,
+          presets: [
+            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'default-id', name: 'Default' },
+            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'other-id', name: 'Other' }
+          ]
+        }
+      })
+    )
+    const addToast = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsSaveMessage: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast,
+      logError: vi.fn()
+    })
+
+    mutations.removeTransformationPreset('default-id')
+
+    expect(addToast).toHaveBeenCalledWith('The default profile was deleted, so "Other" is now the default profile.', 'info')
   })
 })

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -71,22 +71,33 @@ const buildSettingsWithAddedPreset = (settings: Settings): { nextSettings: Setti
       ...settings,
       transformation: {
         ...settings.transformation,
-        defaultPresetId: newPresetId,
+        // Keep the current default profile unchanged on add.
+        defaultPresetId: settings.transformation.defaultPresetId,
         presets: [...settings.transformation.presets, newPreset]
       }
     }
   }
 }
 
-const buildSettingsWithRemovedPreset = (settings: Settings, presetId: string): { nextSettings: Settings | null; error: string | null } => {
+const buildSettingsWithRemovedPreset = (
+  settings: Settings,
+  presetId: string
+): {
+  nextSettings: Settings | null
+  error: string | null
+  fallbackAssigned: boolean
+  fallbackPresetName: string | null
+} => {
   const presets = settings.transformation.presets
   if (presets.length <= 1) {
-    return { nextSettings: null, error: 'At least one profile is required.' }
+    return { nextSettings: null, error: 'At least one profile is required.', fallbackAssigned: false, fallbackPresetName: null }
   }
   const remaining = presets.filter((preset) => preset.id !== presetId)
   const fallbackId = remaining[0].id
+  const fallbackPresetName = remaining[0].name
+  const deletedWasDefault = settings.transformation.defaultPresetId === presetId
   const preferredDefaultId =
-    settings.transformation.defaultPresetId === presetId ? fallbackId : settings.transformation.defaultPresetId
+    deletedWasDefault ? fallbackId : settings.transformation.defaultPresetId
   const defaultPresetId = remaining.some((preset) => preset.id === preferredDefaultId) ? preferredDefaultId : fallbackId
   const currentLastPickedPresetId = settings.transformation.lastPickedPresetId
   const normalizedLastPickedPresetId =
@@ -103,7 +114,9 @@ const buildSettingsWithRemovedPreset = (settings: Settings, presetId: string): {
         presets: remaining
       }
     },
-    error: null
+    error: null,
+    fallbackAssigned: deletedWasDefault,
+    fallbackPresetName
   }
 }
 
@@ -378,6 +391,9 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       return
     }
     state.settings = removal.nextSettings
+    if (removal.fallbackAssigned && removal.fallbackPresetName) {
+      addToast(`The default profile was deleted, so "${removal.fallbackPresetName}" is now the default profile.`, 'info')
+    }
     onStateChange()
   }
 
@@ -432,6 +448,9 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       const saved = await window.speechToTextApi.setSettings(removal.nextSettings)
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
+      if (removal.fallbackAssigned && removal.fallbackPresetName) {
+        addToast(`The default profile was deleted, so "${removal.fallbackPresetName}" is now the default profile.`, 'info')
+      }
       onStateChange()
       return true
     } catch (error) {


### PR DESCRIPTION
## Summary\n- Keep current default profile unchanged when adding a new profile.\n- Preserve deterministic fallback when deleting current default profile (first remaining profile).\n- Add toast notification when fallback default assignment occurs after deleting the current default.\n- Update profiles panel add-detection logic to auto-open the newly added profile by id-diff (not by default id).\n\n## Files\n- src/renderer/settings-mutations.ts\n- src/renderer/profiles-panel-react.tsx\n- src/renderer/settings-mutations.test.ts\n- src/renderer/profiles-panel-react.test.tsx\n- docs/decisions/default-profile-stability-on-add-and-delete-fallback-toast.md\n\n## Tests\n- pnpm vitest run src/renderer/settings-mutations.test.ts src/renderer/profiles-panel-react.test.tsx src/renderer/renderer-app.test.ts\n  - 3 passed, 56 passed\n\n## Related\n- Closes #349\n- Follow-up planning remains in docs/plan PR for #350 and API-key delete modal