### PR TITLE
fix: scope renderer streaming stop to session

### DIFF
--- a/docs/decisions/2026-03-08-renderer-session-scoped-stop-decision.md
+++ b/docs/decisions/2026-03-08-renderer-session-scoped-stop-decision.md
@@ -1,0 +1,35 @@
+<!--
+Where: docs/decisions/2026-03-08-renderer-session-scoped-stop-decision.md
+What: Decision record for session-scoped renderer stop handling in the streaming renderer runtime.
+Why: Preserve the contract established in SSTP-01 while locking the renderer-side stale-command and stale-terminal-event behavior for SSTP-02.
+-->
+
+# Decision: Renderer Stop Handling Is Scoped to the Active Streaming Session
+
+Date: 2026-03-08
+Ticket: `SSTP-02`
+PR: `PR-4`
+
+## Context
+
+`SSTP-01` added explicit streaming start/stop command variants and a bounded stop acknowledgement path. That removed the old raw `toggleRecording` ambiguity, but the renderer could still mis-handle delayed commands and delayed terminal session events because local teardown logic was not yet scoped to the active streaming `sessionId`.
+
+## Decision
+
+The renderer now treats the locally active streaming `sessionId` as the authority for stop/cancel execution and terminal capture teardown.
+
+- explicit `streaming_stop_requested` commands are ignored when they do not match the active local session
+- terminal `ended` / `failed` snapshots are ignored when they target an older session than the active local capture
+- stop acknowledgement is emitted at most once for the matching local session
+- a new streaming session clears the prior handled-stop marker
+
+## Rationale
+
+- A delayed stop for an old session must never stop a newer capture.
+- A delayed terminal event for an old session must never cancel the current capture.
+- Duplicate stop requests should not produce duplicate acknowledgements because main already has a timeout fallback.
+
+## Trade-offs
+
+- Renderer state becomes slightly more explicit because local stop handling now keeps a handled-stop marker in addition to the active session id.
+- If renderer state ever loses the active session id entirely, a stale stop request is ignored and main falls back to the bounded timeout path instead of forcing a potentially wrong stop.

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -277,6 +277,76 @@ describe('handleRecordingCommandDispatch', () => {
     expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('recording_stopped')
   })
 
