### PR TITLE
fix: drain streaming user stop before terminal state

### DIFF
--- a/docs/decisions/2026-03-08-streaming-user-stop-drain-decision.md
+++ b/docs/decisions/2026-03-08-streaming-user-stop-drain-decision.md
@@ -1,0 +1,44 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-user-stop-drain-decision.md
+What: Decision note for drain-safe `user_stop` handling in the streaming session controller.
+Why: Record why stop-time late final segments are accepted only for `user_stop`
+     and why the public session state stays `stopping` instead of adding `draining`.
+-->
+
+# Decision: `user_stop` Drains Late Final Segments While `user_cancel` and `fatal_error` Stay Destructive
+
+## Status
+Accepted — March 8, 2026
+
+## Context
+
+Issues `#425` and `#426` exposed two conflicting needs in the stop path:
+
+- normal user stop must preserve the last legitimate provider output
+- cancel and fatal cleanup must still cut the session off immediately
+
+The existing controller published `stopping` and then rejected all later final segments because both the provider callback gate and `commitFinalSegment()` only accepted `active`.
+
+## Decision
+
+The controller now treats only `reason === 'user_stop'` as drain-safe:
+
+- public state remains `stopping`
+- matching late final segments are accepted while the session is `stopping` for `user_stop`
+- fresh audio ingress remains blocked once stop begins
+- `user_cancel` and `fatal_error` remain destructive and do not drain
+- stop publishes `ended` only if the session is still the same `stopping` session after provider stop returns
+- if a provider failure arrives during stop, `failed` wins and must not be overwritten by `ended`
+
+## Consequences
+
+- Stop-time dictation loss is fixed without adding a new public lifecycle state.
+- Renderer/UI contracts do not need a new `draining` state in this PR.
+- Provider adapters can continue to emit late final segments during stop, but only `user_stop` will accept them.
+- Cancel and fatal cleanup behavior remain strict.
+
+## Out of Scope
+
+- Groq stop timeout budgeting
+- Renderer stop handshake and explicit command transport
+- Boot snapshot sync and dead `provider_end` cleanup

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -195,6 +195,166 @@ describe('InMemoryStreamingSessionController', () => {
     })
   })
 
