### PR TITLE
Fix recording preflight for transformed output + blocked shortcut sound parity

### DIFF
--- a/docs/decisions/issue-360-recording-gate-for-transformed-output.md
+++ b/docs/decisions/issue-360-recording-gate-for-transformed-output.md
@@ -1,0 +1,47 @@
+<!--
+Where: docs/decisions/issue-360-recording-gate-for-transformed-output.md
+What: Decision record for recording preflight gating when transformed output is selected.
+Why: Issue #360 requires consistent blocking across Home and shortcut entry points.
+-->
+
+# Decision: Gate Recording Start When Transformed Output Cannot Run
+
+## Status
+Accepted - March 5, 2026
+
+## Context
+
+Issue #360 reports inconsistent behavior:
+- Home blocked state correctly depends on STT key presence.
+- When output source is `transformed`, recording could still start from shortcut/native command path even if Google key is missing.
+
+This creates user confusion because the selected output source cannot be fulfilled.
+
+## Decision
+
+- Recording availability requires:
+  - selected STT provider API key, and
+  - Google API key when `output.selectedTextSource = transformed`.
+- Apply this preflight consistently across all recording start entry points:
+  - Home button enabled/disabled state.
+  - Shortcut/native `startRecording` and `toggleRecording` (idle-start) path.
+- Block before start side effects so blocked attempts do not:
+  - start recording,
+  - emit recording start sounds.
+
+## Alternatives Considered
+
+1. Allow recording and silently fall back to transcript output.
+- Rejected because it violates explicit output mode choice and hides a configuration error.
+
+2. Gate only Home button and keep shortcut behavior unchanged.
+- Rejected because it preserves inconsistent behavior and regression risk.
+
+3. Block only sound while allowing recording start.
+- Rejected because it creates silent-but-started behavior and worsens debugging.
+
+## Consequences
+
+- Users get consistent blocked behavior regardless of trigger path.
+- Shortcut attempts in blocked state stay silent, matching existing STT-missing behavior.
+- Renderer tests must cover both UI and IPC shortcut integration seams.

