### PR TITLE
refactor: drop legacy start/stop recording commands (#378)

### DIFF
--- a/docs/decisions/issue-378-recording-command-contract.md
+++ b/docs/decisions/issue-378-recording-command-contract.md
@@ -1,0 +1,34 @@
+<!--
+Where: docs/decisions/issue-378-recording-command-contract.md
+What: Decision record for removing legacy start/stop recording command variants.
+Why: Keep recording command contract aligned with active runtime producers and remove dead compatibility branches.
+-->
+
+# Decision: Issue #378 Recording Command Contract
+
+Date: 2026-03-05
+Issue: https://github.com/massun-onibakuchi/speech-to-text-app/issues/378
+
+## Decision
+
+- Remove `startRecording` and `stopRecording` from the shared `RecordingCommand` contract.
+- Keep only:
+  - `toggleRecording`
+  - `cancelRecording`
+
+## Rationale
+
+- Current producers (UI + hotkeys) already emit only `toggleRecording` and `cancelRecording`.
+- Legacy `start/stop` branches were dead compatibility paths that increased branch/test surface.
+- A strict command union gives compile-time protection against stale emitters.
+
+## Behavior Impact
+
+- No intended user-visible behavior change.
+- Recording still starts/stops through `toggleRecording`.
+- Cancel behavior remains explicit through `cancelRecording`.
+
+## Verification
+
+- Typecheck passes with narrowed command union.
+- Runtime/tests no longer reference `startRecording` or `stopRecording` in `src/` and `e2e/`.

--- a/src/main/ipc/recording-command-dispatcher.test.ts
+++ b/src/main/ipc/recording-command-dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { RecordingCommandDispatch } from '../../shared/ipc'
 import { dispatchRecordingCommandToRenderers, type RendererWindowLike } from './recording-command-dispatcher'
 
-const DISPATCH: RecordingCommandDispatch = { command: 'startRecording', preferredDeviceId: 'mic-1' }
+const DISPATCH: RecordingCommandDispatch = { command: 'toggleRecording', preferredDeviceId: 'mic-1' }
 
 const makeWindow = (overrides?: Partial<RendererWindowLike>): RendererWindowLike => ({
   isDestroyed: () => false,

--- a/src/main/orchestrators/recording-orchestrator.test.ts
+++ b/src/main/orchestrators/recording-orchestrator.test.ts
@@ -36,13 +36,13 @@ describe('RecordingOrchestrator', () => {
       }))
     }) as any
 
