### PR TITLE
fix(#350): add unsaved profile draft navigation/unload guards

### DIFF
--- a/docs/decisions/profile-draft-unsaved-guard-phase-b.md
+++ b/docs/decisions/profile-draft-unsaved-guard-phase-b.md
@@ -1,0 +1,44 @@
+# Decision: Profile Draft Unsaved-Change Guards (Issue #350 Phase B)
+
+Where: `src/renderer/app-shell-react.tsx`, `src/renderer/profiles-panel-react.tsx`, `src/renderer/renderer-app.tsx`
+What: Introduce explicit unsaved-change guard flow for profile drafts across tab navigation and window unload.
+Why: Prevent accidental data loss when users edit profile drafts and navigate away or close/reload the renderer.
+
+## Context
+
+Phase A introduced explicit-save profile creation/edit drafts.
+Phase B adds lifecycle guardrails required by issue #350 acceptance:
+- navigation interception with Save/Discard/Stay,
+- unload warning while profile draft is dirty.
+
+## Decision
+
+1. Keep profile draft editing state local to `ProfilesPanelReact`, but expose a minimal imperative guard API to parent shell:
+   - `saveActiveDraft(): Promise<boolean>`
+   - `discardActiveDraft(): void`
+2. Publish profile draft guard state from panel to shell (`isDirty`, `hasDraft`, `isSaving`) via callback.
+3. In `AppShell`, block navigation away from `profiles` while dirty and open a modal:
+   - `Stay`: keep editing and close modal
+   - `Discard`: clear draft and continue navigation
+   - `Save and continue`: persist draft; continue only on success
+4. In `renderer-app`, bind `beforeunload` only while a profile draft is dirty and remove binding once clean.
+
+## Trade-offs
+
+- Pros:
+  - Guard logic is centralized at tab-routing level where navigation decisions occur.
+  - Draft ownership stays in the profile editor, avoiding broad state reshaping.
+  - `beforeunload` warning is tightly scoped to actual risk state.
+- Cons:
+  - Imperative ref contract adds coupling between shell and profiles panel.
+  - Guard flow relies on profile panel callback/ref staying in sync.
+
+## Legacy/Compatibility
+
+No legacy fallback path is retained.
+Old behavior (silent tab switch with dirty draft loss) is removed.
+
+## Validation
+
+- Added UI tests for guarded profile-tab navigation modal behavior.
+- Added renderer integration test for `beforeunload` bind/unbind based on draft dirtiness.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -66,6 +66,7 @@ const buildCallbacks = (overrides: Partial<AppShellCallbacks> = {}): AppShellCal
   onChangeShortcutDraft: vi.fn(),
   onChangeOutputSelection: vi.fn(),
   onDismissToast: vi.fn(),
+  onProfileDraftDirtyChange: vi.fn(),
   isNativeRecording: vi.fn().mockReturnValue(false),
   ...overrides
 })
