### PR TITLE
Spec: add user dictionary contract and provider-native STT hint mapping

### DIFF
--- a/docs/decisions/issue-406-user-dictionary-stt-hints.md
+++ b/docs/decisions/issue-406-user-dictionary-stt-hints.md
@@ -1,0 +1,39 @@
+<!--
+Where: docs/decisions/issue-406-user-dictionary-stt-hints.md
+What: Decision record for issue #406 user dictionary STT-hint mapping and apply-stage behavior.
+Why: Capture non-trivial architecture and product decisions so implementation and tests stay consistent.
+-->
+
+# Decision: Issue #406 User Dictionary as STT Recognition Hints
+
+Date: 2026-03-06  
+Issue: https://github.com/massun-onibakuchi/speech-to-text-app/issues/406
+
+## Context
+
+Issue #406 introduces a user dictionary (`key=value`) for speech correction.
+There are two possible integration paths:
+- treat dictionary as generic LLM/chat prompts, or
+- map dictionary to provider-native STT recognition hint fields.
+
+## Decision
+
+Use provider-native STT hint fields for dictionary input:
+- Groq Whisper-compatible path uses Whisper-native prompt semantics.
+- ElevenLabs Scribe path uses Scribe-native keyterm semantics.
+
+Do not route dictionary entries through generic LLM/chat `systemPrompt` or `userPrompt`.
+
+Apply dictionary replacement only on transcript output, not transformed output.
+
+## Rationale
+
+- Provider-native fields preserve STT-specific recognition behavior and reduce ambiguity.
+- Keeping dictionary out of LLM prompt channels avoids cross-layer coupling and unintended transformation behavior.
+- Transcript-only replacement keeps correction deterministic and prevents double-mutation in transformed flows.
+
+## Consequences
+
+- STT adapter contracts/tests must include recognition-hint mapping assertions by provider.
+- Dictionary UI/validation remains renderer-level, but mapping logic lives at STT adapter boundary in main/runtime paths.
+- The same dictionary data can influence recognition quality and deterministic post-transcript correction.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -263,6 +263,40 @@ Additional capture output rules:
 - If `selectedTextSource=transformed` and transformed text is unavailable because automatic transformation was skipped or failed, capture output **MUST** fall back to transcript text while preserving the configured destinations.
 - Settings UI **SHOULD** present shared destination controls and keep `output.transcript` / `output.transformed` destination rules synchronized when those legacy-compatible fields are retained in persisted settings.
 
+### 4.7 User dictionary (speech correction)
+
+The app **MUST** provide a global app-level user dictionary for speech correction as `key=value` entries.
+Feature issue: https://github.com/massun-onibakuchi/speech-to-text-app/issues/406
+
+CRUD behavior:
+- User **MUST** be able to add a dictionary entry with `key=value`.
+- User **MUST** be able to update an existing dictionary entry value by key.
+- User **MUST** be able to remove an existing dictionary entry by key.
+- Dictionary entry `value` **MUST** be at most 256 characters.
+- Add operations **MUST** fail when the key already exists.
+- Key uniqueness checks **MUST** be case-insensitive.
+
+Replacement behavior:
+- Dictionary replacement **MUST** use exact string matching.
+- Exact matching **MUST** be case-insensitive.
+- User dictionary entries **MUST** be appended to STT model input as recognition hints.
+- Recognition hints **MUST** be mapped to provider-native STT fields (for example Whisper `prompt`, ElevenLabs Scribe `keyterms`).
+- User dictionary hints **MUST NOT** be routed through generic LLM/chat `systemPrompt` or `userPrompt` fields.
+- Dictionary replacement **MUST** run on transcript output only.
+- Dictionary replacement **MUST NOT** run on transformed output.
+
+Dictionary tab behavior:
+- The app **MUST** expose a dedicated top-level **Dictionary** tab in the main workspace tab rail.
+- Dictionary tab **MUST** support add/update/remove interactions for dictionary entries.
+- Dictionary entries **MUST** be displayed in alphabetical order by `key`.
+- Persisted dictionary entries **MUST** be normalized to alphabetical order by `key` at write time.
+- Alphabetical ordering **MUST** use a case-insensitive key comparator with deterministic tie-break on raw key bytes.
+
+Rationale for transcript-only replacement (`4.7` apply stage):
+- It provides deterministic single-stage correction and prevents double mutation across transcript and transformed paths.
+- It preserves transformation behavior and prompt intent by feeding corrected transcript once into transformation.
+- It reduces regression/debug complexity by keeping one source of correction truth.
+
 ## 5. STT API Adapter Model
 
 ### 5.1 STT adapter contract
@@ -278,6 +312,14 @@ Input contract:
 - `apiKeyRef`.
 - Optional `baseUrlOverride` (internal adapter input only; not configured from v1 Settings).
 - Optional language and temperature controls.
+- Optional recognition hints derived from user dictionary entries.
+
+Recognition-hints mapping rules:
+- STT adapters **MUST** map recognition hints to provider-native STT request fields.
+- STT adapters **MUST NOT** map recognition hints to LLM/chat prompt channels.
+- Groq Whisper-compatible requests **MUST** map hints to Whisper-native prompt field semantics.
+- ElevenLabs Scribe requests **MUST** map hints to Scribe-native keyterm field semantics when supported by the selected model.
+- If selected STT model does not expose hint fields, adapter behavior **MUST** degrade gracefully without using LLM/chat prompt channels.
 
 Output contract:
 - `text` (string).
@@ -294,6 +336,7 @@ v1 **MUST** support at least these STT providers:
 Rules:
 - User **MUST** pre-configure STT provider in Settings before recording/transcription execution.
 - User **MUST** pre-configure STT model in Settings before recording/transcription execution.
