### PR TITLE
fix(#350): make profile creation explicit-save and draft-based

### DIFF
--- a/docs/decisions/profile-create-explicit-save-draft-phase-a.md
+++ b/docs/decisions/profile-create-explicit-save-draft-phase-a.md
@@ -1,0 +1,36 @@
+<!--
+Where: docs/decisions/profile-create-explicit-save-draft-phase-a.md
+What: Decision record for #350 phase-A profile creation/editing draft contract.
+Why: Prevent persisted invalid/incomplete profile state and remove implicit add-and-save behavior.
+-->
+
+# Decision: Profile Create Uses Unsaved Draft + Explicit Save (Phase A)
+
+## Status
+Accepted - March 5, 2026
+
+## Context
+
+Issue #350 requires explicit-save profile management behavior and no persistence of invalid/incomplete profile state.
+
+Before this change:
+- `Add profile` triggered immediate persisted creation (`addTransformationPresetAndSave`).
+- New profile creation could persist placeholder/partial profile content before user Save intent.
+
+## Decision
+
+- Remove immediate persisted add-profile path from renderer profile mutation API.
+- `Add profile` now opens a local unsaved draft editor in Profiles tab.
+- Persisted creation happens only via explicit Save from that draft form.
+- Validation for new-profile drafts reuses `validateTransformationPresetDraft` before persistence.
+- Cancel discards the new draft without persistence.
+
+## Consequences
+
+- Profile creation now matches explicit-save semantics already used for profile edits.
+- Invalid/incomplete draft data is blocked before write.
+- Legacy immediate-add compatibility path is removed from profile mutation surface.
+
+## Follow-up
+
+Phase B (#350) adds dirty-navigation and unload guards on top of this draft contract.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -61,7 +61,7 @@ const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCal
   onSelectTranscriptionModel: vi.fn(),
   onSelectDefaultPresetAndSave: vi.fn().mockResolvedValue(true),
   onSavePresetDraft: vi.fn().mockResolvedValue(true),
-  onAddPresetAndSave: vi.fn().mockResolvedValue(true),
+  onCreatePresetFromDraftAndSave: vi.fn().mockResolvedValue(true),
   onRemovePresetAndSave: vi.fn().mockResolvedValue(true),
   onChangeShortcutDraft: vi.fn(),
   onChangeOutputSelection: vi.fn(),

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -98,7 +98,9 @@ export interface AppShellCallbacks {
     presetId: string,
     draft: Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
   ) => Promise<boolean>
-  onAddPresetAndSave: () => Promise<boolean>
+  onCreatePresetFromDraftAndSave: (
+    draft: Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
+  ) => Promise<boolean>
   onRemovePresetAndSave: (presetId: string) => Promise<boolean>
   onChangeShortcutDraft: (key: ShortcutKey, value: string) => void
   onChangeOutputSelection: (
@@ -305,8 +307,8 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               ) => {
                 return callbacks.onSavePresetDraft(presetId, draft)
               }}
-              onAddPreset={async () => {
-                await callbacks.onAddPresetAndSave()
+              onCreatePresetDraft={async (draft) => {
+                return callbacks.onCreatePresetFromDraftAndSave(draft)
               }}
               onRemovePreset={async (presetId: string) => {
                 await callbacks.onRemovePresetAndSave(presetId)

--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -90,7 +90,7 @@ const buildCallbacks = () => ({
   settingsValidationErrors: {},
   onSelectDefaultPreset: vi.fn(),
   onSavePresetDraft: vi.fn().mockResolvedValue(true),
-  onAddPreset: vi.fn(),
+  onCreatePresetDraft: vi.fn().mockResolvedValue(true),
   onRemovePreset: vi.fn()
 })
 
@@ -498,7 +498,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(host.querySelector<HTMLInputElement>('#profile-edit-name')?.value).toBe('Beta')
   })
 
-  it('calls onAddPreset when Add profile button is clicked', async () => {
+  it('opens a new unsaved draft editor when Add profile button is clicked', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -517,7 +517,289 @@ describe('ProfilesPanelReact (STY-05)', () => {
     addBtn?.click()
     await flush()
 
-    expect(cbs.onAddPreset).toHaveBeenCalledTimes(1)
+    expect(cbs.onCreatePresetDraft).not.toHaveBeenCalled()
+    expect(host.querySelector<HTMLInputElement>('#profile-edit-name')?.value).toBe('')
+  })
+
+  it('creates profile only when Save is clicked from new draft editor', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    const addBtn = host.querySelector<HTMLButtonElement>('#profiles-panel-add')
+    addBtn?.click()
+    await flush()
+
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    expect(nameInput).not.toBeNull()
+    if (nameInput) {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      valueSetter?.call(nameInput, 'Gamma')
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    saveBtn?.click()
+    await flush()
+
+    expect(cbs.onCreatePresetDraft).toHaveBeenCalledWith({
+      name: 'Gamma',
+      model: 'gemini-2.5-flash',
+      systemPrompt: '',
+      userPrompt: ''
+    })
+  })
+
+  it('prevents duplicate profile creation when Save is clicked repeatedly while create is pending', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    let resolveCreate: ((value: boolean) => void) | null = null
+    cbs.onCreatePresetDraft.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveCreate = resolve
+        })
+    )
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    expect(saveBtn).not.toBeNull()
+    saveBtn?.click()
+    saveBtn?.click()
+    await flush()
+
+    expect(cbs.onCreatePresetDraft).toHaveBeenCalledTimes(1)
+    expect(saveBtn?.hasAttribute('disabled')).toBe(true)
+
+    resolveCreate?.(true)
+    await flush()
+    await flush()
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+  })
+
+  it('discards new profile draft on Cancel without persistence', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+    expect(host.querySelector('#profile-edit-name')).not.toBeNull()
+
+    const cancelBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Cancel')
+    cancelBtn?.click()
+    await flush()
+
+    expect(cbs.onCreatePresetDraft).not.toHaveBeenCalled()
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+  })
+
+  it('does not auto-reopen the newly created profile editor after successful create rerender', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    cbs.onCreatePresetDraft.mockResolvedValue(true)
+    const initialSettings = buildSettings({ defaultPresetId: 'preset-a' })
+    root.render(
+      <ProfilesPanelReact
+        settings={initialSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    if (nameInput) {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      valueSetter?.call(nameInput, 'Gamma')
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    saveBtn?.click()
+    await flush()
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+
+    // Simulate parent rerender after persisted create succeeds.
+    const addedSettings = buildSettings({
+      defaultPresetId: 'preset-a',
+      presets: [
+        ...initialSettings.transformation.presets,
+        {
+          ...PRESET_A,
+          id: 'preset-c',
+          name: 'Gamma',
+          systemPrompt: '',
+          userPrompt: ''
+        }
+      ]
+    })
+    root.render(
+      <ProfilesPanelReact
+        settings={addedSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+  })
+
+  it('suppresses auto-open when parent rerenders before create resolves, then allows later auto-open events', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const cbs = buildCallbacks()
+    let resolveCreate: ((value: boolean) => void) | null = null
+    cbs.onCreatePresetDraft.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveCreate = resolve
+        })
+    )
+    const initialSettings = buildSettings({ defaultPresetId: 'preset-a' })
+    root.render(
+      <ProfilesPanelReact
+        settings={initialSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    saveBtn?.click()
+    await flush()
+
+    // Parent rerender happens before create promise resolves.
+    const addedSettings = buildSettings({
+      defaultPresetId: 'preset-a',
+      presets: [
+        ...initialSettings.transformation.presets,
+        {
+          ...PRESET_A,
+          id: 'preset-c',
+          name: 'Gamma',
+          systemPrompt: '',
+          userPrompt: ''
+        }
+      ]
+    })
+    root.render(
+      <ProfilesPanelReact
+        settings={addedSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+    expect(host.querySelector<HTMLInputElement>('#profile-edit-name')?.value).toBe('')
+
+    resolveCreate?.(true)
+    await flush()
+    await flush()
+    expect(host.querySelector('#profile-edit-name')).toBeNull()
+
+    // Next unrelated add should still auto-open.
+    const secondAddedSettings = buildSettings({
+      defaultPresetId: 'preset-a',
+      presets: [
+        ...addedSettings.transformation.presets,
+        {
+          ...PRESET_A,
+          id: 'preset-d',
+          name: 'Delta',
+          systemPrompt: 'System D',
+          userPrompt: 'User D {{text}}'
+        }
+      ]
+    })
+    root.render(
+      <ProfilesPanelReact
+        settings={secondAddedSettings}
+        {...cbs}
+      />
+    )
+    await flush()
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    expect(nameInput).not.toBeNull()
+    expect(nameInput?.value).toBe('Delta')
+  })
+
+  it('hides stale validation errors when reopening new draft after cancel', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <ProfilesPanelReact
+        settings={buildSettings()}
+        settingsValidationErrors={{
+          presetName: 'Profile name is required.',
+          systemPrompt: 'System prompt is required.',
+          userPrompt: 'User prompt must include {{text}} where the transcript should be inserted.'
+        }}
+        onSelectDefaultPreset={vi.fn()}
+        onSavePresetDraft={vi.fn().mockResolvedValue(true)}
+        onCreatePresetDraft={vi.fn().mockResolvedValue(false)}
+        onRemovePreset={vi.fn()}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+
+    const saveBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Save')
+    saveBtn?.click()
+    await flush()
+    expect(host.textContent).toContain('Profile name is required.')
+
+    const cancelBtn = Array.from(host.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Cancel')
+    cancelBtn?.click()
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('#profiles-panel-add')?.click()
+    await flush()
+    expect(host.textContent).not.toContain('Profile name is required.')
   })
 
   it('auto-opens the newly added profile editor even when default profile stays unchanged', async () => {
@@ -671,7 +953,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
         }}
         onSelectDefaultPreset={vi.fn()}
         onSavePresetDraft={vi.fn().mockResolvedValue(false)}
-        onAddPreset={vi.fn()}
+        onCreatePresetDraft={vi.fn().mockResolvedValue(false)}
         onRemovePreset={vi.fn()}
       />
     )

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -27,6 +27,8 @@ import {
   SelectValue
 } from './components/ui/select'
 
+const NEW_PRESET_FORM_ID = 'new_profile_draft'
+
 // Local draft type — mirrors editable fields from TransformationPreset.
 interface EditDraft {
   name: string
@@ -42,6 +44,13 @@ const buildDraft = (preset: TransformationPreset): EditDraft => ({
   userPrompt: preset.userPrompt
 })
 
+const buildNewPresetDraft = (): EditDraft => ({
+  name: '',
+  model: 'gemini-2.5-flash',
+  systemPrompt: '',
+  userPrompt: ''
+})
+
 // ---------------------------------------------------------------------------
 // ProfilesPanelReact props
 // ---------------------------------------------------------------------------
@@ -54,7 +63,9 @@ export interface ProfilesPanelReactProps {
     presetId: string,
     draft: Pick<TransformationPreset, 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
   ) => Promise<boolean>
-  onAddPreset: () => void | Promise<void>
+  onCreatePresetDraft: (
+    draft: Pick<TransformationPreset, 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
+  ) => Promise<boolean>
   onRemovePreset: (presetId: string) => void | Promise<void>
 }
 
@@ -66,12 +77,21 @@ interface ProfileCardProps {
   preset: TransformationPreset
   isDefault: boolean
   isEditing: boolean
+  isActionsDisabled: boolean
   onOpenEdit: () => void
   onSetDefault: () => void
   onRemove: () => void
 }
 
-const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, onRemove }: ProfileCardProps) => {
+const ProfileCard = ({
+  preset,
+  isDefault,
+  isEditing,
+  isActionsDisabled,
+  onOpenEdit,
+  onSetDefault,
+  onRemove
+}: ProfileCardProps) => {
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     // Only handle key activation when the card itself is focused.
     // Nested action buttons (star/edit/trash) must keep their own key behavior.
@@ -80,6 +100,7 @@ const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, o
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
+      if (isActionsDisabled) return
       onOpenEdit()
     }
   }
@@ -90,7 +111,10 @@ const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, o
       tabIndex={0}
       aria-label={`${preset.name} profile${isDefault ? ' (default)' : ''}`}
       aria-expanded={isEditing}
-      onClick={onOpenEdit}
+      onClick={() => {
+        if (isActionsDisabled) return
+        onOpenEdit()
+      }}
       onKeyDown={handleKeyDown}
       className={cn(
         'group/card relative flex cursor-pointer flex-col gap-1 rounded-md border p-3 transition-colors',
@@ -116,8 +140,10 @@ const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, o
               <button
                 type="button"
                 aria-label={`Set ${preset.name} as default profile`}
+                disabled={isActionsDisabled}
                 onClick={(e) => {
                   e.stopPropagation()
+                  if (isActionsDisabled) return
                   onSetDefault()
                 }}
                 className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -128,8 +154,10 @@ const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, o
             <button
               type="button"
               aria-label={`Edit ${preset.name} profile`}
+              disabled={isActionsDisabled}
               onClick={(e) => {
                 e.stopPropagation()
+                if (isActionsDisabled) return
                 onOpenEdit()
               }}
               className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -139,8 +167,10 @@ const ProfileCard = ({ preset, isDefault, isEditing, onOpenEdit, onSetDefault, o
             <button
               type="button"
               aria-label={`Remove ${preset.name} profile`}
+              disabled={isActionsDisabled}
               onClick={(e) => {
                 e.stopPropagation()
+                if (isActionsDisabled) return
                 onRemove()
               }}
               className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -169,6 +199,7 @@ interface ProfileEditFormProps {
   presetNameError: string
   systemPromptError: string
   userPromptError: string
+  isSaving: boolean
   onChangeDraft: (patch: Partial<EditDraft>) => void
   onSave: () => void
   onCancel: () => void
@@ -180,6 +211,7 @@ const ProfileEditForm = ({
   presetNameError,
   systemPromptError,
   userPromptError,
+  isSaving,
   onChangeDraft,
   onSave,
   onCancel
@@ -294,6 +326,7 @@ const ProfileEditForm = ({
       <button
         type="button"
         onClick={onCancel}
+        disabled={isSaving}
         className="flex h-7 items-center rounded border border-border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       >
         Cancel
@@ -301,6 +334,7 @@ const ProfileEditForm = ({
       <button
         type="button"
         onClick={onSave}
+        disabled={isSaving}
         className="flex h-7 items-center rounded bg-primary px-2.5 text-xs text-primary-foreground transition-colors hover:bg-primary/90"
       >
         Save
@@ -318,20 +352,30 @@ export const ProfilesPanelReact = ({
   settingsValidationErrors,
   onSelectDefaultPreset,
   onSavePresetDraft,
-  onAddPreset,
+  onCreatePresetDraft,
   onRemovePreset
 }: ProfilesPanelReactProps) => {
   const { presets, defaultPresetId } = settings.transformation
 
   // Which preset's inline edit form is currently open (null = all collapsed).
   const [editingPresetId, setEditingPresetId] = useState<string | null>(null)
+  const [isCreatingPresetDraft, setIsCreatingPresetDraft] = useState(false)
 
   // Local form draft — isolated from settings to support Cancel without persisting.
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null)
+  const [showNewDraftValidationErrors, setShowNewDraftValidationErrors] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const isSavingRef = useRef(false)
+  const suppressNextAutoOpenRef = useRef(false)
 
   // Auto-open edit form when a new preset is added (detected by id diff).
   const prevPresetIdsRef = useRef(new Set(presets.map((preset) => preset.id)))
   useEffect(() => {
+    if (suppressNextAutoOpenRef.current) {
+      suppressNextAutoOpenRef.current = false
+      prevPresetIdsRef.current = new Set(presets.map((preset) => preset.id))
+      return
+    }
     const prevIds = prevPresetIdsRef.current
     const newPreset = presets.find((preset) => !prevIds.has(preset.id))
     if (newPreset) {
@@ -352,29 +396,55 @@ export const ProfilesPanelReact = ({
   const openEdit = (presetId: string) => {
     const preset = presets.find((p) => p.id === presetId)
     if (!preset) return
+    setIsCreatingPresetDraft(false)
     setEditingPresetId(presetId)
     setEditDraft(buildDraft(preset))
   }
 
   const applyDraftPatch = (patch: Partial<EditDraft>) => {
-    if (!editDraft || !editingPresetId) return
+    if (!editDraft || (!editingPresetId && !isCreatingPresetDraft)) return
     const next = { ...editDraft, ...patch }
     setEditDraft(next)
   }
 
   const handleSave = async () => {
-    if (!editingPresetId || !editDraft) return
-    const didSave = await onSavePresetDraft(editingPresetId, editDraft)
-    if (didSave) {
-      setEditingPresetId(null)
-      setEditDraft(null)
+    const isNewDraft = isCreatingPresetDraft
+    if (!editDraft || isSavingRef.current || (!isNewDraft && !editingPresetId)) return
+    isSavingRef.current = true
+    setIsSaving(true)
+    if (isNewDraft) {
+      suppressNextAutoOpenRef.current = true
+    }
+    try {
+      const didSave =
+        isNewDraft
+          ? await onCreatePresetDraft(editDraft)
+          : await onSavePresetDraft(editingPresetId as string, editDraft)
+      if (didSave) {
+        if (isNewDraft) {
+          setShowNewDraftValidationErrors(false)
+        }
+        setIsCreatingPresetDraft(false)
+        setEditingPresetId(null)
+        setEditDraft(null)
+        return
+      }
+      if (isNewDraft) {
+        suppressNextAutoOpenRef.current = false
+        setShowNewDraftValidationErrors(true)
+      }
+    } finally {
+      isSavingRef.current = false
+      setIsSaving(false)
     }
   }
 
   const handleCancel = () => {
     // Discard local draft entirely; parent state is unchanged until Save.
+    setIsCreatingPresetDraft(false)
     setEditingPresetId(null)
     setEditDraft(null)
+    setShowNewDraftValidationErrors(false)
   }
 
   return (
@@ -386,7 +456,7 @@ export const ProfilesPanelReact = ({
         aria-label="Transformation profiles"
       >
         {presets.map((preset) => {
-          const isEditing = editingPresetId === preset.id
+          const isEditing = !isCreatingPresetDraft && editingPresetId === preset.id
           const isDefault = preset.id === defaultPresetId
 
           return (
@@ -395,6 +465,7 @@ export const ProfilesPanelReact = ({
                 preset={preset}
                 isDefault={isDefault}
                 isEditing={isEditing}
+                isActionsDisabled={isSaving}
                 onOpenEdit={() => { openEdit(preset.id) }}
                 onSetDefault={() => {
                   void onSelectDefaultPreset(preset.id)
@@ -417,6 +488,7 @@ export const ProfilesPanelReact = ({
                     presetNameError={settingsValidationErrors.presetName ?? ''}
                     systemPromptError={settingsValidationErrors.systemPrompt ?? ''}
                     userPromptError={settingsValidationErrors.userPrompt ?? ''}
+                    isSaving={isSaving}
                     onChangeDraft={applyDraftPatch}
                     onSave={() => { void handleSave() }}
                     onCancel={handleCancel}
@@ -431,13 +503,35 @@ export const ProfilesPanelReact = ({
           <button
             type="button"
             id="profiles-panel-add"
-            onClick={() => { void onAddPreset() }}
+            onClick={() => {
+              if (isSaving) return
+              setIsCreatingPresetDraft(true)
+              setEditingPresetId(null)
+              setEditDraft(buildNewPresetDraft())
+              setShowNewDraftValidationErrors(false)
+            }}
+            disabled={isSaving}
             className="flex h-7 w-full items-center justify-center gap-1 rounded border border-dashed border-border text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Plus className="size-3" />
             Add profile
           </button>
         </div>
+        {isCreatingPresetDraft && editDraft && (
+          <div className="mx-1 rounded-md border border-primary/40 bg-primary/5 px-3 pb-3 pt-2">
+            <ProfileEditForm
+              draft={editDraft}
+              presetId={NEW_PRESET_FORM_ID}
+              presetNameError={showNewDraftValidationErrors ? settingsValidationErrors.presetName ?? '' : ''}
+              systemPromptError={showNewDraftValidationErrors ? settingsValidationErrors.systemPrompt ?? '' : ''}
+              userPromptError={showNewDraftValidationErrors ? settingsValidationErrors.userPrompt ?? '' : ''}
+              isSaving={isSaving}
+              onChangeDraft={applyDraftPatch}
+              onSave={() => { void handleSave() }}
+              onCancel={handleCancel}
+            />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -476,7 +476,7 @@ const rerenderShellFromState = (): void => {
     },
     onSelectDefaultPresetAndSave: mutations.setDefaultTransformationPresetAndSave,
     onSavePresetDraft: mutations.saveTransformationPresetDraft,
-    onAddPresetAndSave: mutations.addTransformationPresetAndSave,
+    onCreatePresetFromDraftAndSave: mutations.createTransformationPresetFromDraftAndSave,
     onRemovePresetAndSave: mutations.removeTransformationPresetAndSave,
     onChangeShortcutDraft: (key, value) => {
       applyNonSecretAutosavePatch((current) => ({

--- a/src/renderer/settings-mutations.test.ts
+++ b/src/renderer/settings-mutations.test.ts
@@ -253,7 +253,6 @@ describe('createSettingsMutations.deleteApiKey', () => {
       state,
       onStateChange,
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity,
       addToast,
@@ -282,7 +281,6 @@ describe('createSettingsMutations.deleteApiKey', () => {
       state,
       onStateChange,
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity,
       addToast,
@@ -312,7 +310,6 @@ describe('createSettingsMutations.deleteApiKey', () => {
       state,
       onStateChange,
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast: vi.fn(),
@@ -372,6 +369,13 @@ describe('createSettingsMutations.setDefaultTransformationPreset', () => {
 })
 
 describe('createSettingsMutations profile persistence helpers', () => {
+  const validNewProfileDraft = {
+    name: 'Gamma',
+    model: 'gemini-2.5-flash' as const,
+    systemPrompt: 'System Gamma',
+    userPrompt: 'User {{text}}'
+  }
+
   beforeEach(() => {
     ;(window as Window & { speechToTextApi: any }).speechToTextApi = {
       setSettings: vi.fn(async (settings: Settings) => settings),
@@ -382,7 +386,7 @@ describe('createSettingsMutations profile persistence helpers', () => {
     }
   })
 
-  it('persists default/add/remove profile actions immediately', async () => {
+  it('persists default/create/remove profile actions explicitly', async () => {
     const settings = structuredClone(DEFAULT_SETTINGS)
     settings.transformation.defaultPresetId = 'preset-a'
     settings.transformation.presets = [
@@ -401,7 +405,7 @@ describe('createSettingsMutations profile persistence helpers', () => {
     })
 
     await mutations.setDefaultTransformationPresetAndSave('preset-b')
-    await mutations.addTransformationPresetAndSave()
+    await mutations.createTransformationPresetFromDraftAndSave(validNewProfileDraft)
     await mutations.removeTransformationPresetAndSave('preset-a')
 
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(3)
@@ -431,7 +435,7 @@ describe('createSettingsMutations profile persistence helpers', () => {
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
   })
 
-  it('does not emit inline save message when adding a profile with immediate save', async () => {
+  it('persists a new profile only when explicit create-from-draft save is called', async () => {
     const state = createState(structuredClone(DEFAULT_SETTINGS))
 
     const mutations = createSettingsMutations({
@@ -444,12 +448,12 @@ describe('createSettingsMutations profile persistence helpers', () => {
       logError: vi.fn()
     })
 
-    await mutations.addTransformationPresetAndSave()
+    await mutations.createTransformationPresetFromDraftAndSave(validNewProfileDraft)
 
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
   })
 
-  it('emits error toasts when default/add/remove profile persistence fails', async () => {
+  it('emits error toasts when default/create/remove profile persistence fails', async () => {
     const settings = structuredClone(DEFAULT_SETTINGS)
     settings.transformation.defaultPresetId = 'preset-a'
     settings.transformation.presets = [
@@ -471,7 +475,7 @@ describe('createSettingsMutations profile persistence helpers', () => {
     })
 
     await mutations.setDefaultTransformationPresetAndSave('preset-b')
-    await mutations.addTransformationPresetAndSave()
+    await mutations.createTransformationPresetFromDraftAndSave(validNewProfileDraft)
     await mutations.removeTransformationPresetAndSave('preset-a')
 
     expect(addToast).toHaveBeenCalledWith('Failed to update default profile: disk error', 'error')
@@ -479,7 +483,7 @@ describe('createSettingsMutations profile persistence helpers', () => {
     expect(addToast).toHaveBeenCalledWith('Failed to remove profile: disk error', 'error')
   })
 
-  it('does not change default profile when adding a profile with immediate save', async () => {
+  it('does not change default profile when creating a profile from draft', async () => {
     const settings = structuredClone(DEFAULT_SETTINGS)
     settings.transformation.defaultPresetId = 'preset-a'
     settings.transformation.presets = [
@@ -492,14 +496,13 @@ describe('createSettingsMutations profile persistence helpers', () => {
       state,
       onStateChange: vi.fn(),
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast: vi.fn(),
       logError: vi.fn()
     })
 
-    await mutations.addTransformationPresetAndSave()
+    await mutations.createTransformationPresetFromDraftAndSave(validNewProfileDraft)
 
     const savedSettings = vi.mocked(window.speechToTextApi.setSettings).mock.calls[0]?.[0] as Settings
     expect(savedSettings.transformation.defaultPresetId).toBe('preset-a')
@@ -519,7 +522,6 @@ describe('createSettingsMutations profile persistence helpers', () => {
       state,
       onStateChange: vi.fn(),
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast,
@@ -529,6 +531,39 @@ describe('createSettingsMutations profile persistence helpers', () => {
     await mutations.removeTransformationPresetAndSave('preset-a')
 
     expect(addToast).toHaveBeenCalledWith('The default profile was deleted, so "Beta" is now the default profile.', 'info')
+  })
+  it('blocks invalid new profile draft and does not persist', async () => {
+    const state = createState(structuredClone(DEFAULT_SETTINGS))
+    const setSettingsValidationErrors = vi.fn()
+    const addToast = vi.fn()
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsValidationErrors,
+      addActivity: vi.fn(),
+      addToast,
+      logError: vi.fn()
+    })
+
+    const didSave = await mutations.createTransformationPresetFromDraftAndSave({
+      name: '   ',
+      model: 'gemini-2.5-flash',
+      systemPrompt: '   ',
+      userPrompt: 'invalid'
+    })
+
+    expect(didSave).toBe(false)
+    expect(window.speechToTextApi.setSettings).not.toHaveBeenCalled()
+    expect(setSettingsValidationErrors).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presetName: 'Profile name is required.',
+        systemPrompt: 'System prompt is required.',
+        userPrompt: expect.stringContaining('{{text}}')
+      })
+    )
+    expect(addToast).toHaveBeenCalledWith('Profile validation failed. Fix highlighted fields.', 'error')
   })
 })
 
@@ -619,45 +654,6 @@ describe('createSettingsMutations.saveTransformationPresetDraft', () => {
   })
 })
 
-describe('createSettingsMutations.addTransformationPreset', () => {
-  it('keeps current default profile unchanged and keeps pick-and-run memory unchanged', () => {
-    const state = createState(
-      structuredClone({
-        ...DEFAULT_SETTINGS,
-        transformation: {
-          ...DEFAULT_SETTINGS.transformation,
-          defaultPresetId: 'preset-a',
-          lastPickedPresetId: null,
-          presets: [
-            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
-            { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'preset-b', name: 'Beta' }
-          ]
-        }
-      })
-    )
-    const onStateChange = vi.fn()
-
-    const mutations = createSettingsMutations({
-      state,
-      onStateChange,
-      invalidatePendingAutosave: vi.fn(),
-      setSettingsValidationErrors: vi.fn(),
-      addActivity: vi.fn(),
-      addToast: vi.fn(),
-      logError: vi.fn()
-    })
-
-    const beforeCount = state.settings!.transformation.presets.length
-    const defaultBefore = state.settings!.transformation.defaultPresetId
-    mutations.addTransformationPreset()
-
-    expect(state.settings!.transformation.presets).toHaveLength(beforeCount + 1)
-    expect(state.settings!.transformation.defaultPresetId).toBe(defaultBefore)
-    expect(state.settings!.transformation.lastPickedPresetId).toBeNull()
-    expect(onStateChange).toHaveBeenCalledOnce()
-  })
-})
-
 describe('createSettingsMutations.removeTransformationPreset', () => {
   it('keeps default preset valid and clears stale lastPickedPresetId after removing a profile', () => {
     const state = createState(
@@ -743,7 +739,6 @@ describe('createSettingsMutations.removeTransformationPreset', () => {
       state,
       onStateChange: vi.fn(),
       invalidatePendingAutosave: vi.fn(),
-      setSettingsSaveMessage: vi.fn(),
       setSettingsValidationErrors: vi.fn(),
       addActivity: vi.fn(),
       addToast,

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -53,15 +53,23 @@ const buildSettingsWithDefaultPreset = (settings: Settings, defaultPresetId: str
   }
 })
 
-const buildSettingsWithAddedPreset = (settings: Settings): { nextSettings: Settings; newPresetId: string } => {
+const buildSettingsWithAddedPresetFromDraft = (
+  settings: Settings,
+  draft: Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
+): { nextSettings: Settings; newPresetId: string } => {
   const newPresetId = `preset-${Date.now()}`
+  const presetValidation = validateTransformationPresetDraft({
+    presetNameRaw: draft.name,
+    systemPromptRaw: draft.systemPrompt,
+    userPromptRaw: draft.userPrompt
+  })
   const newPreset = {
     id: newPresetId,
-    name: `Preset ${settings.transformation.presets.length + 1}`,
+    name: presetValidation.normalized.presetName,
     provider: 'google' as const,
-    model: 'gemini-2.5-flash' as const,
-    systemPrompt: '',
-    userPrompt: '',
+    model: draft.model,
+    systemPrompt: presetValidation.normalized.systemPrompt,
+    userPrompt: presetValidation.normalized.userPrompt,
     shortcut: settings.shortcuts.runTransform ?? DEFAULT_SETTINGS.shortcuts.runTransform
   }
   return {
@@ -405,14 +413,6 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     }
   }
 
-  const addTransformationPreset = (): void => {
-    if (!state.settings) {
-      return
-    }
-    state.settings = buildSettingsWithAddedPreset(state.settings).nextSettings
-    onStateChange()
-  }
-
   const removeTransformationPreset = (presetId: string): void => {
     if (!state.settings) {
       return
@@ -447,15 +447,48 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     }
   }
 
-  const addTransformationPresetAndSave = async (): Promise<boolean> => {
+  const createTransformationPresetFromDraftAndSave = async (
+    draft: Pick<Settings['transformation']['presets'][number], 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
+  ): Promise<boolean> => {
     if (!state.settings) return false
-    const { nextSettings } = buildSettingsWithAddedPreset(state.settings)
+    const presetValidation = validateTransformationPresetDraft({
+      presetNameRaw: draft.name,
+      systemPromptRaw: draft.systemPrompt,
+      userPromptRaw: draft.userPrompt
+    })
+
+    const nextErrors: SettingsValidationErrors = { ...state.settingsValidationErrors }
+    if (presetValidation.errors.presetName) {
+      nextErrors.presetName = presetValidation.errors.presetName
+    } else {
+      delete nextErrors.presetName
+    }
+    if (presetValidation.errors.systemPrompt) {
+      nextErrors.systemPrompt = presetValidation.errors.systemPrompt
+    } else {
+      delete nextErrors.systemPrompt
+    }
+    if (presetValidation.errors.userPrompt) {
+      nextErrors.userPrompt = presetValidation.errors.userPrompt
+    } else {
+      delete nextErrors.userPrompt
+    }
+    setSettingsValidationErrors(nextErrors)
+
+    if (Object.keys(presetValidation.errors).length > 0) {
+      addToast('Profile validation failed. Fix highlighted fields.', 'error')
+      return false
+    }
+
+    const { nextSettings } = buildSettingsWithAddedPresetFromDraft(state.settings, draft)
     try {
       invalidatePendingAutosave()
       const saved = await window.speechToTextApi.setSettings(nextSettings)
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
       onStateChange()
+      addActivity(`Profile "${presetValidation.normalized.presetName}" created.`, 'success')
+      addToast('Profile created.', 'success')
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown profile add error'
@@ -514,8 +547,7 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
     patchRecordingMethodDraft,
     patchRecordingSampleRateDraft,
     patchRecordingDeviceDraft,
-    addTransformationPreset,
-    addTransformationPresetAndSave,
+    createTransformationPresetFromDraftAndSave,
     removeTransformationPreset,
     removeTransformationPresetAndSave,
     applyTranscriptionProviderChange


### PR DESCRIPTION
## Summary
- switch Add Profile flow to local draft mode; no immediate persistence on Add
- persist new profiles only on explicit Save via create-from-draft mutation
- keep default profile unchanged while entering a new draft
- remove legacy immediate-add mutation paths and rewire AppShell/Renderer callbacks to draft-create API
- harden async save UX: prevent duplicate Save submissions and disable conflicting profile actions during in-flight save

## Tests
- pnpm vitest run src/renderer/settings-mutations.test.ts src/renderer/profiles-panel-react.test.tsx ✅
- pnpm vitest run src/renderer/app-shell-react.test.tsx ⚠️ fails in this environment due unresolved @radix-ui/react-dialog import from src/renderer/components/ui/dialog.tsx (baseline env issue)

## Docs
- docs/decisions/profile-create-explicit-save-draft-phase-a.md

## Notes
- Required second-pass Claude review was attempted but blocked by CLI quota: "You're out of extra usage · resets 3am (UTC)"