### PR TITLE
fix: recover streaming UI pending state

### DIFF
--- a/docs/decisions/2026-03-08-streaming-ui-pending-state-decision.md
+++ b/docs/decisions/2026-03-08-streaming-ui-pending-state-decision.md
@@ -1,0 +1,36 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-ui-pending-state-decision.md
+What: Decision record for streaming-specific pending-state recovery in the renderer UI.
+Why: Capture why Home processing state now follows streaming lifecycle truth instead of relying only on the recording command promise.
+-->
+
+# Decision: Streaming UI Pending State Follows Lifecycle Truth
+
+Date: 2026-03-08
+Ticket: `SSTP-05`
+PR: `PR-5`
+
+## Context
+
+The Home UI previously treated `pendingActionId` as the source of truth for `Processing...`. That worked for batch recording, but in streaming mode the renderer can receive terminal lifecycle truth before the original `runRecordingCommand()` promise settles. When that happened, the UI could remain stuck on `Processing...` even though the session had already ended or failed.
+
+## Decision
+
+Streaming mode now uses renderer-specific pending state:
+
+- a short-lived streaming command token covers the gap before lifecycle snapshots arrive
+- a `pendingStreamingSessionId` tracks the active streaming session while lifecycle truth is non-terminal
+- terminal snapshots and local fatal cleanup clear streaming pending state directly
+- batch mode keeps using `pendingActionId`
+
+## Rationale
+
+- The UI should leave `Processing...` when streaming lifecycle truth says the session is terminal, regardless of whether the original IPC promise has resolved.
+- Streaming state is session-scoped, so the pending UI model also needs to be session-scoped.
+- Keeping batch `pendingActionId` unchanged avoids unnecessary churn outside the streaming path.
+
+## Trade-offs
+
+- Renderer state gains a small amount of streaming-only bookkeeping.
+- The app shell now derives streaming processing state instead of letting `HomeReact` infer it from `pendingActionId` alone.
+- Late promise completions still exist, but they can no longer re-stick the streaming UI once lifecycle truth has cleared the session-scoped pending state.

