### PR TITLE
feat: play sound on shortcut default profile change

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -210,7 +210,13 @@ The app **MUST** play notification sounds for:
 - Recording cancelled.
 - Successful capture completion.
 - Transformation failure when transformation was attempted and failed.
+- Successful `changeTransformationDefault` shortcut updates (default preset id actually changed).
 - Successful capture completion **MUST** play the completion success sound exactly once regardless of `output.selectedTextSource` (`transcript` or `transformed`).
+
+`changeTransformationDefault` sound semantics:
+- The app **MUST** play `skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3` only when shortcut-driven default profile change is committed.
+- The app **MUST NOT** play that sound when picker selection is cancelled or keeps the same default profile.
+- Direct default profile changes from renderer window controls **MUST NOT** play that sound.
 
 Additional notes:
 - Distinct tones **SHOULD** be used for success vs failure.
@@ -930,4 +936,3 @@ To keep non-blocking behavior consistent with section 4.5, future streaming mode
 - expose per-segment status in activity/toast UI.
 - keep recording command handling responsive while segment transforms are in flight.
 - keep per-segment commit idempotent to tolerate retries/reconnects.
-

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -224,8 +224,10 @@ Steps:
 2. If exactly two presets exist, app toggles default to the other preset directly (no picker window).
 3. If three or more presets exist, app opens preset selection UI (dedicated picker window in main process) and waits for a selection.
 4. App sets `settings.transformation.defaultPresetId` to the resolved next preset id.
-5. No transformation request is enqueued during this action.
-6. Later `runTransform` requests use the updated default preset.
+5. If the default preset actually changed, app plays `skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3`.
+6. If picker selection is canceled or does not change the default preset, no sound plays.
+7. No transformation request is enqueued during this action.
+8. Later `runTransform` requests use the updated default preset.
 
 ---
 

