### PR TITLE
Add prompt-based GitHub release updates

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,50 @@
+# Where: .github/workflows/release-macos.yml
+# What:  Builds, signs, and publishes macOS Electron release artifacts to GitHub Releases.
+# Why:   electron-updater needs GitHub-hosted release metadata/artifacts for packaged update checks.
+
+name: Release macOS
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release-macos:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run release verification
+        run: |
+          pnpm run typecheck
+          pnpm run test
+
+      - name: Build, sign, and publish release artifacts
+        run: pnpm run dist:mac:publish

--- a/docs/decisions/github-releases-auto-update.md
+++ b/docs/decisions/github-releases-auto-update.md
@@ -1,0 +1,20 @@
+# GitHub Releases Auto-Update
+
+## Context
+
+The app did not have any updater logic, release metadata publishing, or operator docs for Electron auto-updates. The requested behavior is prompt-based updates on macOS using GitHub Releases.
+
+## Decision
+
+Use `electron-updater` in the main process with the electron-builder GitHub publish provider. Configure the updater with `autoDownload = false` so the app prompts before downloading, then prompt again after download completes before restarting to install.
+
+## Why
+
+- GitHub Releases is the simplest hosted update source for this app's current distribution model.
+- `electron-updater` matches the existing electron-builder packaging flow and generates the release metadata the client consumes.
+- Prompt-before-download is the least surprising UX for a utility that typically lives in the tray and may restart background behavior.
+
+## Trade-Offs
+
+- This assumes public GitHub Releases. Private-release update flows are not a good default because they push GitHub auth handling onto end-user clients.
+- Auto-update will only work from signed packaged macOS builds, so local dev and unsigned artifacts intentionally skip update checks.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,12 @@
+# Release Checklist
+
+- Bump `package.json` version to the release version before tagging.
+- Confirm the macOS signing secrets are configured in GitHub Actions:
+  - `CSC_LINK`
+  - `CSC_KEY_PASSWORD`
+  - `APPLE_ID`
+  - `APPLE_APP_SPECIFIC_PASSWORD`
+  - `APPLE_TEAM_ID`
+- Push a tag in the form `vX.Y.Z` to trigger `.github/workflows/release-macos.yml`.
+- Verify the workflow uploaded the DMG, ZIP, and `latest-mac.yml` assets to the GitHub Release.
+- Install the signed build on macOS and confirm the app prompts when a newer release is published.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "v1 macOS speech-to-text app",
   "main": "out/main/index.js",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:massun-onibakuchi/speech-to-text-app.git"