--- a/src/renderer/app-shell-react.test.tsx
+++ b/src/renderer/app-shell-react.test.tsx
@@ -44,6 +44,8 @@ const buildState = (overrides: Partial<AppShellState> = {}): AppShellState => ({
   apiKeyStatus: readyStatus,
   apiKeySaveStatus: { groq: '', elevenlabs: '', google: '' },
   pendingActionId: null,
+  pendingStreamingSessionId: null,
+  pendingStreamingCommandToken: null,
   hasCommandError: false,
   audioInputSources: [],
   audioSourceHint: '',

--- a/src/renderer/app-shell-react.tsx
+++ b/src/renderer/app-shell-react.tsx
@@ -92,6 +92,8 @@ export interface AppShellState {
   apiKeyStatus: ApiKeyStatusSnapshot
   apiKeySaveStatus: Record<ApiKeyProvider, string>
   pendingActionId: string | null
+  pendingStreamingSessionId: string | null
+  pendingStreamingCommandToken: number | null
   hasCommandError: boolean
   audioInputSources: AudioInputSource[]
   audioSourceHint: string
@@ -216,6 +218,9 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
   }
 
   const isRecording = callbacks.isNativeRecording()
+  const isStreamingPending =
+    uiState.settings?.processing.mode === 'streaming' &&
+    (uiState.pendingStreamingCommandToken !== null || (uiState.pendingStreamingSessionId !== null && !isRecording))
   const isStreamingSettingsLocked =
     uiState.streamingSessionState.state === 'starting' ||
     uiState.streamingSessionState.state === 'active' ||
@@ -281,7 +286,7 @@ export const AppShell = ({ state: uiState, callbacks }: AppShellProps) => {
           <HomeReact
             settings={uiState.settings}
             apiKeyStatus={uiState.apiKeyStatus}
-            pendingActionId={uiState.pendingActionId}
+            isProcessing={isStreamingPending || (uiState.pendingActionId !== null && !isRecording)}
             hasCommandError={uiState.hasCommandError}
             isRecording={isRecording}
             onRunRecordingCommand={(command: RecordingCommand) => {

--- a/src/renderer/home-react.test.tsx
+++ b/src/renderer/home-react.test.tsx
@@ -43,7 +43,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={readyStatus}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={false}
         onRunRecordingCommand={vi.fn()}
@@ -77,7 +77,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={readyStatus}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={true}
         onRunRecordingCommand={vi.fn()}
@@ -107,7 +107,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={readyStatus}
-        pendingActionId="recording:toggleRecording"
+        isProcessing={true}
         hasCommandError={false}
         isRecording={false}
         onRunRecordingCommand={vi.fn()}
@@ -133,7 +133,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={readyStatus}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={false}
         onRunRecordingCommand={onRunRecordingCommand}
@@ -156,7 +156,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={readyStatus}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={true}
         onRunRecordingCommand={onRunRecordingCommand}
@@ -179,7 +179,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={readySettings}
         apiKeyStatus={{ groq: false, elevenlabs: false, google: false }}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={false}
         onRunRecordingCommand={vi.fn()}
@@ -221,7 +221,7 @@ describe('HomeReact recording button (STY-03)', () => {
       <HomeReact
         settings={settings}
         apiKeyStatus={{ groq: true, elevenlabs: true, google: false }}
-        pendingActionId={null}
+        isProcessing={false}
         hasCommandError={false}
         isRecording={false}
         onRunRecordingCommand={vi.fn()}

--- a/src/renderer/home-react.tsx
+++ b/src/renderer/home-react.tsx
@@ -23,7 +23,7 @@ import { cn } from './lib/utils'
 interface HomeReactProps {
   settings: Settings
   apiKeyStatus: ApiKeyStatusSnapshot
-  pendingActionId: string | null
+  isProcessing: boolean
   hasCommandError: boolean
   isRecording: boolean
   onRunRecordingCommand: (command: RecordingCommand) => void
@@ -46,7 +46,7 @@ const formatTimer = (seconds: number): string => {
 export const HomeReact = ({
   settings,
   apiKeyStatus,
-  pendingActionId,
+  isProcessing,
   hasCommandError: _hasCommandError,
   isRecording,
   onRunRecordingCommand,
@@ -55,8 +55,6 @@ export const HomeReact = ({
   const recordingBlocked = resolveRecordingBlockedMessage(settings, apiKeyStatus)
 
   // Determine recording state: idle | recording | processing
-  // Processing = a pending action exists but not yet recording (e.g. toggling or cancelling)
-  const isProcessing = pendingActionId !== null && !isRecording
   const isIdle = !isRecording && !isProcessing
 
   // Recording timer — counts up every second while isRecording is true

--- a/src/renderer/home-status.test.ts
+++ b/src/renderer/home-status.test.ts
@@ -5,7 +5,7 @@ describe('resolveHomeCommandStatus', () => {
   it('returns Busy when an action is pending', () => {
     expect(
       resolveHomeCommandStatus({
-        pendingActionId: 'recording:toggleRecording',
+        isProcessing: true,
         isRecording: true,
         hasCommandError: true
       })
@@ -15,7 +15,7 @@ describe('resolveHomeCommandStatus', () => {
   it('returns Recording when active recording is in progress and no pending action', () => {
     expect(
       resolveHomeCommandStatus({
-        pendingActionId: null,
+        isProcessing: false,
         isRecording: true,
         hasCommandError: false
       })
@@ -25,7 +25,7 @@ describe('resolveHomeCommandStatus', () => {
   it('returns Error when there is no pending action/recording but latest command failed', () => {
     expect(
       resolveHomeCommandStatus({
-        pendingActionId: null,
+        isProcessing: false,
         isRecording: false,
         hasCommandError: true
       })
@@ -35,7 +35,7 @@ describe('resolveHomeCommandStatus', () => {
   it('returns Idle when there is no pending action, recording, or command error', () => {
     expect(
       resolveHomeCommandStatus({
-        pendingActionId: null,
+        isProcessing: false,
         isRecording: false,
         hasCommandError: false
       })

--- a/src/renderer/home-status.ts
+++ b/src/renderer/home-status.ts
@@ -3,7 +3,7 @@
 // Why: Keeps 4-state badge logic deterministic and testable.
 
 export interface HomeCommandStatusInput {
-  pendingActionId: string | null
+  isProcessing: boolean
   isRecording: boolean
   hasCommandError: boolean
 }
@@ -14,7 +14,7 @@ export interface HomeCommandStatusView {
 }
 
 export const resolveHomeCommandStatus = (input: HomeCommandStatusInput): HomeCommandStatusView => {
-  if (input.pendingActionId !== null) {
+  if (input.isProcessing) {
     return { label: 'Busy', cssClass: 'is-busy' }
   }
   if (input.isRecording) {

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -25,6 +25,8 @@ const createDeps = (): { deps: NativeRecordingDeps; state: NativeRecordingDeps['
     audioSourceHint: '',
     hasCommandError: true,
     pendingActionId: 'recording:cancelRecording',
+    pendingStreamingSessionId: null,
+    pendingStreamingCommandToken: null,
     streamingSessionState: {
       sessionId: null,
       state: 'idle',

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -59,6 +59,8 @@ export type RecordingMutableState = {
   audioSourceHint: string
   hasCommandError: boolean
   pendingActionId: string | null
+  pendingStreamingSessionId: string | null
+  pendingStreamingCommandToken: number | null
   streamingSessionState: StreamingSessionStateSnapshot
 }
 
@@ -382,6 +384,8 @@ export const startNativeRecording = async (
           deps.logError('renderer.streaming_capture_failed', error)
           recorderState.streamingCapture = null
           state.hasCommandError = true
+          state.pendingStreamingSessionId = null
+          state.pendingStreamingCommandToken = null
           deps.addToast(`Streaming capture failed: ${message}`, 'error')
           deps.onStateChange()
           if (!sessionId) {

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -75,6 +75,9 @@ const state = {
   } as Record<ApiKeyProvider, string>,
   activity: [] as ActivityItem[],
   pendingActionId: null as string | null,
+  pendingStreamingSessionId: null as string | null,
+  pendingStreamingCommandToken: null as number | null,
+  pendingStreamingCommandCounter: 0,
   activityCounter: 0,
   toasts: [] as ToastItem[],
   toastCounter: 0,
@@ -465,6 +468,19 @@ const applyStreamingSessionState = (snapshot: StreamingSessionStateSnapshot): vo
     state.seenStreamingSegmentKeys.clear()
   }
 
+  if (snapshot.sessionId && (snapshot.state === 'starting' || snapshot.state === 'active' || snapshot.state === 'stopping')) {
+    state.pendingStreamingSessionId = snapshot.sessionId
+    state.pendingStreamingCommandToken = null
+  }
+  if (
+    snapshot.sessionId &&
+    (snapshot.state === 'ended' || snapshot.state === 'failed') &&
+    state.pendingStreamingSessionId === snapshot.sessionId
+  ) {
+    state.pendingStreamingSessionId = null
+    state.pendingStreamingCommandToken = null
+  }
+
   const didStateChange =
     previous.sessionId !== snapshot.sessionId ||
     previous.state !== snapshot.state ||
@@ -505,6 +521,35 @@ const applyStreamingError = (error: StreamingErrorEvent): void => {
 }
 
 const runRecordingCommandAction = async (command: Parameters<typeof window.speechToTextApi.runRecordingCommand>[0]): Promise<void> => {
+  if (state.settings?.processing.mode === 'streaming') {
+    if (state.pendingStreamingCommandToken !== null) {
+      return
+    }
+
+    const commandToken = ++state.pendingStreamingCommandCounter
+    state.pendingStreamingCommandToken = commandToken
+    if (state.streamingSessionState.sessionId) {
+      state.pendingStreamingSessionId = state.streamingSessionState.sessionId
+    }
+    state.hasCommandError = false
+    rerenderShellFromState()
+    try {
+      await window.speechToTextApi.runRecordingCommand(command)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown recording error'
+      logRendererError('renderer.recording_dispatch_failed', error, { command })
+      state.hasCommandError = true
+      state.pendingStreamingSessionId = null
+      addToast(`${command} failed: ${message}`, 'error')
+    } finally {
+      if (state.pendingStreamingCommandToken === commandToken) {
+        state.pendingStreamingCommandToken = null
+      }
+      rerenderShellFromState()
+    }
+    return
+  }
+
   if (state.pendingActionId !== null) {
     return
   }
@@ -842,6 +887,9 @@ export const stopRendererAppForTests = (): void => {
   state.apiKeySaveStatus = { groq: '', elevenlabs: '', google: '' }
   state.activity = []
   state.pendingActionId = null
+  state.pendingStreamingSessionId = null
+  state.pendingStreamingCommandToken = null
+  state.pendingStreamingCommandCounter = 0
   state.activityCounter = 0
   state.toasts = []
   state.toastCounter = 0

--- a/src/renderer/streaming-ui-state.integration.test.tsx
+++ b/src/renderer/streaming-ui-state.integration.test.tsx
@@ -1,0 +1,180 @@
+/*
+Where: src/renderer/streaming-ui-state.integration.test.tsx
+What: Integration-style renderer tests for streaming pending-state recovery.
+Why: Prove the Home UI leaves Processing when lifecycle truth goes terminal,
+     even if the original recording command promise never resolves.
+*/
+
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  CompositeTransformResult,
+  HotkeyErrorNotification,
+  IpcApi,
+  RecordingCommandDispatch,
+  StreamingErrorEvent,
+  StreamingSegmentEvent,
+  StreamingSessionStateSnapshot
+} from '../shared/ipc'
+import { DEFAULT_SETTINGS } from '../shared/domain'
+import { startRendererApp, stopRendererAppForTests } from './renderer-app'
+
+const flush = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+
+const waitForCondition = async (label: string, condition: () => boolean, attempts = 30): Promise<void> => {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    await flush()
+    if (condition()) {
+      return
+    }
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+const streamingSettings = (() => {
+  const settings = structuredClone(DEFAULT_SETTINGS)
+  settings.processing.mode = 'streaming'
+  settings.processing.streaming.enabled = true
+  settings.processing.streaming.provider = 'local_whispercpp_coreml'
+  settings.processing.streaming.transport = 'native_stream'
+  settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+  settings.processing.streaming.outputMode = 'stream_raw_dictation'
+  return settings
+})()
+
+const buildHarness = (): {
+  api: IpcApi
+  emitStreamingSessionState: (snapshot: StreamingSessionStateSnapshot) => void
+} => {
+  let onStreamingSessionStateListener: ((snapshot: StreamingSessionStateSnapshot) => void) | null = null
+
+  const api: IpcApi = {
+    ping: async () => 'pong',
+    getSettings: async () => structuredClone(streamingSettings),
+    setSettings: async (settings) => settings,
+    getApiKeyStatus: async () => ({ groq: true, elevenlabs: true, google: true }),
+    setApiKey: async () => {},
+    deleteApiKey: async () => {},
+    testApiKeyConnection: async (provider) => ({
+      provider,
+      status: 'success',
+      message: 'ok'
+    }),
+    getHistory: async () => [],
+    getAudioInputSources: async () => [],
+    playSound: async () => {},
+    runRecordingCommand: async () => await new Promise<void>(() => {}),
+    submitRecordedAudio: async () => {},
+    startStreamingSession: async () => {},
+    stopStreamingSession: async (_request) => {},
+    ackStreamingRendererStop: async (_ack) => {},
+    pushStreamingAudioFrameBatch: async () => {},
+    onRecordingCommand: (_listener: (dispatch: RecordingCommandDispatch) => void) => () => {},
+    onStreamingSessionState: (listener: (state: StreamingSessionStateSnapshot) => void) => {
+      onStreamingSessionStateListener = listener
+      return () => {
+        onStreamingSessionStateListener = null
+      }
+    },
+    onStreamingSegment: (_listener: (segment: StreamingSegmentEvent) => void) => () => {},
+    onStreamingError: (_listener: (error: StreamingErrorEvent) => void) => () => {},
+    runPickTransformationFromClipboard: async () => {},
+    onCompositeTransformStatus: (_listener: (result: CompositeTransformResult) => void) => () => {},
+    onHotkeyError: (_listener: (notification: HotkeyErrorNotification) => void) => () => {},
+    onSettingsUpdated: (_listener: () => void) => () => {},
+    onOpenSettings: (_listener: () => void) => () => {}
+  }
+
+  return {
+    api,
+    emitStreamingSessionState: (snapshot) => {
+      if (!onStreamingSessionStateListener) {
+        throw new Error('Streaming session listener is not registered.')
+      }
+      onStreamingSessionStateListener(snapshot)
+    }
+  }
+}
+
+afterEach(() => {
+  stopRendererAppForTests()
+  document.body.innerHTML = ''
+})
+
+describe('streaming UI pending-state recovery', () => {
+  it('returns Home from Processing to Error when a failed session snapshot arrives', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const harness = buildHarness()
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForCondition('renderer boot', () => mountPoint.querySelector('[data-route-tab="activity"]') !== null)
+
+    mountPoint.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')?.click()
+    await waitForCondition('processing state', () => (mountPoint.textContent ?? '').includes('Processing...'))
+
+    harness.emitStreamingSessionState({
+      sessionId: 'session-ui-failed',
+      state: 'starting',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    })
+    harness.emitStreamingSessionState({
+      sessionId: 'session-ui-failed',
+      state: 'failed',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'fatal_error'
+    })
+
+    await waitForCondition('processing clears after failed snapshot', () => !(mountPoint.textContent ?? '').includes('Processing...'))
+    expect(mountPoint.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')?.disabled).toBe(false)
+  })
+
+  it('returns Home from Processing to idle when an ended session snapshot arrives', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const harness = buildHarness()
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForCondition('renderer boot', () => mountPoint.querySelector('[data-route-tab="activity"]') !== null)
+
+    mountPoint.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')?.click()
+    await waitForCondition('processing state', () => (mountPoint.textContent ?? '').includes('Processing...'))
+
+    harness.emitStreamingSessionState({
+      sessionId: 'session-ui-ended',
+      state: 'starting',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    })
+    harness.emitStreamingSessionState({
+      sessionId: 'session-ui-ended',
+      state: 'ended',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'user_stop'
+    })
+
+    await waitForCondition('processing clears after ended snapshot', () => !(mountPoint.textContent ?? '').includes('Processing...'))
+    expect(mountPoint.querySelector<HTMLButtonElement>('button[aria-label="Start recording"]')?.disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- decouple streaming Home processing state from the shared `pendingActionId`
- clear streaming pending state from terminal session lifecycle updates and local fatal cleanup
- add renderer integration coverage for unresolved command promises that would otherwise leave the UI stuck on `Processing...`

## Testing
- `pnpm typecheck`
- `pnpm vitest run src/renderer/home-react.test.tsx src/renderer/native-recording.test.ts src/renderer/renderer-app.test.ts src/renderer/streaming-ui-state.integration.test.tsx`

## Review notes
- Sub-agent review was attempted but the review agent was interrupted before returning findings.
- Claude second-pass review was attempted under a hard timeout and exited `124` without output.
