### PR TITLE
Fix macOS menu bar settings window behavior

### DIFF
--- a/docs/research/all-possible-user-flow-path-research.md
+++ b/docs/research/all-possible-user-flow-path-research.md
@@ -33,7 +33,7 @@ Every user-observable flow begins from one of these origins:
 
 1. Renderer UI action.
 2. Global shortcut callback in main.
-3. Tray menu action (`Settings`, `Quit`, tray click to show window).
+3. Tray menu action (`Settings...`, `Quit`; tray icon click only opens the tray menu).
 4. App lifecycle event (boot, activate, second-instance).
 
 ## 2.2 Flow buses
@@ -81,8 +81,8 @@ Failure outcomes:
 
 1. User closes window (red close): window hides unless app is quitting.
 2. User clicks dock icon or app activates: hidden window is shown/focused.
-3. Tray click: show/focus window.
-4. Tray `Settings`: show/focus window and emit `onOpenSettings` to renderer.
+3. Tray icon click: keep app in tray/background mode and show only the tray menu.
+4. Tray `Settings...`: show/focus window and emit `onOpenSettings` to renderer.
 5. Tray `Quit`: normal quit path; global hotkeys unregistered on `will-quit`.
 
 ## 4. Renderer navigation and local UI paths

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -162,6 +162,8 @@ Steps:
 
 Notes:
 - Expected behavior is the same for installed builds and manual runs launched from `dist/`: closing the main window should hide it (background/tray mode) rather than destroying the renderer, so global shortcuts continue to work while the app process is still running.
+- Clicking the macOS menu bar icon should keep the app in tray/background mode; it must not re-open the main window by itself.
+- The main window opens from the menu bar only when the user chooses `Settings...`.
 - Global shortcuts stop only after the app is explicitly quit (for example via the tray menu) or the process exits/crashes.
 
 ---

--- a/src/main/core/window-manager.test.ts
+++ b/src/main/core/window-manager.test.ts
@@ -207,15 +207,22 @@ describe('WindowManager', () => {
     expect(mocks.Tray).toHaveBeenCalledWith(mocks.emptyImage)
   })
 
-  it('builds tray context menu with Settings and Quit actions', () => {
+  it('builds tray context menu with Settings... and Quit actions', () => {
     const manager = new WindowManager()
     manager.ensureTray()
 
     expect(mocks.Menu.buildFromTemplate).toHaveBeenCalledTimes(1)
     const template = mocks.Menu.buildFromTemplate.mock.calls[0]?.[0] as Array<Record<string, unknown>>
-    expect(template[0]?.label).toBe('Settings')
+    expect(template[0]?.label).toBe('Settings...')
     expect(template[1]?.type).toBe('separator')
     expect(template[2]?.label).toBe('Quit')
+  })
+
+  it('does not register a tray click handler that shows the main window', () => {
+    const manager = new WindowManager()
+    manager.ensureTray()
+
+    expect(mocks.trayOn).not.toHaveBeenCalledWith('click', expect.any(Function))
   })
 
   it('opens settings route immediately when renderer is already loaded', () => {
@@ -223,7 +230,7 @@ describe('WindowManager', () => {
     manager.ensureTray()
 
     const template = mocks.Menu.buildFromTemplate.mock.calls[0]?.[0] as Array<{ label?: string; click?: () => void }>
-    const settingsItem = template.find((item) => item.label === 'Settings')
+    const settingsItem = template.find((item) => item.label === 'Settings...')
 
     settingsItem?.click?.()
 
@@ -239,7 +246,7 @@ describe('WindowManager', () => {
     mocks.webContentsIsLoadingMainFrame.mockReturnValue(true)
 
     const template = mocks.Menu.buildFromTemplate.mock.calls[0]?.[0] as Array<{ label?: string; click?: () => void }>
-    const settingsItem = template.find((item) => item.label === 'Settings')
+    const settingsItem = template.find((item) => item.label === 'Settings...')
 
     settingsItem?.click?.()
 

--- a/src/main/core/window-manager.ts
+++ b/src/main/core/window-manager.ts
@@ -90,7 +90,7 @@ export class WindowManager {
     this.tray.setContextMenu(
       Menu.buildFromTemplate([
         {
-          label: 'Settings',
+          label: 'Settings...',
           click: () => this.openSettingsFromTray()
         },
         { type: 'separator' },
@@ -100,10 +100,6 @@ export class WindowManager {
         }
       ])
     )
-
-    this.tray.on('click', () => {
-      this.showMainWindow()
-    })
   }
 
   showMainWindow(): void {


### PR DESCRIPTION
## Summary
- stop reopening the main window when the macOS menu bar icon is clicked
- rename the tray menu item to 
- update tray behavior tests and user-flow docs to match

## Verification
- pnpm install
- pnpm test -- src/main/core/window-manager.test.ts
- pnpm exec tsc --noEmit