@@ -353,5 +354,99 @@ describe('AppShell layout (STY-02)', () => {
     expect(host.querySelector('[data-tab-panel="activity"]')?.classList.contains('hidden')).toBe(false)
     expect(host.querySelector('[data-tab-panel="settings"]')?.classList.contains('hidden')).toBe(true)
     expect(host.querySelector('[data-tab-panel="profiles"]')?.classList.contains('hidden')).toBe(true)
+  })
+
+  it('blocks leaving Profiles tab with unsaved draft and shows unsaved changes dialog', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const onNavigate = vi.fn()
+    root.render(<AppShell state={buildState({ activeTab: 'profiles' })} callbacks={buildCallbacks({ onNavigate })} />)
+    await flush()
+
+    host.querySelector<HTMLElement>('[data-tab-panel="profiles"] [role="button"]')?.click()
+    await flush()
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    expect(nameInput).not.toBeNull()
+    if (nameInput) {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(nameInput, `${nameInput.value} updated`)
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')?.click()
+    await flush()
+
+    expect(onNavigate).not.toHaveBeenCalledWith('settings')
+    expect(document.body.textContent).toContain('Unsaved profile changes')
+  })
+
+  it('discards draft and continues navigation when Discard is selected in unsaved changes dialog', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const onNavigate = vi.fn()
+    root.render(<AppShell state={buildState({ activeTab: 'profiles' })} callbacks={buildCallbacks({ onNavigate })} />)
+    await flush()
+
+    host.querySelector<HTMLElement>('[data-tab-panel="profiles"] [role="button"]')?.click()
+    await flush()
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    if (nameInput) {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(nameInput, `${nameInput.value} updated`)
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')?.click()
+    await flush()
+    const discardButton = Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Discard')
+    discardButton?.click()
+    await flush()
+
+    expect(onNavigate).toHaveBeenCalledWith('settings')
+  })
+
+  it('keeps navigation blocked when Save and continue fails', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const onNavigate = vi.fn()
+    const onSavePresetDraft = vi.fn().mockResolvedValue(false)
+    root.render(
+      <AppShell
+        state={buildState({ activeTab: 'profiles' })}
+        callbacks={buildCallbacks({ onNavigate, onSavePresetDraft })}
+      />
+    )
+    await flush()
+
+    host.querySelector<HTMLElement>('[data-tab-panel="profiles"] [role="button"]')?.click()
+    await flush()
+    const nameInput = host.querySelector<HTMLInputElement>('#profile-edit-name')
+    if (nameInput) {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(nameInput, `${nameInput.value} updated`)
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    host.querySelector<HTMLButtonElement>('[data-route-tab="settings"]')?.click()
+    await flush()
+    const saveAndContinue = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.trim() === 'Save and continue'
+    )
+    saveAndContinue?.click()
+    await flush()
+    await flush()
+
+    expect(onSavePresetDraft).toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalledWith('settings')
+    expect(document.body.textContent).toContain('Unsaved profile changes')
   })
 })

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -18,14 +18,18 @@
  *   • Tab state is UI-local only — business state/IPC contracts are unchanged.
  */
 
-import type { ComponentType, MouseEvent } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ComponentType, type MouseEvent } from 'react'
 import { Activity, CheckCircle2, CircleAlert, Cpu, Info, Keyboard, Mic, Settings as SettingsIcon, Zap } from 'lucide-react'
 import { type OutputTextSource, type Settings } from '../shared/domain'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot, AudioInputSource, RecordingCommand } from '../shared/ipc'
 import type { ActivityItem } from './activity-feed'
 import { ActivityFeedReact } from './activity-feed-react'
 import { HomeReact } from './home-react'
-import { ProfilesPanelReact } from './profiles-panel-react'
+import {
+  ProfilesPanelReact,
+  type ProfileDraftGuardState,
+  type ProfilesPanelHandle
+} from './profiles-panel-react'
 import { SettingsApiKeysReact } from './settings-api-keys-react'
 import { SettingsOutputReact } from './settings-output-react'
 import { SettingsRecordingReact } from './settings-recording-react'
@@ -36,6 +40,7 @@ import { ShellChromeReact } from './shell-chrome-react'
 import { StatusBarReact } from './status-bar-react'
 import { Separator } from './components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './components/ui/dialog'
 import { cn } from './lib/utils'
 
 // Exported so renderer-app.tsx can use the same constant when initialising state.audioInputSources.
@@ -108,6 +113,7 @@ export interface AppShellCallbacks {
     destinations: { copyToClipboard: boolean; pasteAtCursor: boolean }
   ) => void
   onDismissToast: (toastId: number) => void
+  onProfileDraftDirtyChange: (isDirty: boolean) => void
   isNativeRecording: () => boolean
 }
 