--- a/docs/plans/issue-360-execution-plan.md
+++ b/docs/plans/issue-360-execution-plan.md
@@ -1,0 +1,198 @@
+# Issue 360 Execution Plan
+
+## Context
+- Issue: https://github.com/massun-onibakuchi/speech-to-text-app/issues/360
+- Problem: Recording remains enabled when `output.selectedTextSource = transformed` and Google key is missing.
+- Additional requirement: Shortcut-triggered blocked attempts must not play recording sounds.
+
+## Delivery Model
+- 1 ticket = 1 PR.
+- Tickets are sorted by priority and should merge in order.
+- Keep each PR small, reversible, and independently testable.
+
+## Ticket Priority Order
+1. P0 - Ticket T360-1: Functional fix for all recording entry points (UI + shortcut/native)
+2. P1 - Ticket T360-2: Regression coverage (unit + integration tests)
+3. P2 - Ticket T360-3: Decision documentation
+
+---
+
+## Ticket T360-1 (P0)
+### Goal
+Disable all recording entry points (Home button and shortcut/native command start paths) when transformed output is selected and Google key is missing, while preserving STT-key precedence behavior.
+
+### Approach
+- Introduce a shared recording preflight guard in renderer logic used by both:
+  - Home disabled/blocked state rendering.
+  - Native recording start branches (`startRecording` and `toggleRecording` when idle).
+- Guard before any start side effects to avoid silent-but-started bugs:
+  - before recording start call
+  - before success activity messages
+  - before sound events
+- Preserve precedence:
+  - If STT key missing for selected STT provider, return STT blocked reason.
+  - Else if output source is `transformed` and Google key missing, return transform blocked reason.
+  - Else allow start.
+
+### Scope Files
+- `src/renderer/blocked-control.ts`
+- `src/renderer/home-react.tsx`
+- `src/renderer/native-recording.ts`
+- `src/renderer/renderer-app.tsx` (only if guard wiring needs lightweight state plumb)
+
+### Checklist
+- [ ] Shared recording preflight guard implemented and reused.
+- [ ] Home recording button disabled for transformed-output + missing Google key.
+- [ ] Shortcut/native blocked attempts do not start recording.
+- [ ] Shortcut/native blocked attempts do not play recording sounds.
+- [ ] STT-key-missing behavior remains unchanged.
+
+### Tasks (Chunked)
+1. Add/refactor shared preflight function for recording availability.
+2. Apply guard in Home blocked message/disabled flow.
+3. Apply same guard at native recording start and toggle-start branches.
+4. Ensure blocked path exits before start/sound side effects.
+5. Run focused smoke tests for renderer recording flows.
+
+### Gates
+- Gate A (Functional): Home button disabled when transformed output selected + Google key missing.
+- Gate B (Functional): Shortcut blocked attempt does not start recording and does not emit recording sounds.
+- Gate C (Parity): STT-key-missing blocked behavior still matches current UX.
+- Gate D (Quality): Targeted tests for touched areas pass.
+
+### Trade-offs
+- Shared guard reduces drift between UI state and command execution behavior.
+- Small refactor cost now prevents recurring mismatches between button state and shortcut behavior.
+- Guard stays renderer-local for minimal scope; runtime preflight remains a separate defense layer.
+
+### Code Snippet (Target)
+```ts
+const blocked = resolveRecordingBlockedMessage(settings, apiKeyStatus)
+if (blocked) {
+  // Block before any start side effects
+  return
+}
+
+await startRecordingFlow()
+await playSound('recording_started')
+```
+
+### PR Linkage
+- PR: `fix/issue-360-recording-preflight-all-entry-points`
+
+---
+
+## Ticket T360-2 (P1)
+### Goal
+Lock regressions with unit and integration tests across Home, native recording, and IPC shortcut seams.
+
+### Approach
+- Add matrix-style tests for preflight result permutations.
+- Add integration coverage where recording command dispatch arrives via `onRecordingCommand` IPC listener.
+- Verify both blocked and allowed paths for start/toggle commands and sound side effects.
+
+### Scope Files
+- `src/renderer/blocked-control.test.ts`
+- `src/renderer/home-react.test.tsx`
+- `src/renderer/native-recording.test.ts`
+- `src/renderer/renderer-app.test.ts`
+
+### Checklist
+- [ ] Matrix covers STT providers (`groq`, `elevenlabs`).
+- [ ] Matrix covers output source (`transcript`, `transformed`).
+- [ ] Matrix covers commands (`startRecording`, `toggleRecording`).
+- [ ] Blocked transformed+missing-google path asserts: no recording start, no sound.
+- [ ] Unblocked control cases assert recording and sound behavior still work.
+
+### Tasks (Chunked)
+1. Add unit matrix tests for `resolveRecordingBlockedMessage`.
+2. Add Home component assertion for transformed-output disable state.
+3. Add native recording tests for blocked no-start/no-sound.
+4. Add `renderer-app` integration test for IPC shortcut blocked-start parity.
+5. Run targeted renderer tests and stabilize assertions.
+
+### Gates
+- Gate A (Coverage): Required matrix scenarios are asserted.
+- Gate B (Integration): IPC shortcut blocked path is tested end-to-end in renderer layer.
+- Gate C (Quality):
+  - `pnpm test -- src/renderer/blocked-control.test.ts`
+  - `pnpm test -- src/renderer/home-react.test.tsx`
+  - `pnpm test -- src/renderer/native-recording.test.ts`
+  - `pnpm test -- src/renderer/renderer-app.test.ts`
+
+### Trade-offs
+- More test permutations increase maintenance cost slightly.
+- Integration test adds runtime, but closes the highest-risk seam.
+
+### Code Snippet (Test Matrix Sketch)
+```ts
+const cases = [
+  { provider: 'groq', source: 'transcript', stt: true, google: false, blocked: false },
+  { provider: 'groq', source: 'transformed', stt: true, google: false, blocked: true },
+  { provider: 'elevenlabs', source: 'transformed', stt: false, google: true, blocked: true }
+]
+```
+
+### PR Linkage
+- PR: `test/issue-360-recording-block-regression-coverage`
+
+---
+
+## Ticket T360-3 (P2)
+### Goal
+Document the architecture decision so future refactors preserve preflight UX consistency.
+
+### Approach
+- Add decision record describing why transformed output mode requires Google-key availability for recording start eligibility.
+- Document alternatives considered and why they were rejected.
+
+### Scope Files
+- `docs/decisions/issue-360-recording-gate-for-transformed-output.md` (new)
+
+### Checklist
+- [ ] Decision document captures problem, decision, alternatives, and consequences.
+- [ ] Trade-offs between strict pre-blocking and permissive fallback are explicit.
+- [ ] PR references issue and prior functional/test PRs.
+
+### Tasks (Chunked)
+1. Draft decision context and constraints.
+2. Capture selected approach and rejected alternatives.
+3. Note operational risks and mitigations.
+4. Link to tests/PRs that enforce the decision.
+
+### Gates
+- Gate A (Completeness): Decision record includes rationale + alternatives + consequences.
+- Gate B (Traceability): Decision doc links back to issue/PR/test artifacts.
+
+### Trade-offs
+- Documentation overhead is small but improves long-term consistency and reviewer onboarding.
+
+### Code Snippet (Decision Example)
+```md
+Decision: Gate recording start when selected output source cannot be produced.
+Reason: Prevent user confusion and inconsistent command-side behavior.
+```
+
+### PR Linkage
+- PR: `docs/issue-360-recording-gate-decision`
+
+---
+
+## Risks and Mitigations
+- Risk: UI blocked state and native command path drift over time.
+  - Mitigation: One shared preflight helper reused across both paths.
+- Risk: Stale API key status during shortcut-triggered start decision.
+  - Mitigation: Use latest `apiKeyStatus` snapshot and refresh when state changes materially.
+- Risk: Sound suppression accidentally mutes valid starts.
+  - Mitigation: Add positive-control tests for unblocked sound playback.
+
+## Feasibility Assessment
+- T360-1: Medium-high feasibility; limited files with one shared-guard refactor.
+- T360-2: High feasibility; mostly test implementation with existing harnesses.
+- T360-3: High feasibility; documentation-only.
+
+## Start Workflow (Execution Sequence)
+1. Implement T360-1 and open PR-1.
+2. After PR-1 merge, implement T360-2 and open PR-2.
+3. After PR-2 merge, complete T360-3 and open PR-3.
+4. Sync default branch after each merge before starting next ticket.

