### PR TITLE
fix: bound groq streaming user stop

### DIFF
--- a/docs/decisions/2026-03-08-groq-user-stop-budget-decision.md
+++ b/docs/decisions/2026-03-08-groq-user-stop-budget-decision.md
@@ -1,0 +1,46 @@
+<!--
+Where: docs/decisions/2026-03-08-groq-user-stop-budget-decision.md
+What: Decision note for bounding Groq `user_stop` with a fixed stop budget.
+Why: Record why the adapter now prefers liveness after a short grace window
+     instead of waiting indefinitely on hung upload or drain work.
+-->
+
+# Decision: Groq `user_stop` Uses a Fixed End-to-End Stop Budget
+
+## Status
+Accepted — March 8, 2026
+
+## Context
+
+Issue `#425` showed that Groq stop could hang indefinitely because `user_stop` waited for all in-flight work to settle with no deadline.
+
+That wait covered:
+
+- active upload requests
+- the adapter's completed-chunk drain loop
+- any callback work triggered while draining
+
+Without a budget, one stalled request could keep the renderer in a permanent stop state.
+
+## Decision
+
+Groq `user_stop` now uses a fixed end-to-end budget of `3000ms`:
+
+- normal fast uploads and drain work are still allowed to finish
+- if the budget expires, the adapter aborts all outstanding requests
+- any undrained completed chunks are discarded
+- `user_cancel` and `fatal_error` remain immediately abortive
+
+The budget is enforced in the adapter, not the controller, because the hang source is adapter-owned upload/drain work.
+
+## Consequences
+
+- Stop liveness wins over perfect final-chunk completeness after the budget expires.
+- Fast final chunks still commit normally.
+- A badly stalled upload can no longer block the whole stop path forever.
+
+## Out of Scope
+
+- Renderer stop handshake
+- Fatal-stop reason transport
+- Controller drain-safe final-segment acceptance

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -229,6 +229,34 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFinalSegment).not.toHaveBeenCalled()
   })
 
+  it('drops buffered audio on user_cancel even before any upload starts', async () => {
+    const fetchFn = vi.fn()
+    const onFinalSegment = vi.fn()
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn
+    })
+
+    await adapter.start()
+    await adapter.pushAudioFrameBatch({
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: null,
+      frames: [{ samples: new Float32Array([0.2, 0.2, 0.2, 0.2]), timestampMs: 0 }]
+    })
+    await adapter.stop('user_cancel')
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(onFinalSegment).not.toHaveBeenCalled()
+  })
+
   it('reports a fatal upload error when all Groq retries are exhausted', async () => {
     const onFailure = vi.fn()
     const fetchFn = vi
@@ -255,5 +283,80 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({
       code: 'groq_chunk_upload_failed'
     }))
+  })
+
+  it('bounds user_stop when an upload never settles', async () => {
+    const seenSignals: AbortSignal[] = []
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async (_input, init) => {
+        if (init?.signal) {
+          seenSignals.push(init.signal)
+        }
+        await new Promise(() => {})
+        return new Response(JSON.stringify({ text: 'never' }), { status: 200 })
+      }),
+      stopBudgetDelayMs: vi.fn(async () => {})
+    })
+
+    await adapter.start()
+    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
+    await adapter.stop('user_stop')
+
+    expect(seenSignals).toHaveLength(1)
+    expect(seenSignals[0]?.aborted).toBe(true)
+  })
+
+  it('cuts off the remaining drain tail when user_stop budget expires mid-drain', async () => {
+    let releaseFirstSegment: (() => void) | null = null
+    let releaseStopBudget: (() => void) | null = null
+    const onFinalSegment = vi.fn(async (segment: { text: string }) => {
+      if (segment.text === 'hello') {
+        releaseStopBudget?.()
+        await new Promise<void>((resolve) => {
+          releaseFirstSegment = resolve
+        })
+      }
+    })
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({
+        text: 'hello world',
+        segments: [
+          { start: 0, end: 0.5, text: 'hello' },
+          { start: 0.5, end: 1.0, text: 'world' }
+        ]
+      }), { status: 200 })),
+      stopBudgetDelayMs: vi.fn(() => new Promise<void>((resolve) => {
+        releaseStopBudget = resolve
+      }))
+    })
+
+    await adapter.start()
+    await adapter.pushAudioFrameBatch(makeBatch({
+      startMs: 1000,
+      flushReason: 'speech_pause'
+    }))
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment).toHaveBeenCalledTimes(1)
+    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'hello'
+    }))
+    releaseFirstSegment?.()
   })
 })

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -38,6 +38,7 @@ export interface GroqRollingUploadAdapterDependencies {
   secretStore: Pick<SecretStore, 'getApiKey'>
   fetchFn?: typeof fetch
   delayMs?: (ms: number) => Promise<void>
+  stopBudgetDelayMs?: (ms: number) => Promise<void>
   chunkWindowPolicy?: ChunkWindowPolicy
 }
 