@@ -159,6 +165,20 @@ const ToastTone = ({
 }
 
 export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
+  const profilesPanelRef = useRef<ProfilesPanelHandle | null>(null)
+  const [profileDraftGuardState, setProfileDraftGuardState] = useState<ProfileDraftGuardState>({
+    isDirty: false,
+    hasDraft: false,
+    isSaving: false
+  })
+  const [pendingNavigationTab, setPendingNavigationTab] = useState<AppTab | null>(null)
+  const [isUnsavedDraftDialogOpen, setIsUnsavedDraftDialogOpen] = useState(false)
+  const [isGuardActionPending, setIsGuardActionPending] = useState(false)
+
+  useLayoutEffect(() => {
+    callbacks.onProfileDraftDirtyChange(profileDraftGuardState.isDirty)
+  }, [callbacks, profileDraftGuardState.isDirty])
+
   if (!uiState.settings) {
     return (
       <div className="flex h-screen flex-col bg-background items-center justify-center">
@@ -172,6 +192,28 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
   }
 
   const isRecording = callbacks.isNativeRecording()
+  const proceedPendingNavigation = () => {
+    const nextTab = pendingNavigationTab
+    if (!nextTab) {
+      setIsUnsavedDraftDialogOpen(false)
+      return
+    }
+    setPendingNavigationTab(null)
+    setIsUnsavedDraftDialogOpen(false)
+    callbacks.onNavigate(nextTab)
+  }
+  const requestTabNavigation = (tab: AppTab) => {
+    if (tab === uiState.activeTab) {
+      return
+    }
+    if (uiState.activeTab === 'profiles' && tab !== 'profiles' && profileDraftGuardState.isDirty) {
+      setPendingNavigationTab(tab)
+      setIsUnsavedDraftDialogOpen(true)
+      return
+    }
+    callbacks.onNavigate(tab)
+  }
+
   const onTabsRailClick = (event: MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement | null
     const trigger = target?.closest('[data-route-tab]') as HTMLElement | null
@@ -179,8 +221,24 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
     if (!tab) {
       return
     }
-    callbacks.onNavigate(tab)
+    requestTabNavigation(tab)
   }
+  const isDialogActionDisabled = isGuardActionPending || profileDraftGuardState.isSaving
+  useEffect(() => {
+    if (
+      isUnsavedDraftDialogOpen &&
+      pendingNavigationTab &&
+      !profileDraftGuardState.isDirty &&
+      !profileDraftGuardState.isSaving
+    ) {
+      proceedPendingNavigation()
+    }
+  }, [
+    isUnsavedDraftDialogOpen,
+    pendingNavigationTab,
+    profileDraftGuardState.isDirty,
+    profileDraftGuardState.isSaving
+  ])
 
   return (
     <div className="flex h-screen flex-col bg-background">
@@ -202,7 +260,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               callbacks.onRunRecordingCommand(command)
             }}
             onOpenSettings={() => {
-              callbacks.onOpenSettings()
+              requestTabNavigation('settings')
             }}
           />
         </aside>
@@ -211,7 +269,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
         <Tabs
           value={uiState.activeTab}
           onValueChange={(value) => {
-            callbacks.onNavigate(value as AppTab)
+            requestTabNavigation(value as AppTab)
           }}
           orientation="horizontal"
           className="flex flex-1 flex-col overflow-hidden"
@@ -296,6 +354,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
             )}
           >
             <ProfilesPanelReact
+              ref={profilesPanelRef}
               settings={uiState.settings}
               settingsValidationErrors={uiState.settingsValidationErrors}
               onSelectDefaultPreset={async (presetId: string) => {
@@ -313,6 +372,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
               onRemovePreset={async (presetId: string) => {
                 await callbacks.onRemovePresetAndSave(presetId)
               }}
+              onDraftGuardChange={setProfileDraftGuardState}
             />
           </TabsContent>
 
@@ -500,6 +560,76 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
           </li>
         ))}
       </ul>
