### PR TITLE
Add dictionary Replace/With column labels

### DIFF
--- a/docs/plans/issue-406-dictionary-column-labels-execution-plan.md
+++ b/docs/plans/issue-406-dictionary-column-labels-execution-plan.md
@@ -1,0 +1,56 @@
+<!--
+Where: docs/plans/issue-406-dictionary-column-labels-execution-plan.md
+What: Execution plan for dictionary entry column labels.
+Why: Keep the UI adjustment scoped to one reviewable PR with explicit risk and test gates.
+-->
+
+# Issue 406 Dictionary Column Labels Execution Plan
+
+## Ticket 1: Add Dictionary Entry Column Labels
+
+### Goal
+- Add a visible label row above dictionary entries so the key/value columns are explicitly labeled `Replace` and `With`.
+- Make the label row visually distinct from dictionary item rows without changing the current blur-save or delete behavior.
+
+### Checklist
+- Add a visible header row above populated dictionary entries.
+- Use exact labels `Replace` and `With`.
+- Apply a distinct muted color treatment to the header row.
+- Keep add/edit/delete logic unchanged.
+- Add focused component coverage for the labels and styling hook.
+
+### Tasks
+- Update `src/renderer/dictionary-panel-react.tsx` to render a header row only when entries exist.
+- Use a stable selector for test coverage so the visual treatment is locked without snapshot noise.
+- Extend `src/renderer/dictionary-panel-react.test.tsx` with one focused test for exact labels and header styling.
+- Run focused renderer tests and typecheck.
+
+### Gates
+- `pnpm vitest run src/renderer/dictionary-panel-react.test.tsx`
+- `pnpm run typecheck`
+
+### Approach
+- Keep the change local to the dictionary panel instead of introducing shared layout primitives.
+- Render the header as a compact row immediately above the list to preserve current row markup and event handling.
+- Use a muted background and muted foreground token so the header is distinct from entry rows but still aligned with the existing design system.
+
+### Scope Files
+- `src/renderer/dictionary-panel-react.tsx`
+- `src/renderer/dictionary-panel-react.test.tsx`
+- `docs/plans/issue-406-dictionary-column-labels-execution-plan.md`
+
+### Trade-Offs
+- Reusing utility classes keeps the diff small and easy to review, but exact visual balance still depends on the existing theme tokens.
+- Adding a test hook is slightly more explicit than purely text-based assertions, but it avoids brittle DOM traversal and makes the styling contract clear.
+
+### Code Snippet
+```tsx
+<div
+  data-testid="dictionary-entry-header"
+  className="grid grid-cols-[minmax(6rem,1fr)_minmax(0,1fr)_auto] ... bg-muted/60 ..."
+>
+  <span>Replace</span>
+  <span>With</span>
+  <span aria-hidden="true" />
+</div>
+```

--- a/src/renderer/dictionary-panel-react.test.tsx
+++ b/src/renderer/dictionary-panel-react.test.tsx
@@ -79,6 +79,31 @@ describe('DictionaryPanelReact', () => {
     expect(labels).toEqual(['Alpha', 'zeta'])
   })
 