+  it('commits late final segments that arrive while user_stop is draining', async () => {
+    let runtimeCallbacks:
+      | {
+        onFinalSegment: (segment: {
+          sessionId: string
+          sequence: number
+          text: string
+          startedAt: string
+          endedAt: string
+        }) => Promise<void> | void
+      }
+      | undefined
+    const applyStreamingSegmentWithDetail = vi.fn(async (segment: any) => ({
+      status: 'succeeded' as const,
+      message: `${segment.sourceText}${segment.delimiter}`
+    }))
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      outputService: { applyStreamingSegmentWithDetail },
+      createProviderRuntime: ({ callbacks }) => {
+        runtimeCallbacks = callbacks
+        return {
+          start: async () => {},
+          stop: async () => {
+            await runtimeCallbacks?.onFinalSegment({
+              sessionId: 'session-1',
+              sequence: 0,
+              text: 'late words',
+              startedAt: '2026-03-07T00:00:00.000Z',
+              endedAt: '2026-03-07T00:00:01.000Z'
+            })
+          },
+          pushAudioFrameBatch: async () => {}
+        }
+      }
+    })
+    const onSegment = vi.fn()
+    controller.onSegment(onSegment)
+
+    await controller.start(LOCAL_STREAMING_CONFIG)
+    await controller.stop('user_stop')
+
+    expect(applyStreamingSegmentWithDetail).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      sequence: 0,
+      sourceText: 'late words'
+    }), expect.anything())
+    expect(onSegment).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      sequence: 0,
+      text: 'late words'
+    }))
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'ended',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'user_stop'
+    })
+  })
+
+  it('drops late final segments that arrive while user_cancel is stopping', async () => {
+    let runtimeCallbacks:
+      | {
+        onFinalSegment: (segment: {
+          sessionId: string
+          sequence: number
+          text: string
+          startedAt: string
+          endedAt: string
+        }) => Promise<void> | void
+      }
+      | undefined
+    const applyStreamingSegmentWithDetail = vi.fn(async (segment: any) => ({
+      status: 'succeeded' as const,
+      message: `${segment.sourceText}${segment.delimiter}`
+    }))
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      outputService: { applyStreamingSegmentWithDetail },
+      createProviderRuntime: ({ callbacks }) => {
+        runtimeCallbacks = callbacks
+        return {
+          start: async () => {},
+          stop: async () => {
+            await runtimeCallbacks?.onFinalSegment({
+              sessionId: 'session-1',
+              sequence: 0,
+              text: 'discard me',
+              startedAt: '2026-03-07T00:00:00.000Z',
+              endedAt: '2026-03-07T00:00:01.000Z'
+            })
+          },
+          pushAudioFrameBatch: async () => {}
+        }
+      }
+    })
+    const onSegment = vi.fn()
+    controller.onSegment(onSegment)
+
+    await controller.start(LOCAL_STREAMING_CONFIG)
+    await controller.stop('user_cancel')
+
+    expect(applyStreamingSegmentWithDetail).not.toHaveBeenCalled()
+    expect(onSegment).not.toHaveBeenCalled()
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'ended',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'user_cancel'
+    })
+  })
+
+  it('preserves failed terminal state when the provider reports failure during stop', async () => {
+    let runtimeCallbacks:
+      | {
+        onFailure: (failure: { code: string; message: string }) => Promise<void> | void
+      }
+      | undefined
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      createProviderRuntime: ({ callbacks }) => {
+        runtimeCallbacks = callbacks
+        return {
+          start: async () => {},
+          stop: async () => {
+            await runtimeCallbacks?.onFailure({
+              code: 'provider_stop_failed',
+              message: 'Provider stop exploded.'
+            })
+          },
+          pushAudioFrameBatch: async () => {}
+        }
+      }
+    })
+    const onSessionState = vi.fn()
+    controller.onSessionState(onSessionState)
+
+    await controller.start(LOCAL_STREAMING_CONFIG)
+    await controller.stop('user_stop')
+
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual([
+      'starting',
+      'active',
+      'stopping',
+      'failed'
+    ])
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'failed',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'fatal_error'
+    })
+  })
+
   it('commits finalized streaming segments in per-session sequence order', async () => {
     const applyStreamingSegmentWithDetail = vi.fn(async (segment: any) => ({
       status: 'succeeded' as const,

--- a/src/main/services/streaming/streaming-session-controller.ts
+++ b/src/main/services/streaming/streaming-session-controller.ts
@@ -165,10 +165,12 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
       return
     }
 
+    const stoppingSessionId = this.snapshot.sessionId
+    const stoppingConfig = this.currentConfig
     this.publishState({
-      sessionId: this.snapshot.sessionId,
+      sessionId: stoppingSessionId,
       state: 'stopping',
-      config: this.currentConfig,
+      config: stoppingConfig,
       reason
     })
     const providerRuntime = this.currentProviderRuntime
@@ -179,15 +181,20 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
       await this.failCurrentSession(this.toStreamingFailure(error, 'provider_stop_failed'))
       return
     }
+
+    if (this.snapshot.state !== 'stopping' || this.snapshot.sessionId !== stoppingSessionId) {
+      return
+    }
+
     this.publishState({
-      sessionId: this.snapshot.sessionId,
+      sessionId: stoppingSessionId,
       state: 'ended',
-      config: this.currentConfig,
+      config: stoppingConfig,
       reason
     })
     this.currentSegmentRouter?.dispose()
-    if (this.snapshot.sessionId) {
-      this.outputCoordinator.clearScope(this.snapshot.sessionId)
+    if (stoppingSessionId) {
+      this.outputCoordinator.clearScope(stoppingSessionId)
     }
     this.clearCurrentSession()
   }
@@ -202,7 +209,6 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
 
   async commitFinalSegment(segment: ProviderFinalSegmentInput): Promise<OutputApplyResult | null> {
     if (
-      this.snapshot.state !== 'active' ||
       !this.snapshot.sessionId ||
       !this.currentConfig ||
       !this.currentSegmentAssembler ||
@@ -212,6 +218,9 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
     }
     if (segment.sessionId !== this.snapshot.sessionId) {
       throw new Error(`Streaming final segment session mismatch. Expected ${this.snapshot.sessionId}.`)
+    }
+    if (!this.canAcceptFinalSegmentsForSession(segment.sessionId)) {
+      throw new Error('Streaming final segments require an active or drain-safe stopping session.')
     }
 
     const canonicalSegment = this.currentSegmentAssembler.finalize(segment)
@@ -285,7 +294,7 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
   private createProviderRuntimeCallbacks(sessionId: string) {
     return {
       onFinalSegment: async (segment: ProviderFinalSegmentInput) => {
-        if (this.snapshot.state !== 'active' || this.snapshot.sessionId !== sessionId) {
+        if (!this.canAcceptFinalSegmentsForSession(sessionId)) {
           return
         }
         try {
@@ -340,5 +349,13 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
       code,
       message: error instanceof Error ? error.message : String(error)
     }
+  }
+
+  private canAcceptFinalSegmentsForSession(sessionId: string): boolean {
+    if (this.snapshot.sessionId !== sessionId) {
+      return false
+    }
+
+    return this.snapshot.state === 'active' || (this.snapshot.state === 'stopping' && this.snapshot.reason === 'user_stop')
   }
 }

--- a/src/main/test-support/streaming-stop-integration.test.ts
+++ b/src/main/test-support/streaming-stop-integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Where: src/main/test-support/streaming-stop-integration.test.ts
+ * What:  Integration coverage for the streaming stop path across the controller
+ *        and the real Groq rolling-upload adapter.
+ * Why:   SSTP-03 must prove that late stop-time provider output still commits
+ *        before the session ends.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { InMemoryStreamingSessionController } from '../services/streaming/streaming-session-controller'
+import { GroqRollingUploadAdapter } from '../services/streaming/groq-rolling-upload-adapter'
+
+const GROQ_STREAMING_CONFIG = {
+  provider: 'groq_whisper_large_v3_turbo' as const,
+  transport: 'rolling_upload' as const,
+  model: 'whisper-large-v3-turbo',
+  outputMode: 'stream_raw_dictation' as const,
+  maxInFlightTransforms: 2,
+  apiKeyRef: 'groq',
+  language: 'auto' as const,
+  delimiterPolicy: {
+    mode: 'space' as const,
+    value: null
+  },
+  transformationProfile: null
+}
+
+describe('streaming stop integration', () => {
+  it('commits the final Groq stop-time segment before publishing ended', async () => {
+    const applyStreamingSegmentWithDetail = vi.fn(async (segment: any) => ({
+      status: 'succeeded' as const,
+      message: `${segment.sourceText}${segment.delimiter}`
+    }))
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      outputService: { applyStreamingSegmentWithDetail },
+      secretStore: {
+        getApiKey: () => 'test-key'
+      },
+      createProviderRuntime: ({ sessionId, config, callbacks }) =>
+        new GroqRollingUploadAdapter({
+          sessionId,
+          config,
+          callbacks
+        }, {
+          secretStore: { getApiKey: () => 'test-key' },
+          fetchFn: vi.fn(async () => new Response(JSON.stringify({
+            text: 'last words',
+            segments: [
+              {
+                start: 0,
+                end: 1,
+                text: 'last words'
+              }
+            ]
+          }), { status: 200 }))
+        })
+    })
+    const onSessionState = vi.fn()
+    const onSegment = vi.fn()
+    controller.onSessionState(onSessionState)
+    controller.onSegment(onSegment)
+
+    await controller.start(GROQ_STREAMING_CONFIG)
+    await controller.pushAudioFrameBatch({
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: null,
+      frames: [
+        {
+          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
+          timestampMs: 1000
+        }
+      ]
+    })
+    await controller.stop('user_stop')
+
+    expect(applyStreamingSegmentWithDetail).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      sequence: 0,
+      sourceText: 'last words'
+    }), expect.anything())
+    expect(onSegment).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      sequence: 0,
+      text: 'last words'
+    }))
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual([
+      'starting',
+      'active',
+      'stopping',
+      'ended'
+    ])
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'ended',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: 'user_stop'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- keep `user_stop` drain-safe so late final segments can still commit while the session is stopping
- prevent stop-time provider failures from being overwritten by a later `ended` state
- add controller regressions, a Groq-backed stop integration test, and a decision note for the new stop semantics

## Testing
- pnpm vitest run src/main/services/streaming/streaming-session-controller.test.ts
- pnpm vitest run src/main/test-support/streaming-stop-integration.test.ts
- pnpm vitest run src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm vitest run src/main/services/streaming/whispercpp-streaming-adapter.test.ts

## Notes
- this is PR-1 / SSTP-03 from the approved remediation plan
- sub-agent review was unavailable in this worktree session, and Claude CLI review is currently quota-blocked; changes were self-reviewed after the targeted tests passed

## References
- Refs #425
- Refs #426