### PR TITLE
fix: remove legacy header icon near macOS traffic lights

### DIFF
--- a/docs/decisions/remove-header-legacy-icon.md
+++ b/docs/decisions/remove-header-legacy-icon.md
@@ -1,0 +1,30 @@
+<!--
+Where: docs/decisions/remove-header-legacy-icon.md
+What: Decision record for removing the remaining header icon near macOS traffic lights.
+Why: Prevent visual conflict with native titlebar controls and align with issue request.
+-->
+
+# Decision: Remove Legacy Header Icon Near Traffic Lights
+
+Date: 2026-03-06
+
+## Context
+
+The renderer header still rendered a left icon container at `#app > div > header > div:first-child`.
+On macOS this appears close to traffic lights and looks like a legacy titlebar icon.
+
+## Decision
+
+- Remove the left icon container from `ShellChromeReact`.
+- Keep only the recording status indicator in header.
+- Keep drag-region behavior and platform-specific titlebar clearances.
+
+## Scope
+
+- `src/renderer/shell-chrome-react.tsx`
+- `src/renderer/shell-chrome-react.test.tsx`
+
+## Trade-off
+
+- Pros: removes unwanted visual icon and keeps layout simple.
+- Cons: header has less branding affordance.

--- a/src/renderer/shell-chrome-react.test.tsx
+++ b/src/renderer/shell-chrome-react.test.tsx
@@ -2,7 +2,7 @@
  * Where: src/renderer/shell-chrome-react.test.tsx
  * What: Component tests for the compact app header bar.
  * Why: Guard header metadata and state dot behavior after STY-02 re-architecture.
- *      ShellChromeReact is now a fixed header with logo + recording state dot only;
+ *      ShellChromeReact is now a fixed header with recording state indicator only;
  *      tab navigation has moved to the right workspace panel in AppShell.
  */
 
@@ -56,7 +56,7 @@ describe('ShellChromeReact', () => {
     expect(host.textContent).not.toContain('Speech-to-Text v1')
   })
 
-  it('renders header element with logo icon', async () => {
+  it('renders header element without legacy logo icon container', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -65,8 +65,7 @@ describe('ShellChromeReact', () => {
     await flush()
 
     expect(host.querySelector('header')).not.toBeNull()
-    // Logo container uses bg-primary/10 class
-    expect(host.querySelector('.\\[bg-primary\\/10\\]') ?? host.querySelector('[class*="bg-primary"]')).not.toBeNull()
+    expect(host.querySelector('header svg')).toBeNull()
   })
 
   it('adds drag-region classes to the header and no-drag classes to child groups', async () => {
@@ -80,7 +79,7 @@ describe('ShellChromeReact', () => {
     const header = host.querySelector('header')
     expect(header?.className).toContain('app-region-drag')
     expect(header?.className).toContain('select-none')
-    expect(host.querySelectorAll('.app-region-no-drag').length).toBe(2)
+    expect(host.querySelectorAll('.app-region-no-drag').length).toBe(1)
   })
 
   it('uses macOS traffic-light clearance padding when platform is darwin', async () => {

--- a/src/renderer/shell-chrome-react.tsx
+++ b/src/renderer/shell-chrome-react.tsx
@@ -1,8 +1,9 @@
 /*
  * Where: src/renderer/shell-chrome-react.tsx
- * What: Compact app header bar — logo and recording state dot.
+ * What: Compact app header bar — recording state indicator only.
  * Why: STY-02 re-architecture moves the tab rail into the right workspace panel;
- *      the header is now a fixed visual anchor that shows global recording state.
+ *      the header is now a fixed visual anchor that shows global recording state
+ *      without a branded icon near the macOS traffic lights.
  *
  * UX rationale:
  *   • State dot in the header gives permanent visual feedback without occupying
@@ -11,7 +12,6 @@
  *     in docs/ui-design-guidelines.md rather than decorative entrance animation.
  */
 
-import { AudioWaveform } from 'lucide-react'
 import { cn } from './lib/utils'
 
 interface ShellChromeReactProps {
@@ -24,18 +24,11 @@ export const ShellChromeReact = ({ isRecording }: ShellChromeReactProps) => {
   return (
     <header
       className={cn(
-        'flex items-center justify-between border-b px-4 py-2 bg-card/50',
+        'flex items-center justify-end border-b px-4 py-2 bg-card/50',
         'app-region-drag select-none',
         isDarwin ? 'pl-[var(--traffic-light-clearance)]' : 'pr-[var(--titlebar-overlay-clearance)]'
       )}
     >
-      {/* Logo */}
-      <div className="flex items-center gap-2 app-region-no-drag">
-        <div className="size-6 rounded-md bg-primary/10 flex items-center justify-center">
-          <AudioWaveform className="size-3.5 text-primary" aria-hidden="true" />
-        </div>
-      </div>
-
       {/* Recording state dot: persistent global feedback per UI Design Guidelines header contract */}
       <div className="flex items-center gap-1.5 app-region-no-drag" aria-live="polite" aria-atomic="true">
         <span


### PR DESCRIPTION
## Summary
- remove the left legacy header icon container from ShellChromeReact
- keep recording status indicator and drag/titlebar clearances intact
- update component tests to assert icon absence and updated no-drag count
- add decision note documenting rationale and scope

## Testing
- pnpm test -- src/renderer/shell-chrome-react.test.tsx
- pnpm test -- src/renderer/shell-chrome-react.test.tsx src/renderer/app-shell-react.test.tsx
