### PR TITLE
test: add large-input dictionary replacement regression gate (issue #406 T6)

### DIFF
--- a/src/main/services/transcription/dictionary-replacement.test.ts
+++ b/src/main/services/transcription/dictionary-replacement.test.ts
@@ -41,4 +41,17 @@ describe('applyDictionaryReplacement', () => {
     ])
     expect(result).toBe('hello,the world! the?')
   })
+
+  it('handles large dictionary/transcript inputs within the test timeout budget', () => {
+    const entries = Array.from({ length: 500 }, (_value, index) => ({
+      key: `word-${index}`,
+      value: `term-${index}`
+    }))
+    const transcript = Array.from({ length: 4000 }, (_value, index) => `word-${index % 500}`).join(' ')
+
+    const result = applyDictionaryReplacement(transcript, entries)
+
+    expect(result.startsWith('term-0 term-1 term-2')).toBe(true)
+    expect(result.includes('word-')).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- add a large-input regression test for applyDictionaryReplacement
- exercise dictionary correction with 500 entries across a 4000-token transcript
- assert full replacement completion on big input to guard against accidental performance/complexity regressions

## Why
- execution plan T6 requires a performance sanity gate for dictionary replacement path
- this keeps the guardrail in the core helper where transcript correction complexity is concentrated

## Scope
- src/main/services/transcription/dictionary-replacement.test.ts

## Testing
- pnpm vitest run src/main/services/transcription/dictionary-replacement.test.ts
- pnpm test