+  it('renders Replace and With column labels with distinct header styling', async () => {
+    const host = document.createElement('div')
+    document.body.append(host)
+    root = createRoot(host)
+
+    root.render(
+      <DictionaryPanelReact
+        settings={buildSettings([{ key: 'teh', value: 'the' }])}
+        onAddEntry={vi.fn()}
+        onUpdateEntry={vi.fn().mockResolvedValue(true)}
+        onDeleteEntry={vi.fn()}
+      />
+    )
+    await flush()
+
+    const header = host.querySelector<HTMLElement>('[data-testid="dictionary-entry-header"]')
+    if (!header) {
+      throw new Error('dictionary entry header is missing')
+    }
+
+    expect(header.textContent).toContain('Replace')
+    expect(header.textContent).toContain('With')
+    expect(header.className).toContain('bg-muted/60')
+  })
+
   it('adds a new entry when key/value are valid', async () => {
     const host = document.createElement('div')
     document.body.append(host)

--- a/src/renderer/dictionary-panel-react.tsx
+++ b/src/renderer/dictionary-panel-react.tsx
@@ -210,80 +210,90 @@ export const DictionaryPanelReact = ({ settings, onAddEntry, onUpdateEntry, onDe
         {entries.length === 0 ? (
           <p className="text-[10px] text-muted-foreground m-0">No dictionary entries yet.</p>
         ) : (
-          <ul className="m-0 p-0 list-none space-y-2">
-            {entries.map((entry, index) => (
-              <li key={entry.key} className="rounded border border-border/70 p-2 space-y-1">
-                <div className="flex items-center gap-2" onBlur={handleRowBlur(entry)}>
-                  <input
-                    id={`dictionary-key-${index}`}
-                    value={resolveRowDraft(entry).key}
-                    onChange={(event) => {
-                      const nextKey = event.target.value
-                      setRowDrafts((prev) => ({
-                        ...prev,
-                        [entry.key]: {
-                          ...(prev[entry.key] ?? { key: entry.key, value: entry.value }),
-                          key: nextKey
-                        }
-                      }))
-                      setRowErrors((prev) => {
-                        const next = { ...prev }
-                        delete next[entry.key]
-                        return next
-                      })
-                    }}
-                    className="h-8 min-w-24 rounded border border-input bg-input px-2 text-xs font-mono text-muted-foreground"
-                    aria-label={`Key for ${entry.key}`}
-                    maxLength={MAX_KEY_LENGTH}
-                  />
-                  <input
-                    id={`dictionary-value-${index}`}
-                    value={resolveRowDraft(entry).value}
-                    onChange={(event) => {
-                      const nextValue = event.target.value
-                      setRowDrafts((prev) => ({
-                        ...prev,
-                        [entry.key]: {
-                          ...(prev[entry.key] ?? { key: entry.key, value: entry.value }),
-                          value: nextValue
-                        }
-                      }))
-                      setRowErrors((prev) => {
-                        const next = { ...prev }
-                        delete next[entry.key]
-                        return next
-                      })
-                    }}
-                    className="h-8 flex-1 rounded border border-input bg-input px-2 text-xs"
-                    aria-label={`Value for ${entry.key}`}
-                    maxLength={MAX_VALUE_LENGTH}
-                  />
-                  <button
-                    id={`dictionary-delete-${index}`}
-                    type="button"
-                    className="h-8 rounded border border-border bg-secondary px-2 text-xs text-destructive"
-                    aria-label={`Delete dictionary entry ${entry.key}`}
-                    onClick={() => {
-                      setRowDrafts((prev) => {
-                        const next = { ...prev }
-                        delete next[entry.key]
-                        return next
-                      })
-                      setRowErrors((prev) => {
-                        const next = { ...prev }
-                        delete next[entry.key]
-                        return next
-                      })
-                      onDeleteEntry(entry.key)
-                    }}
-                  >
-                    Delete
-                  </button>
-                </div>
-                {rowErrors[entry.key] ? <p className="text-[10px] text-destructive m-0" aria-live="polite">{rowErrors[entry.key]}</p> : null}
-              </li>
-            ))}
-          </ul>
+          <div className="space-y-2">
+            <div
+              data-testid="dictionary-entry-header"
+              className="grid grid-cols-[minmax(6rem,1fr)_minmax(0,1fr)_auto] items-center gap-2 rounded border border-border/60 bg-muted/60 px-2 py-1 text-[10px] font-semibold text-muted-foreground"
+            >
+              <span>Replace</span>
+              <span>With</span>
+              <span aria-hidden="true" />
+            </div>
+            <ul className="m-0 p-0 list-none space-y-2">
+              {entries.map((entry, index) => (
+                <li key={entry.key} className="rounded border border-border/70 p-2 space-y-1">
+                  <div className="flex items-center gap-2" onBlur={handleRowBlur(entry)}>
+                    <input
+                      id={`dictionary-key-${index}`}
+                      value={resolveRowDraft(entry).key}
+                      onChange={(event) => {
+                        const nextKey = event.target.value
+                        setRowDrafts((prev) => ({
+                          ...prev,
+                          [entry.key]: {
+                            ...(prev[entry.key] ?? { key: entry.key, value: entry.value }),
+                            key: nextKey
+                          }
+                        }))
+                        setRowErrors((prev) => {
+                          const next = { ...prev }
+                          delete next[entry.key]
+                          return next
+                        })
+                      }}
+                      className="h-8 min-w-24 rounded border border-input bg-input px-2 text-xs font-mono text-muted-foreground"
+                      aria-label={`Key for ${entry.key}`}
+                      maxLength={MAX_KEY_LENGTH}
+                    />
+                    <input
+                      id={`dictionary-value-${index}`}
+                      value={resolveRowDraft(entry).value}
+                      onChange={(event) => {
+                        const nextValue = event.target.value
+                        setRowDrafts((prev) => ({
+                          ...prev,
+                          [entry.key]: {
+                            ...(prev[entry.key] ?? { key: entry.key, value: entry.value }),
+                            value: nextValue
+                          }
+                        }))
+                        setRowErrors((prev) => {
+                          const next = { ...prev }
+                          delete next[entry.key]
+                          return next
+                        })
+                      }}
+                      className="h-8 flex-1 rounded border border-input bg-input px-2 text-xs"
+                      aria-label={`Value for ${entry.key}`}
+                      maxLength={MAX_VALUE_LENGTH}
+                    />
+                    <button
+                      id={`dictionary-delete-${index}`}
+                      type="button"
+                      className="h-8 rounded border border-border bg-secondary px-2 text-xs text-destructive"
+                      aria-label={`Delete dictionary entry ${entry.key}`}
+                      onClick={() => {
+                        setRowDrafts((prev) => {
+                          const next = { ...prev }
+                          delete next[entry.key]
+                          return next
+                        })
+                        setRowErrors((prev) => {
+                          const next = { ...prev }
+                          delete next[entry.key]
+                          return next
+                        })
+                        onDeleteEntry(entry.key)
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                  {rowErrors[entry.key] ? <p className="text-[10px] text-destructive m-0" aria-live="polite">{rowErrors[entry.key]}</p> : null}
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </section>
     </section>


### PR DESCRIPTION
## Summary
- add a visible dictionary entry header row with `Replace` and `With` labels
- give the header a muted color treatment distinct from item rows
- add focused component coverage and include the execution plan file in this branch

## Testing
- pnpm vitest run src/renderer/dictionary-panel-react.test.tsx
- pnpm run typecheck
- pnpm test