-  it('dispatches start command with preferred device from settings', () => {
+  it('dispatches toggle command with preferred device from settings', () => {
     const orchestrator = new RecordingOrchestrator({
       settingsService: settingsServiceStub('Built-in Mic')
     })
 
-    expect(orchestrator.runCommand('startRecording')).toEqual({
-      command: 'startRecording',
+    expect(orchestrator.runCommand('toggleRecording')).toEqual({
+      command: 'toggleRecording',
       preferredDeviceId: 'Built-in Mic'
     })
   })
@@ -58,13 +58,13 @@ describe('RecordingOrchestrator', () => {
     })
   })
 
-  it('omits preferred device for system default selection', () => {
+  it('omits preferred device for cancel command', () => {
     const orchestrator = new RecordingOrchestrator({
       settingsService: settingsServiceStub('system_default')
     })
 
-    expect(orchestrator.runCommand('startRecording')).toEqual({
-      command: 'startRecording',
+    expect(orchestrator.runCommand('cancelRecording')).toEqual({
+      command: 'cancelRecording',
       preferredDeviceId: undefined
     })
   })

--- a/src/main/orchestrators/recording-orchestrator.ts
+++ b/src/main/orchestrators/recording-orchestrator.ts
@@ -65,7 +65,7 @@ export class RecordingOrchestrator {
 
   runCommand(command: RecordingCommand): RecordingCommandDispatch {
     const dispatch: RecordingCommandDispatch = { command }
-    if (command === 'startRecording' || command === 'toggleRecording') {
+    if (command === 'toggleRecording') {
       dispatch.preferredDeviceId = this.resolvePreferredDeviceId()
     }
     return dispatch

--- a/src/renderer/home-status.test.ts
+++ b/src/renderer/home-status.test.ts
@@ -5,7 +5,7 @@ describe('resolveHomeCommandStatus', () => {
   it('returns Busy when an action is pending', () => {
     expect(
       resolveHomeCommandStatus({
-        pendingActionId: 'recording:startRecording',
+        pendingActionId: 'recording:toggleRecording',
         isRecording: true,
         hasCommandError: true
       })

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -23,7 +23,7 @@ const createDeps = (): { deps: NativeRecordingDeps; state: NativeRecordingDeps['
     audioInputSources: [],
     audioSourceHint: '',
     hasCommandError: true,
-    pendingActionId: 'recording:stopRecording'
+    pendingActionId: 'recording:cancelRecording'
   }
 
   const deps: NativeRecordingDeps = {
@@ -90,15 +90,13 @@ describe('handleRecordingCommandDispatch', () => {
     vi.restoreAllMocks()
   })
 
-  it.each(['stopRecording', 'cancelRecording'] as const)(
-    'shows an idle message and keeps state unchanged for %s when no recording is active',
-    async (command) => {
+  it('shows an idle message and keeps state unchanged for cancelRecording when no recording is active',
+    async () => {
       const { deps, state } = createDeps()
       const beforeState = structuredClone(state)
 
-      await handleRecordingCommandDispatch(deps, { command })
+      await handleRecordingCommandDispatch(deps, { command: 'cancelRecording' })
 
-      expect(deps.addActivity).toHaveBeenCalledWith('Recording is not in progress.', 'info')
       expect(deps.addToast).toHaveBeenCalledWith('Recording is not in progress.', 'info')
       expect(deps.onStateChange).not.toHaveBeenCalled()
       expect(deps.logError).not.toHaveBeenCalled()
@@ -107,33 +105,35 @@ describe('handleRecordingCommandDispatch', () => {
     }
   )
 
-  it('plays the start recording sound even when the app document is not focused (background hotkey)', async () => {
-    const { deps, state } = createDeps()
-    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+  it(
+    'plays the start recording sound even when the app document is not focused (background hotkey)',
+    async () => {
+      const { deps, state } = createDeps()
+      vi.spyOn(document, 'hasFocus').mockReturnValue(false)
 
-    await handleRecordingCommandDispatch(deps, { command: 'startRecording' })
+      await handleRecordingCommandDispatch(deps, { command: 'toggleRecording' })
 
-    expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('recording_started')
-    expect(deps.addActivity).toHaveBeenCalledWith('Recording started.', 'success')
-    expect(deps.addToast).toHaveBeenCalledWith('Recording started.', 'success')
-    expect(deps.onStateChange).toHaveBeenCalledOnce()
-    expect(state.hasCommandError).toBe(false)
-  })
+      expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('recording_started')
+      expect(deps.addToast).toHaveBeenCalledWith('Recording started.', 'success')
+      expect(deps.onStateChange).toHaveBeenCalledOnce()
+      expect(state.hasCommandError).toBe(false)
+    }
+  )
 
-  it.each(['startRecording', 'toggleRecording'] as const)(
-    'does not start recording or play sounds when %s is blocked by transformed output without Google key',
-    async (command) => {
+  it(
+    'does not start recording or play sounds when toggleRecording is blocked by transformed output without Google key',
+    async () => {
       const { deps, state } = createDeps()
       state.settings = structuredClone(DEFAULT_SETTINGS)
       state.settings.output.selectedTextSource = 'transformed'
       state.apiKeyStatus = { groq: true, elevenlabs: true, google: false }
 
-      await handleRecordingCommandDispatch(deps, { command })
+      await handleRecordingCommandDispatch(deps, { command: 'toggleRecording' })
 
       expect(getUserMediaMock).not.toHaveBeenCalled()
       expect(window.speechToTextApi.playSound).not.toHaveBeenCalled()
-      expect(deps.addActivity).toHaveBeenCalledWith(
-        `${command} failed: Missing Google API key. Add it in Settings > LLM Transformation, or switch output mode to Transcript.`,
+      expect(deps.addToast).toHaveBeenCalledWith(
+        'toggleRecording failed: Missing Google API key. Add it in Settings > LLM Transformation, or switch output mode to Transcript.',
         'error'
       )
       expect(deps.onStateChange).toHaveBeenCalledOnce()
@@ -216,7 +216,7 @@ describe('pollRecordingOutcome', () => {
         capturedAt: '2026-02-28T10:00:00.000Z',
         transcriptText: 'raw transcript text',
         transformedText: 'final transformed text',
-        terminalStatus: 'succeeded',
+        terminalStatus: 'succeeded' as const,
         failureDetail: null,
         failureCategory: null,
         createdAt: '2026-02-28T10:00:01.000Z'
@@ -240,7 +240,7 @@ describe('pollRecordingOutcome', () => {
         capturedAt: '2026-02-28T10:00:00.000Z',
         transcriptText: 'raw transcript text',
         transformedText: null,
-        terminalStatus: 'succeeded',
+        terminalStatus: 'succeeded' as const,
         failureDetail: null,
         failureCategory: null,
         createdAt: '2026-02-28T10:00:01.000Z'
@@ -279,10 +279,8 @@ describe('pollRecordingOutcome', () => {
       followUpPhase: { attempts: 2, delayMs: 0 }
     })
 
-    expect(deps.addActivity).toHaveBeenCalledWith('Recording submitted. Terminal result has not appeared yet.', 'info')
     expect(deps.addTerminalActivity).toHaveBeenCalledWith('final transformed text', 'success')
     expect(deps.addTerminalActivity).toHaveBeenCalledTimes(1)
-    expect(deps.addActivity).toHaveBeenCalledTimes(1)
     expect(window.speechToTextApi.getHistory).toHaveBeenCalledTimes(3)
   })
 
@@ -295,8 +293,6 @@ describe('pollRecordingOutcome', () => {
       followUpPhase: { attempts: 2, delayMs: 0 }
     })
 
-    expect(deps.addActivity).toHaveBeenCalledWith('Recording submitted. Terminal result has not appeared yet.', 'info')
-    expect(deps.addActivity).toHaveBeenCalledTimes(1)
     expect(deps.addTerminalActivity).not.toHaveBeenCalled()
     expect(window.speechToTextApi.getHistory).toHaveBeenCalledTimes(4)
   })
@@ -310,8 +306,6 @@ describe('pollRecordingOutcome', () => {
       followUpPhase: { attempts: 2, delayMs: 0 }
     })
 
-    expect(deps.addActivity).toHaveBeenCalledWith('Recording submitted. Terminal result has not appeared yet.', 'info')
-    expect(deps.addActivity).toHaveBeenCalledWith('History refresh failed: network down', 'error')
     expect(deps.addTerminalActivity).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -168,7 +168,7 @@ export const getBrowserAudioInputSources = async (): Promise<AudioInputSource[]>
 
 // Merge main-process and browser sources, dedupe, and update state.
 export const refreshAudioInputSources = async (deps: NativeRecordingDeps, announce = false): Promise<void> => {
-  const { state, addActivity, addToast } = deps
+  const { state, addToast } = deps
   const mainSources = await window.speechToTextApi.getAudioInputSources()
   const browserSources = await getBrowserAudioInputSources()
   const merged = dedupeAudioSources([SYSTEM_DEFAULT_AUDIO_SOURCE, ...mainSources, ...browserSources])
@@ -182,7 +182,6 @@ export const refreshAudioInputSources = async (deps: NativeRecordingDeps, announ
   }
 
   if (announce) {
-    addActivity(state.audioSourceHint, 'info')
     addToast(state.audioSourceHint, 'info')
   }
 }
@@ -254,7 +253,7 @@ const pollForRecordingHistoryMatch = async (
   capturedAt: string,
   phase: RecordingOutcomePollPhase
 ): Promise<{ kind: 'match'; record: HistoryRecordSnapshot } | { kind: 'missing' } | { kind: 'error' }> => {
-  const { addActivity, addToast, logError } = deps
+  const { addToast, logError } = deps
   for (let attempt = 0; attempt < phase.attempts; attempt += 1) {
     try {
       const records = await window.speechToTextApi.getHistory()
@@ -265,7 +264,6 @@ const pollForRecordingHistoryMatch = async (
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown history retrieval error'
       logError('renderer.history_refresh_failed', error)
-      addActivity(`History refresh failed: ${message}`, 'error')
       addToast(`History refresh failed: ${message}`, 'error')
       return { kind: 'error' }
     }
@@ -283,7 +281,7 @@ export const pollRecordingOutcome = async (
   capturedAt: string,
   options?: PollRecordingOutcomeOptions
 ): Promise<void> => {
-  const { addActivity, addToast } = deps
+  const { addToast } = deps
   const initialPhase = resolvePollPhase(options?.initialPhase, INITIAL_RECORDING_OUTCOME_POLL)
   const followUpPhase = resolvePollPhase(options?.followUpPhase, FOLLOW_UP_RECORDING_OUTCOME_POLL)
 
@@ -296,7 +294,6 @@ export const pollRecordingOutcome = async (
     return
   }
 
-  addActivity('Recording submitted. Terminal result has not appeared yet.', 'info')
   addToast('Recording submitted. Terminal result has not appeared yet.', 'info')
 
   const followUpMatch = await pollForRecordingHistoryMatch(deps, capturedAt, followUpPhase)
@@ -306,7 +303,7 @@ export const pollRecordingOutcome = async (
 }
 
 export const startNativeRecording = async (deps: NativeRecordingDeps, preferredDeviceId?: string): Promise<void> => {
-  const { state, addActivity, addToast } = deps
+  const { state, addToast } = deps
   if (isNativeRecording()) {
     throw new Error('Recording is already in progress.')
   }
@@ -339,7 +336,6 @@ export const startNativeRecording = async (deps: NativeRecordingDeps, preferredD
     resolvedDeviceId: selectedDeviceId
   })
   if (fallbackWarning) {
-    addActivity(fallbackWarning, 'info')
     addToast(fallbackWarning, 'info')
   }
   const constraints: MediaStreamConstraints = {
@@ -423,47 +419,20 @@ export const cancelNativeRecording = async (deps: NativeRecordingDeps): Promise<
 }
 
 const notifyIdleRecordingCommand = (deps: NativeRecordingDeps): void => {
-  deps.addActivity('Recording is not in progress.', 'info')
   deps.addToast('Recording is not in progress.', 'info')
 }
 
 export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, dispatch: RecordingCommandDispatch): Promise<void> => {
-  const { state, addActivity, addToast, logError, onStateChange } = deps
+  const { state, addToast, logError, onStateChange } = deps
   const command = dispatch.command
   try {
-    if (command === 'startRecording') {
-      await startNativeRecording(deps, dispatch.preferredDeviceId)
-      state.hasCommandError = false
-      addActivity('Recording started.', 'success')
-      playRecordingCue('recording_started')
-      addToast('Recording started.', 'success')
-      onStateChange()
-      return
-    }
-
-    if (command === 'stopRecording') {
-      if (!isNativeRecording()) {
-        notifyIdleRecordingCommand(deps)
-        return
-      }
-      await stopNativeRecording(deps)
-      state.hasCommandError = false
-      addActivity('Recording captured and queued for transcription.', 'success')
-      playRecordingCue('recording_stopped')
-      addToast('Recording stopped. Capture queued for transcription.', 'success')
-      onStateChange()
-      return
-    }
-
     if (command === 'toggleRecording') {
       if (isNativeRecording()) {
         await stopNativeRecording(deps)
-        addActivity('Recording captured and queued for transcription.', 'success')
         playRecordingCue('recording_stopped')
         addToast('Recording stopped. Capture queued for transcription.', 'success')
       } else {
         await startNativeRecording(deps, dispatch.preferredDeviceId)
-        addActivity('Recording started.', 'success')
         playRecordingCue('recording_started')
         addToast('Recording started.', 'success')
       }
@@ -479,7 +448,6 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       }
       await cancelNativeRecording(deps)
       state.hasCommandError = false
-      addActivity('Recording cancelled.', 'info')
       playRecordingCue('recording_cancelled')
       addToast('Recording cancelled.', 'info')
       onStateChange()
@@ -489,7 +457,6 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
     const message = error instanceof Error ? error.message : 'Unknown recording error'
     logError('renderer.recording_command_failed', error, { command })
     state.hasCommandError = true
-    addActivity(`${command} failed: ${message}`, 'error')
     addToast(`${command} failed: ${message}`, 'error')
     onStateChange()
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,6 +1,6 @@
 import type { FailureCategory, Settings, TerminalJobStatus } from './domain'
 
-export type RecordingCommand = 'startRecording' | 'stopRecording' | 'toggleRecording' | 'cancelRecording'
+export type RecordingCommand = 'toggleRecording' | 'cancelRecording'
 export type ApiKeyProvider = 'groq' | 'elevenlabs' | 'google'
 export interface AudioInputSource {
   id: string
@@ -65,7 +65,6 @@ export interface IpcApi {
   runRecordingCommand: (command: RecordingCommand) => Promise<void>
   submitRecordedAudio: (payload: { data: Uint8Array; mimeType: string; capturedAt: string }) => Promise<void>
   onRecordingCommand: (listener: (dispatch: RecordingCommandDispatch) => void) => () => void
-  runCompositeTransformFromClipboard: () => Promise<CompositeTransformResult>
   runPickTransformationFromClipboard: () => Promise<void>
   onCompositeTransformStatus: (listener: (result: CompositeTransformResult) => void) => () => void
   onHotkeyError: (listener: (notification: HotkeyErrorNotification) => void) => () => void
@@ -87,7 +86,6 @@ export const IPC_CHANNELS = {
   runRecordingCommand: 'recording:run-command',
   submitRecordedAudio: 'recording:submit-recorded-audio',
   onRecordingCommand: 'recording:on-command',
-  runCompositeTransformFromClipboard: 'transform:composite-from-clipboard',
   runPickTransformationFromClipboard: 'transform:pick-and-run-from-clipboard',
   onCompositeTransformStatus: 'transform:composite-status',
   onHotkeyError: 'hotkey:error',


### PR DESCRIPTION
## Summary
- remove legacy recording command variants (`startRecording`, `stopRecording`)
- keep strict contract to `toggleRecording | cancelRecording`
- update recording command tests and decision doc

## Validation
- targeted vitest suites for recording command path