### PR TITLE
test(335): harden delete-modal coverage and remove legacy API-key e2e selectors

### DIFF
--- a/docs/plans/issues-349-350-and-api-key-delete-modal-execution-plan.md
+++ b/docs/plans/issues-349-350-and-api-key-delete-modal-execution-plan.md
@@ -294,6 +294,9 @@ Before coding, either:
 - Reopen issue `#335`, or
 - Create a new superseding issue and replace references in this plan/PR metadata.
 
+Gate status:
+- Completed on 2026-03-05 by reopening issue `#335`: https://github.com/massun-onibakuchi/speech-to-text-app/issues/335
+
 ### Approach (locked)
 
 Use explicit delete API contract only:

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -135,7 +135,8 @@ test('uses per-tab scroll isolation in workspace panels', async ({ page }) => {
 
 test('exposes icon-control aria labels and supports profile keyboard activation', async ({ page }) => {
   await page.locator('[data-route-tab="settings"]').click()
-  await expect(page.locator('[data-api-key-visibility-toggle="groq"]')).toHaveAttribute('aria-label', /Show|Hide/)
+  await expect(page.locator('[aria-label="Delete Groq API key"]')).toBeVisible()
+  await expect(page.locator('[data-api-key-visibility-toggle="groq"]')).toHaveCount(0)
 
   await page.locator('[data-route-tab="profiles"]').click()
   const firstProfileCard = page.locator('[data-tab-panel="profiles"]').locator('[role="button"][aria-label*="profile"]').first()
@@ -268,22 +269,43 @@ test('shows provider API key inputs in Settings', async ({ page }) => {
   await selectSttProvider(page, 'groq')
 })
 
-test('supports API key show/hide toggle and per-provider connection status', async ({ page }) => {
+test('supports API key delete confirmation flow and removes legacy visibility/test controls', async ({ page }) => {
+  // Seed a saved key directly via IPC contract so delete flow is deterministic in E2E.
+  await page.evaluate(async () => {
+    await window.speechToTextApi.setApiKey('groq', `e2e-groq-${Date.now()}`)
+  })
+  await page.reload()
+  await page.waitForSelector('[data-route-tab="settings"]')
   await page.locator('[data-route-tab="settings"]').click()
 
-  // Groq is the default — toggle visibility on its key input
-  const groqInput = page.locator('#settings-api-key-groq')
-  await expect(groqInput).toHaveAttribute('type', 'password')
-  await page.locator('[data-api-key-visibility-toggle="groq"]').click()
-  await expect(groqInput).toHaveAttribute('type', 'text')
-  await page.locator('[data-api-key-visibility-toggle="groq"]').click()
-  await expect(groqInput).toHaveAttribute('type', 'password')
+  const groqDeleteButton = page.locator('[aria-label="Delete Groq API key"]')
+  await expect(groqDeleteButton).toBeVisible()
+  await expect(groqDeleteButton).toBeEnabled()
+  await expect(page.locator('[aria-label="Delete Google API key"]')).toBeVisible()
+  await expect(page.locator('[data-api-key-visibility-toggle="groq"]')).toHaveCount(0)
+  await expect(page.locator('[data-api-key-test="groq"]')).toHaveCount(0)
+  await expect(page.locator('[data-api-key-test="google"]')).toHaveCount(0)
+  await expect(page.locator('#api-key-test-status-groq')).toHaveCount(0)
+  await expect(page.locator('#api-key-test-status-elevenlabs')).toHaveCount(0)
+  await expect(page.locator('#api-key-test-status-google')).toHaveCount(0)
 
-  // Switch to ElevenLabs to test that provider's key input and connection test
+  // Confirm cancel is non-destructive.
+  await groqDeleteButton.click()
+  await expect(page.getByRole('heading', { name: 'Delete API key?' })).toBeVisible()
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect(page.getByRole('heading', { name: 'Delete API key?' })).toHaveCount(0)
+
+  // Confirm delete and verify post-delete state transition.
+  await groqDeleteButton.click()
+  await page.getByRole('button', { name: 'Delete key' }).click()
+  await expect(page.locator('#api-key-save-status-groq')).toHaveText('Deleted.')
+  await expect(groqDeleteButton).toBeDisabled()
+
+  // Switch to ElevenLabs and confirm provider-specific delete action remains available.
   await selectSttProvider(page, 'elevenlabs')
-  await page.locator('#settings-api-key-elevenlabs').fill(`e2e-test-${Date.now()}`)
-  await page.locator('[data-api-key-test="elevenlabs"]').click()
-  await expect(page.locator('#api-key-test-status-elevenlabs')).toContainText(/Success:|Failed:/)
+  await expect(page.locator('[aria-label="Delete ElevenLabs API key"]')).toBeVisible()
+  await expect(page.locator('[data-api-key-visibility-toggle="elevenlabs"]')).toHaveCount(0)
+  await expect(page.locator('[data-api-key-test="elevenlabs"]')).toHaveCount(0)
 })
 
 test('macOS provider-key preload smoke @macos', async ({ page }) => {

--- a/src/renderer/settings-api-keys-react.test.tsx
+++ b/src/renderer/settings-api-keys-react.test.tsx
@@ -264,6 +264,35 @@ describe('SettingsApiKeysReact (Google LLM key)', () => {
     expect(document.body.textContent).not.toContain('Delete API key?')
   })
 
+  it('keeps dialog open when delete fails so user can retry or cancel', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    const onDeleteApiKey = vi.fn(async () => false)
+
+    await act(async () => {
+      root?.render(
+        <SettingsApiKeysReact
+          apiKeyStatus={{ groq: false, elevenlabs: false, google: true }}
+          apiKeySaveStatus={{ groq: '', elevenlabs: '', google: '' }}
+          onSaveApiKey={vi.fn(async () => {})}
+          onDeleteApiKey={onDeleteApiKey}
+        />
+      )
+    })
+
+    const deleteButton = host.querySelector<HTMLButtonElement>('[aria-label="Delete Google API key"]')!
+    await act(async () => { deleteButton.click() })
+
+    const confirmButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+      button.textContent?.trim() === 'Delete key'
+    )!
+    await act(async () => { confirmButton.click() })
+
+    expect(onDeleteApiKey).toHaveBeenCalledWith('google')
+    expect(document.body.textContent).toContain('Delete API key?')
+  })
+
   it('confirms delete and calls provider delete callback', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/settings-stt-provider-form-react.test.tsx
+++ b/src/renderer/settings-stt-provider-form-react.test.tsx
@@ -409,4 +409,32 @@ describe('SettingsSttProviderFormReact', () => {
     await act(async () => { confirmButton.click() })
     expect(onDeleteApiKey).toHaveBeenCalledWith('groq')
   })
+
+  it('keeps confirmation open when provider delete fails', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+    const onDeleteApiKey = vi.fn(async () => false)
+
+    await act(async () => {
+      root?.render(
+        <SettingsSttProviderFormReact
+          {...defaultProps}
+          apiKeyStatus={{ groq: true, elevenlabs: false, google: false }}
+          onDeleteApiKey={onDeleteApiKey}
+        />
+      )
+    })
+
+    const deleteButton = host.querySelector<HTMLButtonElement>('[aria-label="Delete Groq API key"]')!
+    await act(async () => { deleteButton.click() })
+
+    const confirmButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+      button.textContent?.trim() === 'Delete key'
+    )!
+    await act(async () => { confirmButton.click() })
+
+    expect(onDeleteApiKey).toHaveBeenCalledWith('groq')
+    expect(document.body.textContent).toContain('Delete API key?')
+  })
 })


### PR DESCRIPTION
## Summary
- mark T4 pre-execution gate complete by reopening #335 and recording it in plan metadata
- add renderer tests to lock delete-failure UX contract (confirmation dialog remains open on delete failure) for Google and STT forms
- replace stale e2e assumptions about removed API-key visibility/test controls with delete-modal flow assertions
- add stricter assertions that legacy API-key test-status surfaces are absent

## Issue
- Reopened and linked: #335

## Verification
- Targeted Vitest suites passed for renderer delete flows, dialog, settings mutations, secret store, and IPC round-trip.
- Re-ran focused renderer Vitest suites after final changes; all passing.

## Known environment limitation
- Focused Playwright run for the updated e2e test failed to launch Electron in this environment.