@@ -71,11 +72,13 @@ interface CompletedChunkUpload {
 
 const GROQ_DEFAULT_BASE = 'https://api.groq.com'
 const GROQ_STT_PATH = '/openai/v1/audio/transcriptions'
+const GROQ_USER_STOP_BUDGET_MS = 3_000
 
 export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private readonly secretStore: Pick<SecretStore, 'getApiKey'>
   private readonly fetchFn: typeof fetch
   private readonly delayMs: (ms: number) => Promise<void>
+  private readonly stopBudgetDelayMs: (ms: number) => Promise<void>
   private readonly chunkWindowPolicy: ChunkWindowPolicy
   private readonly currentChunkFrames: StreamingAudioFrame[] = []
   private currentSampleRateHz = 0
@@ -87,6 +90,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private readonly inFlightChunkPromises = new Map<number, Promise<void>>()
   private readonly abortControllers = new Map<number, AbortController>()
   private drainingCompletedChunks = false
+  private stopDrainTimedOut = false
   private stopped = false
   private lastCommittedEndedAtMs = Number.NEGATIVE_INFINITY
   private lastCommittedTextTail = ''
@@ -98,6 +102,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.secretStore = dependencies.secretStore
     this.fetchFn = dependencies.fetchFn ?? fetch
     this.delayMs = dependencies.delayMs ?? (async (ms) => await new Promise((resolve) => setTimeout(resolve, ms)))
+    this.stopBudgetDelayMs =
+      dependencies.stopBudgetDelayMs ?? (async (ms) => await new Promise((resolve) => setTimeout(resolve, ms)))
     this.chunkWindowPolicy = dependencies.chunkWindowPolicy ?? DEFAULT_GROQ_CHUNK_WINDOW_POLICY
   }
 
@@ -113,16 +119,11 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
   async stop(reason: StreamingSessionStopReason): Promise<void> {
     this.stopped = true
+    this.stopDrainTimedOut = false
 
-    if ((reason === 'user_cancel' || reason === 'fatal_error') && this.abortControllers.size > 0) {
-      for (const controller of this.abortControllers.values()) {
-        controller.abort()
-      }
-      this.abortControllers.clear()
-      this.inFlightChunkPromises.clear()
-      this.completedChunks.clear()
-      this.currentChunkFrames.length = 0
-      this.carryoverFrames = []
+    if (reason === 'user_cancel' || reason === 'fatal_error') {
+      this.abortOutstandingUploads()
+      this.clearPendingStopBuffers()
       return
     }
 
@@ -130,8 +131,24 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       this.scheduleChunkUpload('session_stop')
     }
 
-    await Promise.allSettled(this.inFlightChunkPromises.values())
-    await this.drainCompletedChunks()
+    const finishStopDrainPromise = this.finishStopDrain().catch((error) => {
+      if (this.stopDrainTimedOut) {
+        return
+      }
+      throw error
+    })
+    const outcome = await Promise.race([
+      finishStopDrainPromise.then(() => 'completed' as const),
+      this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
+    ])
+    if (outcome === 'timed_out') {
+      this.stopDrainTimedOut = true
+      this.abortOutstandingUploads()
+      this.clearPendingStopBuffers()
+      return
+    }
+
+    await finishStopDrainPromise
   }
 
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {
@@ -240,6 +257,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       }
 
       const data = (await response.json()) as GroqVerboseResponse