+      <Dialog
+        open={isUnsavedDraftDialogOpen}
+        onOpenChange={(open) => {
+          if (isGuardActionPending) {
+            return
+          }
+          if (!open) {
+            setPendingNavigationTab(null)
+          }
+          setIsUnsavedDraftDialogOpen(open)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unsaved profile changes</DialogTitle>
+            <DialogDescription>
+              You have unsaved profile edits. Save or discard them before leaving the Profiles tab.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <button
+              type="button"
+              disabled={isDialogActionDisabled}
+              className="h-7 rounded border border-border px-2.5 text-xs text-muted-foreground"
+              onClick={() => {
+                setPendingNavigationTab(null)
+                setIsUnsavedDraftDialogOpen(false)
+              }}
+            >
+              Stay
+            </button>
+            <button
+              type="button"
+              disabled={isDialogActionDisabled}
+              className="h-7 rounded border border-border px-2.5 text-xs text-muted-foreground"
+              onClick={() => {
+                if (isDialogActionDisabled) {
+                  return
+                }
+                setIsGuardActionPending(true)
+                profilesPanelRef.current?.discardActiveDraft()
+                proceedPendingNavigation()
+                setIsGuardActionPending(false)
+              }}
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              disabled={isDialogActionDisabled}
+              className="h-7 rounded bg-primary px-2.5 text-xs text-primary-foreground"
+              onClick={() => {
+                if (isDialogActionDisabled) {
+                  return
+                }
+                setIsGuardActionPending(true)
+                void profilesPanelRef.current?.saveActiveDraft().then((didSave) => {
+                  if (didSave) {
+                    proceedPendingNavigation()
+                  }
+                }).finally(() => {
+                  setIsGuardActionPending(false)
+                })
+              }}
+            >
+              Save and continue
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -13,7 +13,7 @@
  *   - Cancel discards local draft without persisting to disk.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { Pencil, Plus, Star, Trash2 } from 'lucide-react'
 import type { Settings, TransformationPreset } from '../shared/domain'
@@ -67,6 +67,30 @@ export interface ProfilesPanelReactProps {
     draft: Pick<TransformationPreset, 'name' | 'model' | 'systemPrompt' | 'userPrompt'>
   ) => Promise<boolean>
   onRemovePreset: (presetId: string) => void | Promise<void>
+  onDraftGuardChange?: (state: ProfileDraftGuardState) => void
+}
+
+export interface ProfileDraftGuardState {
+  isDirty: boolean
+  hasDraft: boolean
+  isSaving: boolean
+}
+
+export interface ProfilesPanelHandle {
+  saveActiveDraft: () => Promise<boolean>
+  discardActiveDraft: () => void
+}
+
+const areDraftsEqual = (left: EditDraft | null, right: EditDraft | null): boolean => {
+  if (!left || !right) {
+    return left === right
+  }
+  return (
+    left.name === right.name &&
+    left.model === right.model &&
+    left.systemPrompt === right.systemPrompt &&
+    left.userPrompt === right.userPrompt
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -347,14 +371,15 @@ const ProfileEditForm = ({
 // ProfilesPanelReact — main export
 // ---------------------------------------------------------------------------
 
-export const ProfilesPanelReact = ({
+export const ProfilesPanelReact = forwardRef<ProfilesPanelHandle, ProfilesPanelReactProps>(({
   settings,
   settingsValidationErrors,
   onSelectDefaultPreset,
   onSavePresetDraft,
   onCreatePresetDraft,
-  onRemovePreset
-}: ProfilesPanelReactProps) => {
+  onRemovePreset,
+  onDraftGuardChange
+}, ref) => {
   const { presets, defaultPresetId } = settings.transformation
 
   // Which preset's inline edit form is currently open (null = all collapsed).
@@ -363,10 +388,21 @@ export const ProfilesPanelReact = ({
 
   // Local form draft — isolated from settings to support Cancel without persisting.
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null)
+  const [originalDraft, setOriginalDraft] = useState<EditDraft | null>(null)
   const [showNewDraftValidationErrors, setShowNewDraftValidationErrors] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const isSavingRef = useRef(false)
+  const inFlightSavePromiseRef = useRef<Promise<boolean> | null>(null)
   const suppressNextAutoOpenRef = useRef(false)
+  const draftGuardState = useMemo<ProfileDraftGuardState>(() => ({
+    isDirty: !areDraftsEqual(editDraft, originalDraft),
+    hasDraft: editDraft !== null,
+    isSaving
+  }), [editDraft, originalDraft, isSaving])
+
+  useLayoutEffect(() => {
+    onDraftGuardChange?.(draftGuardState)
+  }, [draftGuardState, onDraftGuardChange])
 
   // Auto-open edit form when a new preset is added (detected by id diff).
   const prevPresetIdsRef = useRef(new Set(presets.map((preset) => preset.id)))
@@ -379,8 +415,10 @@ export const ProfilesPanelReact = ({
     const prevIds = prevPresetIdsRef.current
     const newPreset = presets.find((preset) => !prevIds.has(preset.id))
     if (newPreset) {
+      setIsCreatingPresetDraft(false)
       setEditingPresetId(newPreset.id)
       setEditDraft(buildDraft(newPreset))
+      setOriginalDraft(buildDraft(newPreset))
     }
     prevPresetIdsRef.current = new Set(presets.map((preset) => preset.id))
   }, [presets])
@@ -389,7 +427,9 @@ export const ProfilesPanelReact = ({
   useEffect(() => {
     if (editingPresetId && !presets.some((p) => p.id === editingPresetId)) {
       setEditingPresetId(null)
+      setIsCreatingPresetDraft(false)
       setEditDraft(null)
+      setOriginalDraft(null)
     }
   }, [editingPresetId, presets])
 
@@ -399,6 +439,7 @@ export const ProfilesPanelReact = ({
     setIsCreatingPresetDraft(false)
     setEditingPresetId(presetId)
     setEditDraft(buildDraft(preset))
+    setOriginalDraft(buildDraft(preset))
   }
 
   const applyDraftPatch = (patch: Partial<EditDraft>) => {
@@ -407,45 +448,73 @@ export const ProfilesPanelReact = ({
     setEditDraft(next)
   }
 
-  const handleSave = async () => {
+  const saveActiveDraft = async (): Promise<boolean> => {
     const isNewDraft = isCreatingPresetDraft
-    if (!editDraft || isSavingRef.current || (!isNewDraft && !editingPresetId)) return
+    if (!editDraft || (!isNewDraft && !editingPresetId)) return true
+    if (isSavingRef.current) {
+      return inFlightSavePromiseRef.current ? await inFlightSavePromiseRef.current : false
+    }
     isSavingRef.current = true
     setIsSaving(true)
-    if (isNewDraft) {
-      suppressNextAutoOpenRef.current = true
-    }
-    try {
-      const didSave =
-        isNewDraft
-          ? await onCreatePresetDraft(editDraft)
-          : await onSavePresetDraft(editingPresetId as string, editDraft)
-      if (didSave) {
-        if (isNewDraft) {
-          setShowNewDraftValidationErrors(false)
-        }
-        setIsCreatingPresetDraft(false)
-        setEditingPresetId(null)
-        setEditDraft(null)
-        return
-      }
+    const savePromise = (async (): Promise<boolean> => {
       if (isNewDraft) {
-        suppressNextAutoOpenRef.current = false
-        setShowNewDraftValidationErrors(true)
+        suppressNextAutoOpenRef.current = true
       }
-    } finally {
-      isSavingRef.current = false
-      setIsSaving(false)
-    }
+      try {
+        const didSave =
+          isNewDraft
+            ? await onCreatePresetDraft(editDraft)
+            : await onSavePresetDraft(editingPresetId as string, editDraft)
+        if (didSave) {
+          if (isNewDraft) {
+            setShowNewDraftValidationErrors(false)
+          }
+          setIsCreatingPresetDraft(false)
+          setEditingPresetId(null)
+          setEditDraft(null)
+          setOriginalDraft(null)
+          return true
+        }
+        if (isNewDraft) {
+          suppressNextAutoOpenRef.current = false
+          setShowNewDraftValidationErrors(true)
+        }
+        return false
+      } finally {
+        isSavingRef.current = false
+        setIsSaving(false)
+      }
+    })()
+    inFlightSavePromiseRef.current = savePromise
+    const didSave = await savePromise
+    inFlightSavePromiseRef.current = null
+    return didSave
   }
 
-  const handleCancel = () => {
+  const discardActiveDraft = () => {
     // Discard local draft entirely; parent state is unchanged until Save.
     setIsCreatingPresetDraft(false)
     setEditingPresetId(null)
     setEditDraft(null)
+    setOriginalDraft(null)
     setShowNewDraftValidationErrors(false)
   }
+  const handleSave = () => { void saveActiveDraft() }
+  const handleCancel = () => { discardActiveDraft() }
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      saveActiveDraft: async () => {
+        if (!draftGuardState.hasDraft || !draftGuardState.isDirty) {
+          return true
+        }
+        return saveActiveDraft()
+      },
+      discardActiveDraft
+    }),
+    [draftGuardState.hasDraft, draftGuardState.isDirty, saveActiveDraft]
+  )
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -473,7 +542,9 @@ export const ProfilesPanelReact = ({
                 onRemove={() => {
                   if (isEditing) {
                     setEditingPresetId(null)
+                    setIsCreatingPresetDraft(false)
                     setEditDraft(null)
+                    setOriginalDraft(null)
                   }
                   void onRemovePreset(preset.id)
                 }}
@@ -508,6 +579,7 @@ export const ProfilesPanelReact = ({
               setIsCreatingPresetDraft(true)
               setEditingPresetId(null)
               setEditDraft(buildNewPresetDraft())
+              setOriginalDraft(buildNewPresetDraft())
               setShowNewDraftValidationErrors(false)
             }}
             disabled={isSaving}
@@ -535,4 +607,4 @@ export const ProfilesPanelReact = ({
       </div>
     </div>
   )
-}
+})

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -575,4 +575,41 @@ describe('renderer app', () => {
     const activityPanel = mountPoint.querySelector<HTMLElement>('[data-tab-panel="activity"]')
     expect(activityPanel?.textContent ?? '').toContain('Transform error: Transformation enqueued.')
   })
+
+  it('binds beforeunload while profile draft is dirty and unbinds after discard', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const harness = buildIpcHarness()
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    startRendererApp(mountPoint)
+    await waitForBoot()
+
+    mountPoint.querySelector<HTMLButtonElement>('[data-route-tab="profiles"]')?.click()
+    await flush()
+
+    mountPoint.querySelector<HTMLElement>('[data-tab-panel="profiles"] [role="button"]')?.click()
+    await flush()
+    const nameInput = mountPoint.querySelector<HTMLInputElement>('#profile-edit-name')
+    expect(nameInput).not.toBeNull()
+    if (nameInput) {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setter?.call(nameInput, `${nameInput.value} draft`)
+      nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await flush()
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+
+    const cancelButton = Array.from(mountPoint.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Cancel')
+    cancelButton?.click()
+    await flush()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
 })

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -68,6 +68,7 @@ const state = {
   audioSourceHint: '',
   hasCommandError: false,
   isShortcutCaptureActive: false,
+  hasUnsavedProfileDraft: false,
   hasAutosaveValidationToast: false,
   settingsValidationErrors: {} as SettingsValidationErrors,
   persistedSettings: null as Settings | null,
@@ -80,6 +81,26 @@ const HOME_API_KEY_STATUS_REFRESH_ATTEMPTS = 3
 const HOME_API_KEY_STATUS_REFRESH_DELAY_MS = 250
 const TOAST_AUTO_DISMISS_MS = 6000
 const TOAST_MAX_VISIBLE = 4
+const BEFORE_UNLOAD_WARNING_TEXT = 'You have unsaved profile changes.'
+
+const onBeforeUnload = (event: BeforeUnloadEvent): string => {
+  event.preventDefault()
+  event.returnValue = BEFORE_UNLOAD_WARNING_TEXT
+  return BEFORE_UNLOAD_WARNING_TEXT
+}
+let isBeforeUnloadBound = false
+
+const syncBeforeUnloadBinding = (): void => {
+  if (state.hasUnsavedProfileDraft && !isBeforeUnloadBound) {
+    window.addEventListener('beforeunload', onBeforeUnload)
+    isBeforeUnloadBound = true
+    return
+  }
+  if (!state.hasUnsavedProfileDraft && isBeforeUnloadBound) {
+    window.removeEventListener('beforeunload', onBeforeUnload)
+    isBeforeUnloadBound = false
+  }
+}
 
 const sleep = async (ms: number): Promise<void> =>
   new Promise((resolve) => {
@@ -497,6 +518,13 @@ const rerenderShellFromState = (): void => {
       dismissToast(toastId)
       rerenderShellFromState()
     },
+    onProfileDraftDirtyChange: (isDirty) => {
+      if (state.hasUnsavedProfileDraft === isDirty) {
+        return
+      }
+      state.hasUnsavedProfileDraft = isDirty
+      syncBeforeUnloadBinding()
+    },
     isNativeRecording
   }
 
@@ -575,6 +603,8 @@ export const startRendererApp = (target?: HTMLDivElement): void => {
 }
 
 export const stopRendererAppForTests = (): void => {
+  state.hasUnsavedProfileDraft = false
+  syncBeforeUnloadBinding()
   clearAutosaveTimer()
   for (const timer of state.toastTimers.values()) {
     clearTimeout(timer)
@@ -600,6 +630,7 @@ export const stopRendererAppForTests = (): void => {
   state.audioSourceHint = ''
   state.hasCommandError = false
   state.isShortcutCaptureActive = false
+  state.hasUnsavedProfileDraft = false
   state.hasAutosaveValidationToast = false
   state.settingsValidationErrors = {}
   state.persistedSettings = null


### PR DESCRIPTION
## Summary
- add unsaved-profile-draft guard modal when navigating away from Profiles tab
- support Save and continue / Discard / Stay guard actions
- route Home "Open Settings" through guarded navigation path
- bind browser beforeunload warning while a profile draft is dirty, unbind when clean
- remove unsafe in-flight save shortcut behavior by awaiting active save promises

## Tests
- pnpm vitest run src/renderer/profiles-panel-react.test.tsx src/renderer/app-shell-react.test.tsx src/renderer/renderer-app.test.ts src/renderer/settings-mutations.test.ts
  - 4 files, 89 tests passed

## Docs
- docs/decisions/profile-draft-unsaved-guard-phase-b.md

## Review
- Sub-agent reviews completed (final pass: no findings)
- Second-model Claude review attempted but blocked by quota: "You're out of extra usage · resets 3am (UTC)"