--- a/src/main/infrastructure/sound-asset-paths.test.ts
+++ b/src/main/infrastructure/sound-asset-paths.test.ts
@@ -41,7 +41,8 @@ describe('SOUND_ASSET_PATHS', () => {
     recordingStopped: 'sound_ex_machina_Button_Blip.mp3',
     recordingCancelled: 'zapsplat_multimedia_click_button_short_sharp_73510.mp3',
     transformationSucceeded: 'zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3',
-    transformationFailed: 'zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3'
+    transformationFailed: 'zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3',
+    defaultProfileChanged: 'skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3'
   }
 
   it('maps each event to the expected file name', () => {

--- a/src/main/infrastructure/sound-asset-paths.ts
+++ b/src/main/infrastructure/sound-asset-paths.ts
@@ -42,6 +42,7 @@ const soundsDir = (): string =>
  *   recording_cancelled     → zapsplat_multimedia_click_button_short_sharp_73510.mp3
  *   transformation_succeeded→ zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3
  *   transformation_failed   → zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3
+ *   default_profile_changed → skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3
  */
 export const SOUND_ASSET_PATHS = {
   get recordingStarted() {
@@ -58,5 +59,8 @@ export const SOUND_ASSET_PATHS = {
   },
   get transformationFailed() {
     return join(soundsDir(), 'zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3')
+  },
+  get defaultProfileChanged() {
+    return join(soundsDir(), 'skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3')
   }
 } as const

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -79,7 +79,8 @@ const initializeServices = (): MainServices => {
       recording_stopped: SOUND_ASSET_PATHS.recordingStopped,
       recording_cancelled: SOUND_ASSET_PATHS.recordingCancelled,
       transformation_succeeded: SOUND_ASSET_PATHS.transformationSucceeded,
-      transformation_failed: SOUND_ASSET_PATHS.transformationFailed
+      transformation_failed: SOUND_ASSET_PATHS.transformationFailed,
+      default_profile_changed: SOUND_ASSET_PATHS.defaultProfileChanged
     })
     const clipboardClient = new ClipboardClient()
     const selectionClient = new SelectionClient({ clipboard: clipboardClient })
@@ -137,6 +138,7 @@ const initializeServices = (): MainServices => {
       readSelectionText: () => selectionClient.readSelection(),
       onCompositeResult: broadcastCompositeTransformStatus,
       onSettingsUpdated: broadcastSettingsUpdated,
+      onDefaultProfileChanged: () => soundService.play('default_profile_changed'),
       onShortcutError: (payload) => {
         const notification: HotkeyErrorNotification = {
           combo: payload.combo,

--- a/src/main/services/hotkey-service.test.ts
+++ b/src/main/services/hotkey-service.test.ts
@@ -68,7 +68,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -95,7 +94,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister, unregisterAll },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -128,7 +126,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister, unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -167,7 +164,6 @@ describe('HotkeyService', () => {
     const setSettings = vi.fn()
     const onSettingsUpdated = vi.fn()
     const runCompositeFromClipboardWithPreset = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
-    const runCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
     const pickProfile = vi.fn(async () => 'b')
     const settings = makeSettings()
 
@@ -175,7 +171,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard,
         runCompositeFromClipboardWithPreset,
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -203,7 +198,6 @@ describe('HotkeyService', () => {
     )
     // The picked preset id is passed directly to the router for this request only.
     expect(runCompositeFromClipboardWithPreset).toHaveBeenCalledWith('b')
-    expect(runCompositeFromClipboard).not.toHaveBeenCalled()
     expect(onSettingsUpdated).toHaveBeenCalledTimes(1)
   })
 
@@ -222,7 +216,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -246,14 +239,12 @@ describe('HotkeyService', () => {
       return true
     })
     const setSettings = vi.fn()
-    const runCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
     const runCompositeFromClipboardWithPreset = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
 
     const service = new HotkeyService({
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings },
       commandRouter: {
-        runCompositeFromClipboard,
         runCompositeFromClipboardWithPreset,
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -268,7 +259,6 @@ describe('HotkeyService', () => {
     await Promise.resolve()
 
     expect(setSettings).not.toHaveBeenCalled()
-    expect(runCompositeFromClipboard).not.toHaveBeenCalled()
     expect(runCompositeFromClipboardWithPreset).not.toHaveBeenCalled()
   })
 
@@ -290,7 +280,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset,
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -331,7 +320,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -359,17 +347,16 @@ describe('HotkeyService', () => {
     const settings = makeSettings()
     settings.transformation.defaultPresetId = 'a'
     settings.transformation.lastPickedPresetId = 'a'
-    const runCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
     const runDefaultCompositeFromClipboard = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
     const runCompositeFromSelection = vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
     const onCompositeResult = vi.fn()
     const onSettingsUpdated = vi.fn()
+    const onDefaultProfileChanged = vi.fn()
 
     const service = new HotkeyService({
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard,
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard,
         runCompositeFromSelection
@@ -378,7 +365,8 @@ describe('HotkeyService', () => {
       pickProfile: vi.fn(async () => 'b'),
       readSelectionText: vi.fn(async () => 'selected'),
       onCompositeResult,
-      onSettingsUpdated
+      onSettingsUpdated,
+      onDefaultProfileChanged
     })
 
     service.registerFromSettings()
@@ -404,7 +392,6 @@ describe('HotkeyService', () => {
         })
       })
     )
-    expect(runCompositeFromClipboard).not.toHaveBeenCalled()
     expect(runCompositeFromSelection).not.toHaveBeenCalled()
     expect(runDefaultCompositeFromClipboard).not.toHaveBeenCalled()
     expect(onCompositeResult).toHaveBeenCalledWith(
@@ -419,6 +406,7 @@ describe('HotkeyService', () => {
       })
     )
     expect(onSettingsUpdated).toHaveBeenCalledTimes(1)
+    expect(onDefaultProfileChanged).toHaveBeenCalledTimes(1)
   })
 
   it('change-default opens picker for 3+ profiles and updates default only', async () => {
@@ -440,12 +428,12 @@ describe('HotkeyService', () => {
     const pickProfile = vi.fn(async () => 'c')
     const onCompositeResult = vi.fn()
     const onSettingsUpdated = vi.fn()
+    const onDefaultProfileChanged = vi.fn()
 
     const service = new HotkeyService({
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -454,7 +442,8 @@ describe('HotkeyService', () => {
       pickProfile,
       readSelectionText: vi.fn(async () => 'selected'),
       onCompositeResult,
-      onSettingsUpdated
+      onSettingsUpdated,
+      onDefaultProfileChanged
     })
 
     service.registerFromSettings()
@@ -482,6 +471,7 @@ describe('HotkeyService', () => {
       })
     )
     expect(onSettingsUpdated).toHaveBeenCalledTimes(1)
+    expect(onDefaultProfileChanged).toHaveBeenCalledTimes(1)
   })
 
   it('change-default does not persist or broadcast when picker selects current default', async () => {
@@ -503,12 +493,12 @@ describe('HotkeyService', () => {
     const pickProfile = vi.fn(async () => 'b')
     const onCompositeResult = vi.fn()
     const onSettingsUpdated = vi.fn()
+    const onDefaultProfileChanged = vi.fn()
 
     const service = new HotkeyService({
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -517,7 +507,8 @@ describe('HotkeyService', () => {
       pickProfile,
       readSelectionText: vi.fn(async () => 'selected'),
       onCompositeResult,
-      onSettingsUpdated
+      onSettingsUpdated,
+      onDefaultProfileChanged
     })
 
     service.registerFromSettings()
@@ -527,12 +518,59 @@ describe('HotkeyService', () => {
     expect(pickProfile).toHaveBeenCalledWith(settings.transformation.presets, 'b')
     expect(setSettings).not.toHaveBeenCalled()
     expect(onSettingsUpdated).not.toHaveBeenCalled()
+    expect(onDefaultProfileChanged).not.toHaveBeenCalled()
     expect(onCompositeResult).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'ok',
         message: expect.stringContaining('already')
       })
     )
+  })
+
+  it('change-default does not persist, broadcast, or play sound when picker is cancelled', async () => {
+    const callbacksByAccelerator = new Map<string, () => void>()
+    const register = vi.fn((_acc: string, callback: () => void) => {
+      callbacksByAccelerator.set(_acc, callback)
+      return true
+    })
+
+    const setSettings = vi.fn()
+    const settings = makeSettings()
+    settings.transformation.defaultPresetId = 'b'
+    settings.transformation.lastPickedPresetId = 'a'
+    settings.transformation.presets = [
+      { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'a', name: 'A' },
+      { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'b', name: 'B' },
+      { ...DEFAULT_SETTINGS.transformation.presets[0], id: 'c', name: 'C' }
+    ]
+    const onCompositeResult = vi.fn()
+    const onSettingsUpdated = vi.fn()
+    const onDefaultProfileChanged = vi.fn()
+
+    const service = new HotkeyService({
+      globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
+      settingsService: { getSettings: () => settings, setSettings },
+      commandRouter: {
+        runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
+        runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
+        runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
+      },
+      runRecordingCommand: vi.fn(async () => undefined),
+      pickProfile: vi.fn(async () => null),
+      readSelectionText: vi.fn(async () => 'selected'),
+      onCompositeResult,
+      onSettingsUpdated,
+      onDefaultProfileChanged
+    })
+
+    service.registerFromSettings()
+    getRegisteredCallback(callbacksByAccelerator, DEFAULT_ACCELERATORS.changeTransformationDefault)()
+    await Promise.resolve()
+
+    expect(setSettings).not.toHaveBeenCalled()
+    expect(onSettingsUpdated).not.toHaveBeenCalled()
+    expect(onDefaultProfileChanged).not.toHaveBeenCalled()
+    expect(onCompositeResult).not.toHaveBeenCalled()
   })
 
   it('change-default reports actionable error when no preset is available', async () => {
@@ -554,7 +592,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -596,7 +633,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -627,7 +663,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => settings, setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -655,7 +690,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -695,7 +729,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -722,7 +755,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -757,7 +789,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard,
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'x' }))
@@ -787,7 +818,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection
@@ -824,7 +854,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection
@@ -860,7 +889,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection
@@ -896,7 +924,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection
@@ -937,7 +964,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection
@@ -977,7 +1003,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection: vi.fn(async () => ({ status: 'ok' as const, message: 'enqueued' }))
@@ -1012,7 +1037,6 @@ describe('HotkeyService', () => {
       globalShortcut: { register, unregister: vi.fn(), unregisterAll: vi.fn() },
       settingsService: { getSettings: () => makeSettings(), setSettings: vi.fn() },
       commandRouter: {
-        runCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromClipboardWithPreset: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runDefaultCompositeFromClipboard: vi.fn(async () => ({ status: 'ok' as const, message: 'x' })),
         runCompositeFromSelection

--- a/src/main/services/hotkey-service.ts
+++ b/src/main/services/hotkey-service.ts
@@ -48,15 +48,13 @@ interface HotkeyDependencies {
   onCompositeResult?: (result: CompositeTransformResult) => void
   onShortcutError?: (payload: { combo: string; accelerator: string; message: string }) => void
   onSettingsUpdated?: () => void
+  onDefaultProfileChanged?: () => void
 }
 
 type HotkeyCommandRouter = Pick<
   CommandRouter,
   'runCompositeFromClipboardWithPreset' | 'runDefaultCompositeFromClipboard' | 'runCompositeFromSelection'
-> & {
-  // Legacy test fixture compatibility only; not used by runtime dispatch.
-  runCompositeFromClipboard?: () => Promise<CompositeTransformResult>
-}
+>
 
 const toElectronAccelerator = (combo: string): string | null => {
   const parts = combo
@@ -114,6 +112,7 @@ export class HotkeyService {
   private readonly onCompositeResult?: (result: CompositeTransformResult) => void
   private readonly onShortcutError?: (payload: { combo: string; accelerator: string; message: string }) => void
   private readonly onSettingsUpdated?: () => void
+  private readonly onDefaultProfileChanged?: () => void
   private readonly registeredShortcuts = new Map<ShortcutAction, RegisteredShortcut>()
   private pickAndRunInFlight = false
   private selectionTransformInFlight = false
@@ -128,6 +127,7 @@ export class HotkeyService {
     this.onCompositeResult = dependencies.onCompositeResult
     this.onShortcutError = dependencies.onShortcutError
     this.onSettingsUpdated = dependencies.onSettingsUpdated
+    this.onDefaultProfileChanged = dependencies.onDefaultProfileChanged
   }
 
   private setSettingsAndBroadcast(nextSettings: Settings): void {
@@ -322,6 +322,7 @@ export class HotkeyService {
     }
 
     this.setSettingsAndBroadcast(nextSettings)
+    this.onDefaultProfileChanged?.()
     this.onCompositeResult?.({
       status: 'ok',
       message: `Default transformation profile changed to "${nextDefaultPreset.name}".`

--- a/src/main/services/sound-service-afplay.test.ts
+++ b/src/main/services/sound-service-afplay.test.ts
@@ -29,7 +29,8 @@ const STUB_PATHS: Record<SoundEvent, string> = {
   recording_stopped: '/stub/sounds/recording_stopped.mp3',
   recording_cancelled: '/stub/sounds/recording_cancelled.mp3',
   transformation_succeeded: '/stub/sounds/transformation_succeeded.mp3',
-  transformation_failed: '/stub/sounds/transformation_failed.mp3'
+  transformation_failed: '/stub/sounds/transformation_failed.mp3',
+  default_profile_changed: '/stub/sounds/default_profile_changed.mp3'
 }
 
 describe('afplay backend', () => {

--- a/src/main/services/sound-service.test.ts
+++ b/src/main/services/sound-service.test.ts
@@ -12,7 +12,8 @@ const ALL_EVENTS: SoundEvent[] = [
   'recording_stopped',
   'recording_cancelled',
   'transformation_succeeded',
-  'transformation_failed'
+  'transformation_failed',
+  'default_profile_changed'
 ]
 
 // Stable test file-path stubs — decoupled from SOUND_ASSET_PATHS (which requires
@@ -22,7 +23,8 @@ const STUB_PATHS: Record<SoundEvent, string> = {
   recording_stopped: '/stub/sounds/recording_stopped.mp3',
   recording_cancelled: '/stub/sounds/recording_cancelled.mp3',
   transformation_succeeded: '/stub/sounds/transformation_succeeded.mp3',
-  transformation_failed: '/stub/sounds/transformation_failed.mp3'
+  transformation_failed: '/stub/sounds/transformation_failed.mp3',
+  default_profile_changed: '/stub/sounds/default_profile_changed.mp3'
 }
 
 describe('NoopSoundService', () => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -12,6 +12,7 @@ export type SoundEvent =
   | 'recording_cancelled'
   | 'transformation_succeeded'
   | 'transformation_failed'
+  | 'default_profile_changed'
 export interface RecordingCommandDispatch {
   command: RecordingCommand
   preferredDeviceId?: string


### PR DESCRIPTION
## Summary
- add a dedicated `default_profile_changed` sound event and map it to `resources/sounds/skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3`
- play that sound only when `changeTransformationDefault` (shortcut flow) actually commits a new default preset
- keep existing toast/status behavior unchanged and ensure no sound on cancel/no-op default selection
- remove legacy hotkey compatibility path (`runCompositeFromClipboard?`) from `HotkeyService`
- update spec and user-flow docs for shortcut-default sound semantics

## Testing
- `pnpm vitest src/main/services/hotkey-service.test.ts src/main/services/sound-service.test.ts src/main/services/sound-service-afplay.test.ts src/main/infrastructure/sound-asset-paths.test.ts src/main/ipc/register-handlers.test.ts`
- `pnpm typecheck`

Closes #391