### PR TITLE
fix: hydrate streaming session snapshot on boot

### DIFF
--- a/docs/decisions/2026-03-08-streaming-boot-snapshot-sync-decision.md
+++ b/docs/decisions/2026-03-08-streaming-boot-snapshot-sync-decision.md
@@ -1,0 +1,38 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-boot-snapshot-sync-decision.md
+What: Decision record for boot-time streaming snapshot hydration and dead stop-reason cleanup.
+Why: Capture why renderer boot now reads current streaming session truth from main and why the unused provider_end contract was removed.
+-->
+
+# Decision: Renderer Boot Hydrates Streaming Session Truth From Main
+
+Date: 2026-03-08
+Ticket: `SSTP-06`
+PR: `PR-6`
+
+## Context
+
+The renderer boot path previously started with a hardcoded local `idle` streaming snapshot and only learned about streaming state through future events. A reloaded or newly opened window could therefore render `idle` while main was already `active`, `stopping`, or `failed`.
+
+At the same time, the shared stop-reason union still advertised `provider_end`, even though the main runtime had no implemented path that could publish that reason.
+
+## Decision
+
+Renderer boot now performs a read-only snapshot fetch from main before steady-state rendering relies on streaming session state.
+
+- preload exposes `getStreamingSessionSnapshot()`
+- main IPC returns `streamingSessionController.getSnapshot()`
+- renderer boot applies that snapshot only while local streaming state is still the untouched initial `idle` state
+- `provider_end` is removed from shared and renderer-facing stop-reason contracts
+
+## Rationale
+
+- New windows and reloads need a truthful starting point instead of waiting for a future event that may never come.
+- Boot hydration must not overwrite a newer event that already arrived during startup, so the snapshot is only allowed to fill the initial `idle` gap.
+- Keeping an unused public stop reason makes lifecycle handling look more expressive than it really is and hides contract drift.
+
+## Trade-offs
+
+- The renderer now depends on one extra IPC read during boot.
+- Snapshot and event paths must remain aligned in future streaming lifecycle changes.
+- Provider-side terminal endings still exist conceptually, but they are no longer represented as a shared/public reason until a real producer path exists.

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -137,10 +137,14 @@ describe('registerIpcHandlers', () => {
 
     expect(getRegisteredHandle(IPC_CHANNELS.startStreamingSession)).toBeTypeOf('function')
     expect(getRegisteredHandle(IPC_CHANNELS.stopStreamingSession)).toBeTypeOf('function')
+    expect(getRegisteredHandle(IPC_CHANNELS.getStreamingSessionSnapshot)).toBeTypeOf('function')
     expect(getRegisteredHandle(IPC_CHANNELS.ackStreamingRendererStop)).toBeTypeOf('function')
     expect(getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioFrameBatch)).toBeTypeOf('function')
 
     await getRegisteredHandle(IPC_CHANNELS.startStreamingSession)?.({}, undefined)
+    expect(getRegisteredHandle(IPC_CHANNELS.getStreamingSessionSnapshot)?.({}, undefined)).toEqual(
+      expect.objectContaining({ sessionId: 'session-1', state: 'active' })
+    )
     await expect(
       getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioFrameBatch)?.({}, {
         sampleRateHz: 16000,

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -509,6 +509,7 @@ const bindIpcHandlers = (svc: MainServices): void => {
       svc.commandRouter.submitRecordedAudio(payload)
     }
   )
+  ipcMain.handle(IPC_CHANNELS.getStreamingSessionSnapshot, () => svc.streamingSessionController.getSnapshot())
   ipcMain.handle(IPC_CHANNELS.startStreamingSession, () => svc.commandRouter.startStreamingSession())
   ipcMain.handle(IPC_CHANNELS.stopStreamingSession, (_event, request: StopStreamingSessionRequest) =>
     svc.commandRouter.stopStreamingSession(request)

--- a/src/main/test-support/streaming-session-snapshot-ipc.test.ts
+++ b/src/main/test-support/streaming-session-snapshot-ipc.test.ts
@@ -1,0 +1,62 @@
+// Where: src/main/test-support/streaming-session-snapshot-ipc.test.ts
+// What:  Integration-style coverage for the read-only streaming snapshot IPC route.
+// Why:   Proves renderer boot hydration can read the same session truth that main
+//        publishes over events without depending on a live Electron window.
+
+import { describe, expect, it } from 'vitest'
+import { IPC_CHANNELS } from '../../shared/ipc'
+import { InMemoryStreamingSessionController } from '../services/streaming/streaming-session-controller'
+import { IpcTestHarness } from './ipc-test-harness'
+
+describe('streaming session snapshot IPC', () => {
+  it('returns the controller snapshot across idle, active, and terminal states', async () => {
+    const harness = new IpcTestHarness()
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1'
+    })
+
+    harness.handle(IPC_CHANNELS.getStreamingSessionSnapshot, async () => controller.getSnapshot())
+
+    await expect(harness.invoke(IPC_CHANNELS.getStreamingSessionSnapshot)).resolves.toEqual({
+      sessionId: null,
+      state: 'idle',
+      provider: null,
+      transport: null,
+      model: null,
+      reason: null
+    })
+
+    await controller.start({
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      outputMode: 'stream_raw_dictation',
+      maxInFlightTransforms: 2,
+      delimiterPolicy: {
+        mode: 'space',
+        value: null
+      },
+      transformationProfile: null
+    })
+
+    await expect(harness.invoke(IPC_CHANNELS.getStreamingSessionSnapshot)).resolves.toEqual({
+      sessionId: 'session-1',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    })
+
+    await controller.stop('user_stop')
+
+    await expect(harness.invoke(IPC_CHANNELS.getStreamingSessionSnapshot)).resolves.toEqual({
+      sessionId: 'session-1',
+      state: 'ended',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'user_stop'
+    })
+  })
+})

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,7 @@ const api: IpcApi = {
   runRecordingCommand: async (command: RecordingCommand) =>
     ipcRenderer.invoke(IPC_CHANNELS.runRecordingCommand, command),
   submitRecordedAudio: async (payload) => ipcRenderer.invoke(IPC_CHANNELS.submitRecordedAudio, payload),
+  getStreamingSessionSnapshot: async () => ipcRenderer.invoke(IPC_CHANNELS.getStreamingSessionSnapshot),
   startStreamingSession: async () => ipcRenderer.invoke(IPC_CHANNELS.startStreamingSession),
   stopStreamingSession: async (request: StopStreamingSessionRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.stopStreamingSession, request),

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -535,18 +535,13 @@ export const handleStreamingSessionStateUpdate = async (
   if (snapshot.state === 'failed' || snapshot.reason === 'fatal_error' || snapshot.reason === 'user_cancel') {
     await streamingCapture.cancel()
   } else {
-    await streamingCapture.stop(snapshot.reason ?? 'provider_end')
+    await streamingCapture.stop(snapshot.reason ?? 'user_stop')
   }
 
   if (snapshot.state === 'failed') {
     deps.state.hasCommandError = true
     deps.onStateChange()
     return
-  }
-
-  if (snapshot.reason === 'provider_end') {
-    deps.addToast('Streaming session ended from the provider side.', 'info')
-    deps.onStateChange()
   }
 }
 

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -73,6 +73,7 @@ interface IpcHarness {
   api: IpcApi
   setApiKeyStatus: (status: { groq: boolean; elevenlabs: boolean; google: boolean }) => void
   setSettings: (next: typeof DEFAULT_SETTINGS) => void
+  setStreamingSessionSnapshot: (snapshot: StreamingSessionStateSnapshot) => void
   emitCompositeTransformStatus: (result: CompositeTransformResult) => void
   emitRecordingCommand: (dispatch: RecordingCommandDispatch) => void
   emitStreamingSessionState: (snapshot: StreamingSessionStateSnapshot) => void
@@ -109,6 +110,14 @@ const buildIpcHarness = (initialSettings?: typeof DEFAULT_SETTINGS): IpcHarness 
     elevenlabs: true,
     google: true
   }
+  let streamingSessionSnapshot: StreamingSessionStateSnapshot = {
+    sessionId: null,
+    state: 'idle',
+    provider: null,
+    transport: null,
+    model: null,
+    reason: null
+  }
 
   const onRecordingCommandSpy = vi.fn((_listener: (dispatch: RecordingCommandDispatch) => void) => () => {})
   const onStreamingSessionStateSpy = vi.fn((_listener: (state: any) => void) => () => {})
@@ -142,6 +151,7 @@ const buildIpcHarness = (initialSettings?: typeof DEFAULT_SETTINGS): IpcHarness 
     playSound: playSoundSpy,
     runRecordingCommand: async (_command: RecordingCommand) => {},
     submitRecordedAudio: async () => {},
+    getStreamingSessionSnapshot: async () => structuredClone(streamingSessionSnapshot),
     startStreamingSession: async () => {},
     stopStreamingSession: async (_request) => {},
     ackStreamingRendererStop: async (_ack) => {},
@@ -164,6 +174,9 @@ const buildIpcHarness = (initialSettings?: typeof DEFAULT_SETTINGS): IpcHarness 
     },
     setSettings: (next) => {
       currentSettings = structuredClone(next)
+    },
+    setStreamingSessionSnapshot: (snapshot) => {
+      streamingSessionSnapshot = structuredClone(snapshot)
     },
     emitCompositeTransformStatus: (result) => {
       const listener = onCompositeTransformStatusSpy.mock.calls[0]?.[0] as
@@ -593,6 +606,118 @@ describe('renderer app', () => {
     expect(mountPoint.textContent).toContain('Streaming session active')
     expect(mountPoint.textContent).toContain('Streamed text: hello world')
     expect(mountPoint.querySelector('#toast-layer')?.textContent ?? '').toContain('provider_exited')
+  })
+
+  it('hydrates an active streaming session snapshot during boot', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.processing.mode = 'streaming'
+    settings.processing.streaming.enabled = true
+    settings.processing.streaming.provider = 'local_whispercpp_coreml'
+    settings.processing.streaming.transport = 'native_stream'
+    settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    const harness = buildIpcHarness(settings)
+    harness.setStreamingSessionSnapshot({
+      sessionId: 'session-boot',
+      state: 'active',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    })
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForBoot()
+
+    expect(mountPoint.querySelector('[data-status-streaming-session]')?.textContent).toContain('stream:active')
+    expect(mountPoint.textContent).toContain('Streaming session active')
+  })
+
+  it('hydrates a failed streaming session snapshot during boot', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.processing.mode = 'streaming'
+    settings.processing.streaming.enabled = true
+    settings.processing.streaming.provider = 'groq_whisper_large_v3_turbo'
+    settings.processing.streaming.transport = 'rolling_upload'
+    settings.processing.streaming.model = 'whisper-large-v3-turbo'
+    const harness = buildIpcHarness(settings)
+    harness.setStreamingSessionSnapshot({
+      sessionId: 'session-failed',
+      state: 'failed',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: 'fatal_error'
+    })
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForBoot()
+
+    expect(mountPoint.querySelector('[data-status-streaming-session]')?.textContent).toContain('stream:failed')
+    expect(mountPoint.textContent).toContain('Streaming session failed')
+  })
+
+  it('does not let a stale boot snapshot overwrite a newer streaming event', async () => {
+    const mountPoint = document.createElement('div')
+    mountPoint.id = 'app'
+    document.body.append(mountPoint)
+
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.processing.mode = 'streaming'
+    settings.processing.streaming.enabled = true
+    settings.processing.streaming.provider = 'local_whispercpp_coreml'
+    settings.processing.streaming.transport = 'native_stream'
+    settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
+    const harness = buildIpcHarness(settings)
+    let resolveSnapshot = (): void => {
+      throw new Error('Snapshot gate resolver was not captured.')
+    }
+    const snapshotGate = new Promise<void>((resolve) => {
+      resolveSnapshot = resolve
+    })
+    harness.api.getStreamingSessionSnapshot = vi.fn(async () => {
+      await snapshotGate
+      const snapshot: StreamingSessionStateSnapshot = {
+        sessionId: 'session-stale',
+        state: 'starting',
+        provider: 'local_whispercpp_coreml',
+        transport: 'native_stream',
+        model: 'ggml-large-v3-turbo-q5_0',
+        reason: null
+      }
+      return snapshot
+    })
+    vi.stubGlobal('speechToTextApi', harness.api)
+    window.speechToTextApi = harness.api
+
+    startRendererApp(mountPoint)
+    await waitForCondition('streaming listener registration', () => harness.onStreamingSessionStateSpy.mock.calls.length === 1)
+
+    harness.emitStreamingSessionState({
+      sessionId: 'session-live',
+      state: 'failed',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'fatal_error'
+    })
+
+    resolveSnapshot()
+    await waitForBoot()
+
+    expect(mountPoint.querySelector('[data-status-streaming-session]')?.textContent).toContain('stream:failed')
+    expect(mountPoint.textContent).toContain('Streaming session failed')
   })
 
   it('opens settings tab when main process emits open-settings event', async () => {

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -502,6 +502,13 @@ const applyStreamingSessionState = (snapshot: StreamingSessionStateSnapshot): vo
   rerenderShellFromState()
 }
 
+const applyBootStreamingSessionSnapshot = (snapshot: StreamingSessionStateSnapshot): void => {
+  if (state.streamingSessionState.sessionId !== null || state.streamingSessionState.state !== 'idle') {
+    return
+  }
+  applyStreamingSessionState(snapshot)
+}
+
 const applyStreamingSegment = (segment: StreamingSegmentEvent): void => {
   const segmentKey = `${segment.sessionId}:${segment.sequence}`
   if (state.seenStreamingSegmentKeys.has(segmentKey)) {
@@ -832,6 +839,9 @@ const render = async (): Promise<void> => {
         openSettingsRoute()
       }
     })
+
+    const bootStreamingSessionSnapshot = await window.speechToTextApi.getStreamingSessionSnapshot()
+    applyBootStreamingSessionSnapshot(bootStreamingSessionSnapshot)
 
     const [pong, loadedSettings, apiKeyStatus] = await Promise.all([
       window.speechToTextApi.ping(),

--- a/src/renderer/streaming-feedback.ts
+++ b/src/renderer/streaming-feedback.ts
@@ -31,9 +31,6 @@ export const formatStreamingSessionMessage = (snapshot: StreamingSessionStateSna
     return 'Streaming session stopping.'
   }
   if (snapshot.state === 'ended') {
-    if (snapshot.reason === 'provider_end') {
-      return 'Streaming session ended from the provider side.'
-    }
     if (snapshot.reason === 'user_cancel') {
       return 'Streaming session cancelled.'
     }

--- a/src/renderer/streaming-ui-state.integration.test.tsx
+++ b/src/renderer/streaming-ui-state.integration.test.tsx
@@ -69,6 +69,14 @@ const buildHarness = (): {
     playSound: async () => {},
     runRecordingCommand: async () => await new Promise<void>(() => {}),
     submitRecordedAudio: async () => {},
+    getStreamingSessionSnapshot: async () => ({
+      sessionId: null,
+      state: 'idle',
+      provider: null,
+      transport: null,
+      model: null,
+      reason: null
+    }),
     startStreamingSession: async () => {},
     stopStreamingSession: async (_request) => {},
     ackStreamingRendererStop: async (_ack) => {},

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -67,7 +67,7 @@ export interface CompositeTransformResult {
 }
 
 export type StreamingSessionState = 'idle' | 'starting' | 'active' | 'stopping' | 'ended' | 'failed'
-export type StreamingSessionStopReason = 'user_stop' | 'user_cancel' | 'provider_end' | 'fatal_error'
+export type StreamingSessionStopReason = 'user_stop' | 'user_cancel' | 'fatal_error'
 export interface StopStreamingSessionRequest {
   sessionId: string
   reason: RendererInitiatedStreamingStopReason
@@ -136,6 +136,7 @@ export interface IpcApi {
   playSound: (event: SoundEvent) => Promise<void>
   runRecordingCommand: (command: RecordingCommand) => Promise<void>
   submitRecordedAudio: (payload: { data: Uint8Array; mimeType: string; capturedAt: string }) => Promise<void>
+  getStreamingSessionSnapshot: () => Promise<StreamingSessionStateSnapshot>
   startStreamingSession: () => Promise<void>
   stopStreamingSession: (request: StopStreamingSessionRequest) => Promise<void>
   ackStreamingRendererStop: (ack: StreamingRendererStopAck) => Promise<void>
@@ -164,6 +165,7 @@ export const IPC_CHANNELS = {
   playSound: 'sound:play',
   runRecordingCommand: 'recording:run-command',
   submitRecordedAudio: 'recording:submit-recorded-audio',
+  getStreamingSessionSnapshot: 'streaming:get-session-snapshot',
   startStreamingSession: 'streaming:start-session',
   stopStreamingSession: 'streaming:stop-session',
   ackStreamingRendererStop: 'streaming:ack-renderer-stop',


### PR DESCRIPTION
## Summary
- add a read-only streaming session snapshot IPC/preload contract so renderer boot can hydrate current main-process truth
- hydrate streaming state during renderer boot without letting a stale boot snapshot overwrite a newer live event
- remove the dead `provider_end` stop-reason surface from shared and renderer-facing contracts

## Testing
- `pnpm typecheck`
- `pnpm vitest run src/main/ipc/register-handlers.test.ts src/main/test-support/streaming-session-snapshot-ipc.test.ts src/renderer/renderer-app.test.ts src/renderer/streaming-ui-state.integration.test.tsx`

## Review notes
- Sub-agent review was attempted and ended interrupted before returning findings.
- Claude second-pass review was attempted with `claude --model sonnet -p ...` under a long timeout and produced no output before it had to be abandoned.