+      if (this.stopDrainTimedOut) {
+        return
+      }
       this.completedChunks.set(chunk.chunkIndex, {
         chunkIndex: chunk.chunkIndex,
         flushReason: chunk.flushReason,
@@ -261,7 +281,15 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.drainingCompletedChunks = true
     let shouldDrainAgain = false
     try {
+      if (this.stopDrainTimedOut) {
+        this.completedChunks.clear()
+        return
+      }
       while (this.completedChunks.has(this.nextChunkIndexToEmit)) {
+        if (this.stopDrainTimedOut) {
+          this.completedChunks.clear()
+          return
+        }
         const completedChunk = this.completedChunks.get(this.nextChunkIndexToEmit)
         this.completedChunks.delete(this.nextChunkIndexToEmit)
         this.nextChunkIndexToEmit += 1
@@ -271,6 +299,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
         const segments = this.buildFinalSegments(completedChunk)
         for (const segment of segments) {
+          if (this.stopDrainTimedOut) {
+            return
+          }
           await this.params.callbacks.onFinalSegment(segment)
         }
       }
@@ -349,12 +380,34 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.lastCommittedTextTail = nextTail.slice(-160)
   }
 
+  private async finishStopDrain(): Promise<void> {
+    await Promise.allSettled(this.inFlightChunkPromises.values())
+    if (this.stopDrainTimedOut) {
+      return
+    }
+    await this.drainCompletedChunks()
+  }
+
   private requireApiKey(): string {
     const apiKey = this.secretStore.getApiKey('groq')
     if (!apiKey) {
       throw new Error('Groq rolling upload requires a saved Groq API key.')
     }
     return apiKey
+  }
+
+  private abortOutstandingUploads(): void {
+    for (const controller of this.abortControllers.values()) {
+      controller.abort()
+    }
+    this.abortControllers.clear()
+    this.inFlightChunkPromises.clear()
+  }
+
+  private clearPendingStopBuffers(): void {
+    this.completedChunks.clear()
+    this.currentChunkFrames.length = 0
+    this.carryoverFrames = []
   }
 }
 

--- a/src/main/test-support/streaming-groq-stop-budget.test.ts
+++ b/src/main/test-support/streaming-groq-stop-budget.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Where: src/main/test-support/streaming-groq-stop-budget.test.ts
+ * What:  Integration coverage for the bounded Groq user_stop path.
+ * Why:   SSTP-04 must prove that a hung Groq upload no longer blocks the full
+ *        controller stop path forever.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { InMemoryStreamingSessionController } from '../services/streaming/streaming-session-controller'
+import { GroqRollingUploadAdapter } from '../services/streaming/groq-rolling-upload-adapter'
+
+const GROQ_STREAMING_CONFIG = {
+  provider: 'groq_whisper_large_v3_turbo' as const,
+  transport: 'rolling_upload' as const,
+  model: 'whisper-large-v3-turbo',
+  outputMode: 'stream_raw_dictation' as const,
+  maxInFlightTransforms: 2,
+  apiKeyRef: 'groq',
+  language: 'auto' as const,
+  delimiterPolicy: {
+    mode: 'space' as const,
+    value: null
+  },
+  transformationProfile: null
+}
+
+describe('streaming Groq stop budget integration', () => {
+  it('lets the controller finish user_stop even when the active upload hangs', async () => {
+    const seenSignals: AbortSignal[] = []
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      secretStore: {
+        getApiKey: () => 'test-key'
+      },
+      createProviderRuntime: ({ sessionId, config, callbacks }) =>
+        new GroqRollingUploadAdapter({
+          sessionId,
+          config,
+          callbacks
+        }, {
+          secretStore: { getApiKey: () => 'test-key' },
+          fetchFn: vi.fn(async (_input, init) => {
+            if (init?.signal) {
+              seenSignals.push(init.signal)
+            }
+            await new Promise(() => {})
+            return new Response(JSON.stringify({ text: 'never' }), { status: 200 })
+          }),
+          stopBudgetDelayMs: vi.fn(async () => {})
+        })
+    })
+    const onSessionState = vi.fn()
+    controller.onSessionState(onSessionState)
+
+    await controller.start(GROQ_STREAMING_CONFIG)
+    await controller.pushAudioFrameBatch({
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: 'speech_pause',
+      frames: [
+        {
+          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
+          timestampMs: 1000
+        }
+      ]
+    })
+    await controller.stop('user_stop')
+
+    expect(seenSignals).toHaveLength(1)
+    expect(seenSignals[0]?.aborted).toBe(true)
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual([
+      'starting',
+      'active',
+      'stopping',
+      'ended'
+    ])
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'ended',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: 'user_stop'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- bound Groq `user_stop` with a fixed end-to-end stop budget
- abort stalled upload work and discard undrained completed chunks after the budget expires
- keep `user_cancel` and `fatal_error` destructive, including the buffered-audio case
- add adapter regressions, a controller-level stop-budget integration test, and a decision note

## Verification
- pnpm vitest run src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm vitest run src/main/test-support/streaming-groq-stop-budget.test.ts
- pnpm vitest run src/main/services/streaming/streaming-session-controller.test.ts

## References
- Refs #425