--- a/src/renderer/blocked-control.test.ts
+++ b/src/renderer/blocked-control.test.ts
@@ -4,13 +4,47 @@
 
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_SETTINGS } from '../shared/domain'
-import { resolveRecordingBlockedMessage, resolveTransformBlockedMessage } from './blocked-control'
+import {
+  isTransformedOutputRecordingBlocked,
+  resolveRecordingBlockedMessage,
+  resolveTransformBlockedMessage
+} from './blocked-control'
 
 describe('resolveRecordingBlockedMessage', () => {
-  it('returns null when the configured STT provider has a saved key', () => {
-    const result = resolveRecordingBlockedMessage(DEFAULT_SETTINGS, {
+  it.each([
+    { provider: 'groq' as const, status: { groq: false, elevenlabs: true, google: true } },
+    { provider: 'elevenlabs' as const, status: { groq: true, elevenlabs: false, google: true } }
+  ])('blocks when selected STT provider key is missing ($provider)', ({ provider, status }) => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transcription.provider = provider
+    settings.output.selectedTextSource = 'transcript'
+
+    const result = resolveRecordingBlockedMessage(settings, status)
+    expect(result).toEqual({
+      reason: 'Recording is blocked.',
+      nextStep: 'Open Settings > Speech-to-Text and save a key or switch provider.',
+      deepLinkTarget: 'settings'
+    })
+  })
+
+  it('returns null when STT key is present and transcript output is selected', () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.output.selectedTextSource = 'transcript'
+    const result = resolveRecordingBlockedMessage(settings, {
       groq: true,
       elevenlabs: false,
+      google: false
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for elevenlabs when elevenlabs key is present and transcript output is selected', () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transcription.provider = 'elevenlabs'
+    settings.output.selectedTextSource = 'transcript'
+    const result = resolveRecordingBlockedMessage(settings, {
+      groq: false,
+      elevenlabs: true,
       google: false
     })
     expect(result).toBeNull()
@@ -27,6 +61,62 @@ describe('resolveRecordingBlockedMessage', () => {
       nextStep: 'Open Settings > Speech-to-Text and save a key or switch provider.',
       deepLinkTarget: 'settings'
     })
+  })
+
+  it('returns transformed-output guidance when transformed output is selected and Google key is missing', () => {
+    const result = resolveRecordingBlockedMessage(DEFAULT_SETTINGS, {
+      groq: true,
+      elevenlabs: true,
+      google: false
+    })
+    expect(result).toEqual({
+      reason: 'Recording is blocked.',
+      nextStep: 'Open Settings > LLM Transformation and save a Google key, or switch output mode to Transcript.',
+      deepLinkTarget: 'settings'
+    })
+  })
+
+  it('prioritizes STT guidance when both STT and Google keys are missing', () => {
+    const result = resolveRecordingBlockedMessage(DEFAULT_SETTINGS, {
+      groq: false,
+      elevenlabs: true,
+      google: false
+    })
+    expect(result).toEqual({
+      reason: 'Recording is blocked.',
+      nextStep: 'Open Settings > Speech-to-Text and save a key or switch provider.',
+      deepLinkTarget: 'settings'
+    })
+  })
+})
+
+describe('isTransformedOutputRecordingBlocked', () => {
+  it('returns true only when transformed output is selected and Google key is missing', () => {
+    expect(
+      isTransformedOutputRecordingBlocked(DEFAULT_SETTINGS, {
+        groq: true,
+        elevenlabs: true,
+        google: false
+      })
+    ).toBe(true)
+
+    expect(
+      isTransformedOutputRecordingBlocked(DEFAULT_SETTINGS, {
+        groq: true,
+        elevenlabs: true,
+        google: true
+      })
+    ).toBe(false)
+
+    const transcriptSettings = structuredClone(DEFAULT_SETTINGS)
+    transcriptSettings.output.selectedTextSource = 'transcript'
+    expect(
+      isTransformedOutputRecordingBlocked(transcriptSettings, {
+        groq: true,
+        elevenlabs: true,
+        google: false
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/renderer/blocked-control.ts
+++ b/src/renderer/blocked-control.ts
@@ -11,26 +11,33 @@ export interface BlockedControlMessage {
   deepLinkTarget: 'settings' | null
 }
 
+export const isTransformedOutputRecordingBlocked = (
+  settings: Settings,
+  apiKeyStatus: ApiKeyStatusSnapshot
+): boolean => settings.output.selectedTextSource === 'transformed' && !apiKeyStatus.google
+
 export const resolveRecordingBlockedMessage = (
   settings: Settings,
   apiKeyStatus: ApiKeyStatusSnapshot
 ): BlockedControlMessage | null => {
   const provider = settings.transcription.provider
-  if (apiKeyStatus[provider]) {
-    return null
-  }
-  if (provider === 'groq') {
+  if (!apiKeyStatus[provider]) {
     return {
       reason: 'Recording is blocked.',
       nextStep: 'Open Settings > Speech-to-Text and save a key or switch provider.',
       deepLinkTarget: 'settings'
     }
   }
-  return {
-    reason: 'Recording is blocked.',
-    nextStep: 'Open Settings > Speech-to-Text and save a key or switch provider.',
-    deepLinkTarget: 'settings'
+
+  if (isTransformedOutputRecordingBlocked(settings, apiKeyStatus)) {
+    return {
+      reason: 'Recording is blocked.',
+      nextStep: 'Open Settings > LLM Transformation and save a Google key, or switch output mode to Transcript.',
+      deepLinkTarget: 'settings'
+    }
   }
+
+  return null
 }
 
 export const resolveTransformBlockedMessage = (

--- a/src/renderer/home-react.test.tsx
+++ b/src/renderer/home-react.test.tsx
@@ -208,4 +208,30 @@ describe('HomeReact recording button (STY-03)', () => {
     blockedOpenSettingsButton?.click()
     expect(onOpenSettings).toHaveBeenCalledTimes(1)
   })
+
+  it('disables recording button when transformed output is selected and Google key is missing', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    const settings: Settings = structuredClone(readySettings)
+    settings.output.selectedTextSource = 'transformed'
+
+    root.render(
+      <HomeReact
+        settings={settings}
+        apiKeyStatus={{ groq: true, elevenlabs: true, google: false }}
+        pendingActionId={null}
+        hasCommandError={false}
+        isRecording={false}
+        onRunRecordingCommand={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />
+    )
+    await flush()
+
+    const btn = host.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')
+    expect(btn?.disabled).toBe(true)
+    expect(host.textContent).toContain('Open Settings > LLM Transformation and save a Google key')
+  })
 })

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -38,6 +38,8 @@ const createDeps = (): { deps: NativeRecordingDeps; state: NativeRecordingDeps['
   return { deps, state }
 }
 
+let getUserMediaMock: ReturnType<typeof vi.fn>
+
 class FakeMediaRecorder {
   static isTypeSupported = vi.fn(() => false)
   mimeType = 'audio/webm'
@@ -64,6 +66,9 @@ describe('handleRecordingCommandDispatch', () => {
   beforeEach(() => {
     resetRecordingState()
     vi.clearAllMocks()
+    getUserMediaMock = vi.fn(async () => ({
+      getTracks: () => []
+    }))
     ;(window as Window & { speechToTextApi: any }).speechToTextApi = {
       playSound: vi.fn(),
       getHistory: vi.fn(),
@@ -75,9 +80,7 @@ describe('handleRecordingCommandDispatch', () => {
     })
     Object.defineProperty(navigator, 'mediaDevices', {
       value: {
-        getUserMedia: vi.fn(async () => ({
-          getTracks: () => []
-        }))
+        getUserMedia: getUserMediaMock
       },
       configurable: true
     })
@@ -116,6 +119,27 @@ describe('handleRecordingCommandDispatch', () => {
     expect(deps.onStateChange).toHaveBeenCalledOnce()
     expect(state.hasCommandError).toBe(false)
   })
+
+  it.each(['startRecording', 'toggleRecording'] as const)(
+    'does not start recording or play sounds when %s is blocked by transformed output without Google key',
+    async (command) => {
+      const { deps, state } = createDeps()
+      state.settings = structuredClone(DEFAULT_SETTINGS)
+      state.settings.output.selectedTextSource = 'transformed'
+      state.apiKeyStatus = { groq: true, elevenlabs: true, google: false }
+
+      await handleRecordingCommandDispatch(deps, { command })
+
+      expect(getUserMediaMock).not.toHaveBeenCalled()
+      expect(window.speechToTextApi.playSound).not.toHaveBeenCalled()
+      expect(deps.addActivity).toHaveBeenCalledWith(
+        `${command} failed: Missing Google API key. Add it in Settings > LLM Transformation, or switch output mode to Transcript.`,
+        'error'
+      )
+      expect(deps.onStateChange).toHaveBeenCalledOnce()
+      expect(state.hasCommandError).toBe(true)
+    }
+  )
 })
 
 describe('resolveSuccessfulRecordingMessage', () => {

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -11,6 +11,7 @@ import type { ApiKeyStatusSnapshot, AudioInputSource, RecordingCommandDispatch }
 import { SYSTEM_DEFAULT_AUDIO_SOURCE } from './app-shell-react'
 import type { ActivityItem } from './activity-feed'
 import { formatFailureFeedback } from './failure-feedback'
+import { isTransformedOutputRecordingBlocked } from './blocked-control'
 import { resolveRecordingDeviceFallbackWarning, resolveRecordingDeviceId } from './recording-device'
 import type { HistoryRecordSnapshot } from '../shared/ipc'
 
@@ -306,9 +307,6 @@ export const pollRecordingOutcome = async (
 
 export const startNativeRecording = async (deps: NativeRecordingDeps, preferredDeviceId?: string): Promise<void> => {
   const { state, addActivity, addToast } = deps
-  if (!navigator.mediaDevices?.getUserMedia) {
-    throw new Error('This environment does not support microphone recording.')
-  }
   if (isNativeRecording()) {
     throw new Error('Recording is already in progress.')
   }
@@ -322,6 +320,12 @@ export const startNativeRecording = async (deps: NativeRecordingDeps, preferredD
   if (!state.apiKeyStatus[provider]) {
     const providerLabel = provider === 'groq' ? 'Groq' : 'ElevenLabs'
     throw new Error(`Missing ${providerLabel} API key. Add it in Settings > Speech-to-Text.`)
+  }
+  if (isTransformedOutputRecordingBlocked(state.settings, state.apiKeyStatus)) {
+    throw new Error('Missing Google API key. Add it in Settings > LLM Transformation, or switch output mode to Transcript.')
+  }
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error('This environment does not support microphone recording.')
   }
 
   const selectedDeviceId = resolveRecordingDeviceId({

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -60,6 +60,8 @@ interface IpcHarness {
   api: IpcApi
   setApiKeyStatus: (status: { groq: boolean; elevenlabs: boolean; google: boolean }) => void
   emitCompositeTransformStatus: (result: CompositeTransformResult) => void
+  emitRecordingCommand: (dispatch: RecordingCommandDispatch) => void
+  playSoundSpy: ReturnType<typeof vi.fn>
   setSettingsSpy: ReturnType<typeof vi.fn>
   onRecordingCommandSpy: ReturnType<typeof vi.fn>
   onCompositeTransformStatusSpy: ReturnType<typeof vi.fn>
@@ -88,6 +90,7 @@ const buildIpcHarness = (): IpcHarness => {
   const onCompositeTransformStatusSpy = vi.fn((_listener: (result: CompositeTransformResult) => void) => () => {})
   const onHotkeyErrorSpy = vi.fn((_listener: (notification: HotkeyErrorNotification) => void) => () => {})
   const setSettingsSpy = vi.fn(async (settings: typeof DEFAULT_SETTINGS) => settings)
+  const playSoundSpy = vi.fn(async () => {})
 
   const api: IpcApi = {
     ping: async () => 'pong',
@@ -103,7 +106,7 @@ const buildIpcHarness = (): IpcHarness => {
     }),
     getHistory: async () => [],
     getAudioInputSources: async () => [],
-    playSound: async () => {},
+    playSound: playSoundSpy,
     runRecordingCommand: async (_command: RecordingCommand) => {},
     submitRecordedAudio: async () => {},
     onRecordingCommand: onRecordingCommandSpy,
@@ -130,6 +133,14 @@ const buildIpcHarness = (): IpcHarness => {
       }
       listener(result)
     },
+    emitRecordingCommand: (dispatch) => {
+      const listener = onRecordingCommandSpy.mock.calls[0]?.[0] as ((payload: RecordingCommandDispatch) => void) | undefined
+      if (!listener) {
+        throw new Error('Recording command listener is not registered.')
+      }
+      listener(dispatch)
+    },
+    playSoundSpy,
     setSettingsSpy,
     onRecordingCommandSpy,
     onCompositeTransformStatusSpy,
@@ -527,6 +538,36 @@ describe('renderer app', () => {
         )
     )
   })
+
+  it.each(['toggleRecording', 'startRecording'] as const)(
+    'blocks shortcut-triggered %s in transformed mode without Google key and does not play sound',
+    async (command) => {
+      const mountPoint = document.createElement('div')
+      mountPoint.id = 'app'
+      document.body.append(mountPoint)
+
+      const harness = buildIpcHarness()
+      harness.setApiKeyStatus({
+        groq: true,
+        elevenlabs: true,
+        google: false
+      })
+      vi.stubGlobal('speechToTextApi', harness.api)
+      window.speechToTextApi = harness.api
+
+      startRendererApp(mountPoint)
+      await waitForBoot()
+
+      harness.emitRecordingCommand({ command })
+      await waitForCondition(
+        'google-key blocked recording failure appears',
+        () => (mountPoint.textContent ?? '').includes('Missing Google API key.')
+      )
+
+      expect(mountPoint.textContent ?? '').not.toContain('This environment does not support microphone recording.')
+      expect(harness.playSoundSpy).not.toHaveBeenCalled()
+    }
+  )
 
   it('does not append non-terminal transform enqueue messages to activity and appends terminal failure only', async () => {
     const mountPoint = document.createElement('div')


### PR DESCRIPTION
## Summary
- fix recording availability gating when output source is `transformed` and Google API key is missing
- apply the same preflight behavior across Home UI and shortcut/native recording command path
- ensure blocked shortcut attempts do not play recording sounds
- add regression tests for provider/output/command coverage
- add issue decision record and execution plan docs

Closes #360

## Changes
- `src/renderer/blocked-control.ts`
  - added transformed-output block condition helper
  - updated recording blocked resolution to require Google key when transformed output is selected
- `src/renderer/native-recording.ts`
  - added transformed-output preflight check in start path
  - check runs before environment/start side effects, preventing blocked starts and sounds
- test updates:
  - `src/renderer/blocked-control.test.ts`
  - `src/renderer/home-react.test.tsx`
  - `src/renderer/native-recording.test.ts`
  - `src/renderer/renderer-app.test.ts`
- docs:
  - `docs/decisions/issue-360-recording-gate-for-transformed-output.md`
  - `docs/plans/issue-360-execution-plan.md`

## Verification
- `pnpm test -- src/renderer/blocked-control.test.ts src/renderer/home-react.test.tsx src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts`
- result: pass