+  },
   "packageManager": "pnpm@10.29.3",
   "scripts": {
     "dev": "electron-vite dev",
@@ -12,6 +16,7 @@
     "preview": "electron-vite preview",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac dmg zip --publish never",
+    "dist:mac:publish": "pnpm run build && electron-builder --mac dmg zip --publish always",
     "release:checklist": "cat docs/release-checklist.md",
     "release:dry-run": "bash scripts/release-dry-run.sh",
     "typecheck": "tsc --noEmit",
@@ -52,6 +57,12 @@
         "zip"
       ],
       "hardenedRuntime": true
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "massun-onibakuchi",
+      "repo": "speech-to-text-app",
+      "releaseType": "release"
     }
   },
   "devDependencies": {
@@ -84,6 +95,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "clsx": "^2.1.1",
     "electron-store": "^11.0.2",
+    "electron-updater": "^6.8.3",
     "lucide-react": "^0.575.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@18.3.1)
@@ -1712,6 +1715,10 @@ packages:
     resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@26.0.11:
     resolution: {integrity: sha512-xNjXfsldUEe153h1DraD0XvDOpqGR0L5eKFkdReB7eFW5HqysDZFfly4rckda6y9dF39N3pkPlOblcfHKGw+uA==}
 
@@ -1958,6 +1965,9 @@ packages:
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
   electron-vite@4.0.0:
     resolution: {integrity: sha512-U3d7GlKjl4BPs1sxYTHn1N8YlMmPvlx1t62UVQ1zouWoBxZs5Hd5yrJcQ+rmMnko/ASbIcx/KFOTXh8YcqLv7w==}
@@ -2475,6 +2485,13 @@ packages:
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -3065,6 +3082,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4824,6 +4844,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.4.4
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@26.0.11:
     dependencies:
       7zip-bin: 5.2.0
@@ -5151,6 +5178,19 @@ snapshots:
       type-fest: 5.4.4
 
   electron-to-chromium@1.5.286: {}
+
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-vite@4.0.0(vite@6.0.7(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
@@ -5766,6 +5806,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
 
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash@4.17.23: {}
 
   log-symbols@4.1.0:
@@ -6350,6 +6394,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,17 @@ Available CI secrets used by e2e workflows:
 pnpm dist:mac     # build + package dmg/zip for macOS
 ```
 
+For GitHub Releases publishing:
+
+```sh
+pnpm dist:mac:publish
+```
+
+- Packaged builds check GitHub Releases for updates on startup.
+- Update downloads are prompt-based: the app asks before downloading and again before restarting to install.
+- Auto-update requires signed macOS releases plus GitHub-hosted release metadata (`latest-mac.yml`).
+- See [docs/release-checklist.md](docs/release-checklist.md) for the release workflow inputs/secrets.
+
 ## Project Structure
 
 ```

--- a/src/main/core/app-lifecycle.test.ts
+++ b/src/main/core/app-lifecycle.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => {
   const ensureTray = vi.fn()
   const showMainWindow = vi.fn()
   const markQuitting = vi.fn()
+  const startUpdater = vi.fn()
 
   return {
     appListeners,
@@ -37,7 +38,8 @@ const mocks = vi.hoisted(() => {
     createMainWindow,
     ensureTray,
     showMainWindow,
-    markQuitting
+    markQuitting,
+    startUpdater
   }
 })
 
@@ -66,6 +68,12 @@ vi.mock('./window-manager', () => ({
   }))
 }))
 
+vi.mock('../services/app-updater-service', () => ({
+  AppUpdaterService: vi.fn().mockImplementation(() => ({
+    start: mocks.startUpdater
+  }))
+}))
+
 import { AppLifecycle } from './app-lifecycle'
 
 describe('AppLifecycle', () => {
@@ -85,6 +93,7 @@ describe('AppLifecycle', () => {
     expect(mocks.registerIpcHandlers).toHaveBeenCalledOnce()
     expect(mocks.createMainWindow).toHaveBeenCalledOnce()
     expect(mocks.ensureTray).toHaveBeenCalledOnce()
+    expect(mocks.startUpdater).toHaveBeenCalledOnce()
 
     const onWindowAllClosed = mocks.appListeners.get('window-all-closed')
     expect(onWindowAllClosed).toBeTypeOf('function')

--- a/src/main/core/app-lifecycle.ts
+++ b/src/main/core/app-lifecycle.ts
@@ -6,10 +6,12 @@
 
 import { app } from 'electron'
 import { registerIpcHandlers, unregisterGlobalHotkeys } from '../ipc/register-handlers'
+import { AppUpdaterService } from '../services/app-updater-service'
 import { WindowManager } from './window-manager'
 
 export class AppLifecycle {
   private readonly windowManager = new WindowManager()
+  private readonly appUpdaterService = new AppUpdaterService()
 
   initialize(): void {
     const singleInstance = app.requestSingleInstanceLock()
@@ -27,6 +29,7 @@ export class AppLifecycle {
       registerIpcHandlers()
       this.windowManager.createMainWindow()
       this.windowManager.ensureTray()
+      this.appUpdaterService.start()
 
       app.on('activate', () => {
         // On macOS, app-icon activation should restore a hidden/minimized main window

--- a/src/main/services/app-updater-service.test.ts
+++ b/src/main/services/app-updater-service.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Where: src/main/services/app-updater-service.test.ts
+ * What:  Tests the prompt-before-download release update flow.
+ * Why:   Prevent silent download regressions and keep restart/install prompting explicit.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppUpdaterService } from './app-updater-service'
+
+type UpdaterListener = (...args: any[]) => void
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, UpdaterListener>()
+  const on = vi.fn((event: string, listener: UpdaterListener) => {
+    listeners.set(event, listener)
+  })
+
+  return {
+    listeners,
+    isPackaged: true,
+    showMessageBox: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+    on
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return mocks.isPackaged
+    }
+  },
+  dialog: {
+    showMessageBox: mocks.showMessageBox
+  }
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    on: mocks.on,
+    checkForUpdates: mocks.checkForUpdates,
+    downloadUpdate: mocks.downloadUpdate,
+    quitAndInstall: mocks.quitAndInstall
+  }
+}))
+
+describe('AppUpdaterService', () => {
+  beforeEach(() => {
+    mocks.listeners.clear()
+    mocks.isPackaged = true
+    vi.clearAllMocks()
+    mocks.checkForUpdates.mockResolvedValue(undefined)
+    mocks.downloadUpdate.mockResolvedValue(undefined)
+    mocks.showMessageBox.mockResolvedValue({ response: 1 })
+  })
+
+  it('checks for updates only when the app is packaged', async () => {
+    mocks.isPackaged = false
+    const service = new AppUpdaterService()
+
+    service.start()
+    await Promise.resolve()
+
+    expect(mocks.checkForUpdates).not.toHaveBeenCalled()
+  })
+
+  it('disables auto-download before checking for updates', async () => {
+    const service = new AppUpdaterService()
+
+    service.start()
+    await Promise.resolve()
+
+    const { autoUpdater } = await import('electron-updater')
+    expect(autoUpdater.autoDownload).toBe(false)
+    expect(autoUpdater.autoInstallOnAppQuit).toBe(true)
+    expect(mocks.checkForUpdates).toHaveBeenCalledOnce()
+  })
+
+  it('downloads an available update when the user accepts the prompt', async () => {
+    mocks.showMessageBox.mockResolvedValueOnce({ response: 0 })
+    const service = new AppUpdaterService()
+
+    service.start()
+    const listener = mocks.listeners.get('update-available')
+    expect(listener).toBeTypeOf('function')
+
+    await listener?.({ version: '0.2.0' })
+
+    expect(mocks.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Update Available',
+        message: 'Version 0.2.0 is available.'
+      })
+    )
+    expect(mocks.downloadUpdate).toHaveBeenCalledOnce()
+  })
+
+  it('does not download an available update when the user defers', async () => {
+    const service = new AppUpdaterService()
+
+    service.start()
+    const listener = mocks.listeners.get('update-available')
+    await listener?.({ version: '0.2.0' })
+
+    expect(mocks.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('prompts to restart when an update download completes', async () => {
+    mocks.showMessageBox.mockResolvedValueOnce({ response: 0 })
+    const service = new AppUpdaterService()
+
+    service.start()
+    const listener = mocks.listeners.get('update-downloaded')
+    expect(listener).toBeTypeOf('function')
+
+    await listener?.({ version: '0.2.0' })
+
+    expect(mocks.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Install Update',
+        message: 'Version 0.2.0 has been downloaded.'
+      })
+    )
+    expect(mocks.quitAndInstall).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/services/app-updater-service.ts
+++ b/src/main/services/app-updater-service.ts
@@ -1,0 +1,193 @@
+/**
+ * Where: src/main/services/app-updater-service.ts
+ * What:  GitHub Releases auto-update orchestration with prompt-before-download behavior.
+ * Why:   Keep update logic out of the lifecycle bootstrap while making release checks testable.
+ */
+
+import { app, dialog } from 'electron'
+import { autoUpdater, type AppUpdater, type UpdateDownloadedEvent, type UpdateInfo } from 'electron-updater'
+import { logStructured } from '../../shared/error-logging'
+
+type MessageBox = Pick<typeof dialog, 'showMessageBox'>
+
+const DOWNLOAD_BUTTON_INDEX = 0
+const INSTALL_BUTTON_INDEX = 0
+
+export class AppUpdaterService {
+  private readonly updater: AppUpdater
+  private readonly messageBox: MessageBox
+  private isChecking = false
+  private isDownloading = false
+  private listenersRegistered = false
+
+  constructor(
+    options: {
+      updater?: AppUpdater
+      messageBox?: MessageBox
+    } = {}
+  ) {
+    this.updater = options.updater ?? autoUpdater
+    this.messageBox = options.messageBox ?? dialog
+  }
+
+  start(): void {
+    if (!app.isPackaged) {
+      logStructured({
+        level: 'info',
+        scope: 'main',
+        event: 'updater.skipped_unpacked',
+        message: 'Skipping release update check because the app is not packaged.'
+      })
+      return
+    }
+
+    if (this.isChecking) {
+      return
+    }
+
+    this.registerListeners()
+    this.isChecking = true
+    this.updater.autoDownload = false
+    this.updater.autoInstallOnAppQuit = true
+
+    void this.updater.checkForUpdates()
+      .catch((error) => {
+        logStructured({
+          level: 'error',
+          scope: 'main',
+          event: 'updater.check_failed',
+          message: 'Failed to check for updates from GitHub Releases.',
+          error
+        })
+      })
+      .finally(() => {
+        this.isChecking = false
+      })
+  }
+
+  private registerListeners(): void {
+    if (this.listenersRegistered) {
+      return
+    }
+
+    this.listenersRegistered = true
+    this.updater.on('checking-for-update', () => {
+      logStructured({
+        level: 'info',
+        scope: 'main',
+        event: 'updater.checking',
+        message: 'Checking GitHub Releases for a newer build.'
+      })
+    })
+
+    this.updater.on('update-not-available', () => {
+      logStructured({
+        level: 'info',
+        scope: 'main',
+        event: 'updater.no_update',
+        message: 'No newer release is available.'
+      })
+    })
+
+    this.updater.on('update-available', (info) => {
+      void this.promptToDownloadUpdate(info).catch((error) => {
+        this.logPromptFailure('updater.download_prompt_failed', 'Failed to show the update download prompt.', error)
+      })
+    })
+
+    this.updater.on('update-downloaded', (event) => {
+      void this.promptToInstallUpdate(event).catch((error) => {
+        this.logPromptFailure('updater.install_prompt_failed', 'Failed to show the update install prompt.', error)
+      })
+    })
+
+    this.updater.on('error', (error) => {
+      logStructured({
+        level: 'error',
+        scope: 'main',
+        event: 'updater.runtime_error',
+        message: 'Electron updater emitted an error.',
+        error
+      })
+      this.isDownloading = false
+    })
+  }
+
+  private async promptToDownloadUpdate(info: UpdateInfo): Promise<void> {
+    if (this.isDownloading) {
+      return
+    }
+
+    logStructured({
+      level: 'info',
+      scope: 'main',
+      event: 'updater.update_available',
+      message: 'A newer release is available.',
+      context: { version: info.version }
+    })
+
+    const result = await this.messageBox.showMessageBox({
+      type: 'info',
+      buttons: ['Download', 'Later'],
+      defaultId: DOWNLOAD_BUTTON_INDEX,
+      cancelId: 1,
+      title: 'Update Available',
+      message: `Version ${info.version} is available.`,
+      detail: 'Download the new release now? The app will prompt again when it is ready to install.'
+    })
+
+    if (result.response !== DOWNLOAD_BUTTON_INDEX) {
+      return
+    }
+
+    this.isDownloading = true
+    try {
+      await this.updater.downloadUpdate()
+    } catch (error) {
+      logStructured({
+        level: 'error',
+        scope: 'main',
+        event: 'updater.download_failed',
+        message: 'Failed to download the selected update.',
+        error,
+        context: { version: info.version }
+      })
+      this.isDownloading = false
+    }
+  }
+
+  private async promptToInstallUpdate(event: UpdateDownloadedEvent): Promise<void> {
+    this.isDownloading = false
+    logStructured({
+      level: 'info',
+      scope: 'main',
+      event: 'updater.update_downloaded',
+      message: 'An update finished downloading and is ready to install.',
+      context: { version: event.version }
+    })
+
+    const result = await this.messageBox.showMessageBox({
+      type: 'info',
+      buttons: ['Restart and Install', 'Later'],
+      defaultId: INSTALL_BUTTON_INDEX,
+      cancelId: 1,
+      title: 'Install Update',
+      message: `Version ${event.version} has been downloaded.`,
+      detail: 'Restart the app now to install the update.'
+    })
+
+    if (result.response === INSTALL_BUTTON_INDEX) {
+      this.updater.quitAndInstall()
+    }
+  }
+
+  private logPromptFailure(event: string, message: string, error: unknown): void {
+    logStructured({
+      level: 'error',
+      scope: 'main',
+      event,
+      message,
+      error
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add a main-process updater service using electron-updater with prompt-before-download behavior
- configure electron-builder GitHub publishing and add a macOS release workflow for signed release artifacts
- document the release/update flow and add focused updater tests

## Testing
- pnpm run typecheck
- pnpm test

## Notes
- the signed/notarized GitHub Actions release path is configured but still needs a real tagged run with valid CSC_* and APPLE_* secrets to verify end-to-end publishing
- the repo review sub-agent found no issues; the extra Claude CLI review attempt timed out without output