+  it('ignores stale streaming stop requests for an older session', async () => {
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'local_whispercpp_coreml'
+    state.settings.processing.streaming.transport = 'native_stream'
+    state.settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    state.streamingSessionState = {
+      sessionId: 'session-live',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-live',
+      preferredDeviceId: 'mic-1'
+    })
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_stop_requested',
+      sessionId: 'session-stale',
+      reason: 'user_stop'
+    })
+
+    expect(audioContextCloseMock).not.toHaveBeenCalled()
+    expect(window.speechToTextApi.ackStreamingRendererStop).not.toHaveBeenCalled()
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledTimes(1)
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('recording_started')
+  })
+
+  it('acknowledges a matching stop request at most once', async () => {
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'local_whispercpp_coreml'
+    state.settings.processing.streaming.transport = 'native_stream'
+    state.settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    state.streamingSessionState = {
+      sessionId: 'session-ack-once',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-ack-once',
+      preferredDeviceId: 'mic-1'
+    })
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_stop_requested',
+      sessionId: 'session-ack-once',
+      reason: 'user_stop'
+    })
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_stop_requested',
+      sessionId: 'session-ack-once',
+      reason: 'user_stop'
+    })
+
+    expect(window.speechToTextApi.ackStreamingRendererStop).toHaveBeenCalledTimes(1)
+  })
+
   it('cancels live streaming capture when the main session fails', async () => {
     const { deps, state } = createDeps()
     state.settings = structuredClone(DEFAULT_SETTINGS)
@@ -285,8 +355,20 @@ describe('handleRecordingCommandDispatch', () => {
     state.settings.processing.streaming.provider = 'local_whispercpp_coreml'
     state.settings.processing.streaming.transport = 'native_stream'
     state.settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    state.streamingSessionState = {
+      sessionId: 'session-1',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    }
 
-    await handleRecordingCommandDispatch(deps, { command: 'toggleRecording' })
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-1',
+      preferredDeviceId: 'mic-1'
+    })
     await handleStreamingSessionStateUpdate(deps, {
       sessionId: 'session-1',
       state: 'failed',
@@ -300,6 +382,40 @@ describe('handleRecordingCommandDispatch', () => {
     expect(deps.addToast).toHaveBeenCalledTimes(1)
     expect(deps.addToast).toHaveBeenLastCalledWith('Recording started.', 'success')
     expect(state.hasCommandError).toBe(true)
+  })
+
+  it('ignores terminal session updates for a stale session while a newer capture is active', async () => {
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'local_whispercpp_coreml'
+    state.settings.processing.streaming.transport = 'native_stream'
+    state.settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    state.streamingSessionState = {
+      sessionId: 'session-current',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-current',
+      preferredDeviceId: 'mic-1'
+    })
+    await handleStreamingSessionStateUpdate(deps, {
+      sessionId: 'session-old',
+      state: 'ended',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'user_stop'
+    })
+
+    expect(audioContextCloseMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -30,6 +30,7 @@ const recorderState = {
   mediaStream: null as MediaStream | null,
   streamingCapture: null as StreamingLiveCapture | null,
   streamingSessionId: null as string | null,
+  lastHandledStreamingStopSessionId: null as string | null,
   chunks: [] as BlobPart[],
   shouldPersistOnStop: true,
   startedAt: '' as string
@@ -42,6 +43,7 @@ export const resetRecordingState = (): void => {
   recorderState.mediaStream = null
   recorderState.streamingCapture = null
   recorderState.streamingSessionId = null
+  recorderState.lastHandledStreamingStopSessionId = null
   recorderState.chunks = []
   recorderState.shouldPersistOnStop = true
   recorderState.startedAt = ''
@@ -367,6 +369,7 @@ export const startNativeRecording = async (
 
   if (isStreamingMode) {
     recorderState.streamingSessionId = streamingSessionId ?? null
+    recorderState.lastHandledStreamingStopSessionId = null
     try {
       recorderState.streamingCapture = await startStreamingLiveCapture({
         deviceConstraints: constraints.audio as MediaTrackConstraints,
@@ -495,11 +498,23 @@ const notifyIdleRecordingCommand = (deps: NativeRecordingDeps): void => {
   deps.addToast('Recording is not in progress.', 'info')
 }
 
+const resolveActiveStreamingSessionId = (state: RecordingMutableState): string | null =>
+  recorderState.streamingSessionId ?? state.streamingSessionState.sessionId
+
+const isMatchingStreamingSession = (state: RecordingMutableState, sessionId: string): boolean =>
+  resolveActiveStreamingSessionId(state) === sessionId
+
 export const handleStreamingSessionStateUpdate = async (
   deps: NativeRecordingDeps,
   snapshot: StreamingSessionStateSnapshot
 ): Promise<void> => {
   if (!recorderState.streamingCapture) {
+    return
+  }
+  if (!snapshot.sessionId) {
+    return
+  }
+  if (!isMatchingStreamingSession(deps.state, snapshot.sessionId)) {
     return
   }
 
@@ -535,6 +550,14 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
   const { state, addToast, logError, onStateChange } = deps
   if ('kind' in dispatch) {
     if (dispatch.kind === 'streaming_start') {
+      const canStartSession =
+        state.streamingSessionState.sessionId === null ||
+        (state.streamingSessionState.sessionId === dispatch.sessionId &&
+          (state.streamingSessionState.state === 'starting' || state.streamingSessionState.state === 'active'))
+      if (!canStartSession) {
+        return
+      }
+
       try {
         if (isNativeRecording()) {
           return
@@ -558,7 +581,14 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       return
     }
 
-    const currentSessionId = recorderState.streamingSessionId ?? deps.state.streamingSessionState.sessionId ?? dispatch.sessionId
+    const currentSessionId = resolveActiveStreamingSessionId(deps.state)
+    if (currentSessionId !== dispatch.sessionId) {
+      return
+    }
+    if (recorderState.lastHandledStreamingStopSessionId === dispatch.sessionId) {
+      return
+    }
+
     let shouldAcknowledge = true
     try {
       if (isNativeRecording()) {
@@ -587,7 +617,8 @@ export const handleRecordingCommandDispatch = async (deps: NativeRecordingDeps, 
       addToast(`${dispatch.kind} failed: ${message}`, 'error')
     } finally {
       if (shouldAcknowledge) {
-        void acknowledgeStreamingRendererStop(logError, currentSessionId, dispatch.reason)
+        recorderState.lastHandledStreamingStopSessionId = dispatch.sessionId
+        void acknowledgeStreamingRendererStop(logError, dispatch.sessionId, dispatch.reason)
       }
       onStateChange()
     }


### PR DESCRIPTION
## Summary
- make renderer streaming stop and terminal teardown obey the active local streaming session id
- ignore stale streaming stop requests and stale terminal session updates for older sessions
- emit stop acknowledgement at most once per matching session and document the renderer-side decision

## Testing
- pnpm typecheck
- pnpm vitest run src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts src/renderer/streaming-live-capture.test.ts src/renderer/streaming-audio-ingress.test.ts

## Review Notes
- sub-agent review was attempted but the agent was interrupted before returning findings
- Claude second-pass review was attempted under a hard timeout and exited with code 124 before producing output