+- For ElevenLabs in v1, supported model selection **MUST** use `scribe_v2`.
 - The app **MUST NOT** automatically choose or switch STT provider/model when configuration is missing.
 - If STT provider is unset, the app **MUST** show actionable error and **MUST NOT** start STT request.
 - If STT model is unset, the app **MUST** show actionable error and **MUST NOT** start STT request.
@@ -411,6 +454,13 @@ settings:
     transformed:
       copyToClipboard: true
       pasteAtCursor: false
+  correction:
+    dictionary:
+      entries:
+        - key: "teh"
+          value: "the"
+        - key: "onibakuti"
+          value: "onibakuchi"
 
   shortcuts:
     toggleRecording: "Cmd+Opt+T"
@@ -455,6 +505,14 @@ classDiagram
   class TranscriptionSettings {
     provider: string
     model: string
+  }
+
+  class CorrectionSettings {
+  }
+
+  class DictionaryEntry {
+    key: string
+    value: string
   }
 
   class TransformationSettings {
@@ -504,8 +562,10 @@ classDiagram
   Settings "1" --> "1" RecordingSettings
   Settings "1" --> "1" ProcessingSettings
   Settings "1" --> "1" TranscriptionSettings
+  Settings "1" --> "1" CorrectionSettings
   Settings "1" --> "1" TransformationSettings
   Settings "1" --> "1" OutputPolicy
+  CorrectionSettings "1" --> "many" DictionaryEntry
   TransformationSettings "1" --> "many" TransformationPreset
   ProcessingSettings "1" --> "0..many" StreamSegment
   ProcessingSettings "1" --> "0..1" StreamingClipboardState
@@ -532,11 +592,13 @@ stateDiagram-v2
 stateDiagram-v2
   [*] --> Queued
   Queued --> Transcribing
-  Transcribing --> Transforming: output.selectedTextSource = transformed
-  Transcribing --> ApplyingOutput: output.selectedTextSource = transcript
+  Transcribing --> CorrectingTranscript
+  CorrectingTranscript --> Transforming: output.selectedTextSource = transformed
+  CorrectingTranscript --> ApplyingOutput: output.selectedTextSource = transcript
   Transforming --> ApplyingOutput
   ApplyingOutput --> Succeeded
   Transcribing --> TranscriptionFailed
+  CorrectingTranscript --> TranscriptionFailed
   Transforming --> TransformationFailed
   ApplyingOutput --> OutputFailedPartial
   Succeeded --> [*]
@@ -553,6 +615,7 @@ sequenceDiagram
   participant R as Renderer
   participant M as Main
   participant CQ as Capture Queue
+  participant C as Correction Stage
   participant TW as Transform Workers
   participant OC as Output Committer
   participant S as STT
@@ -568,7 +631,9 @@ sequenceDiagram
   M->>CQ: enqueue capture job (FIFO)
   CQ->>S: transcribe
   S-->>CQ: transcript
-  CQ->>TW: enqueue transform (optional)
+  CQ->>C: apply dictionary correction (transcript-only)
+  C-->>CQ: corrected transcript
+  CQ->>TW: enqueue transform (optional, from corrected transcript)
   TW->>L: transform
   L-->>TW: transformed text
   TW->>OC: ready for commit
@@ -630,6 +695,15 @@ The test suite **MUST** include:
    - if `selectedTextSource=transformed` and transformed text is unavailable, capture output falls back to transcript using the same destination settings
 15. Window close / background shortcut lifecycle test:
    - closing the main window hides to background and recording shortcuts remain functional until explicit quit
+16. User dictionary tests:
+   - add/update/remove `key=value` flows
+   - duplicate-key add rejection (case-insensitive)
+   - `value` max-length validation rejects entries longer than 256 characters
+   - user dictionary entries are appended to STT request input as recognition hints
+   - provider mapping uses native STT fields (Whisper prompt, Scribe keyterms) and not generic LLM/chat prompts
+   - exact case-insensitive replacement behavior
+   - transcript-only apply-stage enforcement (no transformed-output replacement)
+   - alphabetical ordering by key in persisted/displayed dictionary list
 
 ### 10.2 Manual verification checklist
 
@@ -641,6 +715,9 @@ The test suite **MUST** include:
 - Start/stop/cancel sounds are audible.
 - Transformation completion sound is audible for both success and failure.
 - UI remains responsive during active processing.
+- Dictionary tab exists and allows add/update/remove `key=value` entries.
+- Dictionary value input enforces max length of 256 characters with validation feedback.
+- Dictionary list is sorted alphabetically by key.
 
 ### 10.3 CI execution policy for e2e coverage
 


### PR DESCRIPTION
## Summary
- add normative user dictionary spec section (global `key=value` dictionary, CRUD, max value length 256)
- define dictionary ordering and deterministic case-insensitive sort semantics
- require transcript-only replacement and explicitly disallow transformed-output replacement
- define STT recognition-hint integration via provider-native fields (Whisper prompt / Scribe keyterms), not generic LLM/chat prompts
- align processing lifecycle/sequence and data model diagram with correction stage and correction settings
- add decision record for issue #406 architecture choices

## Related
- Closes #406
- Related umbrella: #375

## Files
- `specs/spec.md`
- `docs/decisions/issue-406-user-dictionary-stt-hints.md`

## Validation
- Docs/spec changes only; no runtime code or tests executed.
- Sub-agent review completed and findings were addressed in this PR.
- Claude skill review attempted via CLI in this environment but did not return output.
