### PR TITLE
fix: harden whisper startup readiness

### DIFF
--- a/docs/decisions/2026-03-08-whisper-startup-readiness-decision.md
+++ b/docs/decisions/2026-03-08-whisper-startup-readiness-decision.md
@@ -1,0 +1,36 @@
+<!--
+Where: docs/decisions/2026-03-08-whisper-startup-readiness-decision.md
+What: Decision record for whisper.cpp startup readiness gating and child-process failure hardening.
+Why: Capture why local streaming startup now waits for a real ready signal and why startup failures keep structured provider-specific detail.
+-->
+
+# Decision: Whisper Startup Must Reach Real Readiness Before Session Activation
+
+Date: 2026-03-08
+Ticket: `SSTP-07`
+PR: `PR-7`
+
+## Context
+
+The local whisper adapter previously resolved `start()` immediately after spawning the child process. That let the controller publish `active` before the runtime had actually emitted its protocol `ready` signal. It also meant child-process startup failures could bypass the structured streaming failure path or get collapsed into a generic `provider_start_failed` code.
+
+## Decision
+
+Local whisper startup now waits for a real runtime ready signal and preserves structured startup failure details.
+
+- `ChildProcessStreamClient` exposes process `error` events
+- `WhisperCppStreamingAdapter.start()` waits for a protocol `ready` event before resolving
+- startup waits are bounded by a dedicated ready timeout
+- startup failures reject with structured provider codes that the controller preserves during `starting -> failed`
+
+## Rationale
+
+- A streaming session should not be `active` until the local runtime is actually ready to accept and process audio.
+- Spawn errors, missing runtime assets, and ready timeouts need distinct failure details so local setup problems are diagnosable.
+- Preserving structured startup codes keeps renderer feedback and future operational debugging anchored to the real cause instead of a generic wrapper code.
+
+## Trade-offs
+
+- Local provider startup is slightly slower because `active` now waits for the ready handshake instead of just process spawn.
+- The adapter owns a small amount of startup-state bookkeeping and one timeout.
+- This hardening remains provider-specific; cloud provider startup semantics are unchanged.

--- a/src/main/infrastructure/child-process-stream-client.test.ts
+++ b/src/main/infrastructure/child-process-stream-client.test.ts
@@ -107,6 +107,28 @@ describe('ChildProcessStreamClient', () => {
     expect(onExit).toHaveBeenCalledWith({ code: 1, signal: 'SIGABRT' })
   })
 
+  it('notifies error listeners on child process startup errors', () => {
+    const child = new FakeChildProcess()
+    const client = new ChildProcessStreamClient(
+      {
+        command: '/bin/fake'
+      },
+      {
+        spawnFn: vi.fn(() => child as any)
+      }
+    )
+
+    const onError = vi.fn()
+    client.onError(onError)
+
+    client.start()
+    child.emit('error', new Error('spawn ENOENT'))
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'spawn ENOENT'
+    }))
+  })
+
   it('stops cleanly with SIGTERM', async () => {
     const child = new FakeChildProcess()
     const client = new ChildProcessStreamClient(

--- a/src/main/infrastructure/child-process-stream-client.ts
+++ b/src/main/infrastructure/child-process-stream-client.ts
@@ -24,6 +24,7 @@ export interface ChildProcessStreamClientDependencies {
 
 type LineListener = (line: string) => void
 type ExitListener = (payload: { code: number | null; signal: NodeJS.Signals | null }) => void
+type ErrorListener = (error: Error) => void
 
 export class ChildProcessStreamClient {
   private readonly spawnFn: typeof spawn
@@ -33,6 +34,7 @@ export class ChildProcessStreamClient {
   private readonly stdoutListeners = new Set<LineListener>()
   private readonly stderrListeners = new Set<LineListener>()
   private readonly exitListeners = new Set<ExitListener>()
+  private readonly errorListeners = new Set<ErrorListener>()
   private child: ChildProcessWithoutNullStreams | null = null
   private stdoutBuffer = ''
   private stderrBuffer = ''
@@ -73,6 +75,15 @@ export class ChildProcessStreamClient {
       this.stderrBuffer = ''
       for (const listener of this.exitListeners) {
         listener({ code, signal })
+      }
+    })
+    child.on('error', (error) => {
+      this.child = null
+      this.stdoutBuffer = ''
+      this.stderrBuffer = ''
+      const normalized = error instanceof Error ? error : new Error(String(error))
+      for (const listener of this.errorListeners) {
+        listener(normalized)
       }
     })
   }
@@ -137,6 +148,13 @@ export class ChildProcessStreamClient {
     this.exitListeners.add(listener)
     return () => {
       this.exitListeners.delete(listener)
+    }
+  }
+
+  onError(listener: ErrorListener): () => void {
+    this.errorListeners.add(listener)
+    return () => {
+      this.errorListeners.delete(listener)
     }
   }
 

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -122,6 +122,76 @@ describe('InMemoryStreamingSessionController', () => {
     expect(controller.getState()).toBe('failed')
   })
 
+  it('keeps structured startup failure details instead of collapsing them to provider_start_failed', async () => {
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      createProviderRuntime: () => ({
+        start: async () => {
+          const error = new Error('Missing whisper.cpp model file') as Error & { code: string }
+          error.code = 'provider_runtime_not_ready'
+          throw error
+        },
+        stop: async () => {},
+        pushAudioFrameBatch: async () => {}
+      })
+    })
+    const onSessionState = vi.fn()
+    const onError = vi.fn()
+    controller.onSessionState(onSessionState)
+    controller.onError(onError)
+
+    await expect(controller.start(LOCAL_STREAMING_CONFIG)).rejects.toMatchObject({
+      code: 'provider_runtime_not_ready',
+      message: 'Missing whisper.cpp model file'
+    })
+
+    expect(onError).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      code: 'provider_runtime_not_ready',
+      message: 'Missing whisper.cpp model file'
+    })
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual(['starting', 'failed'])
+    expect(controller.getSnapshot()).toEqual({
+      sessionId: 'session-1',
+      state: 'failed',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: 'fatal_error'
+    })
+  })
+
+  it('does not publish active until the provider start promise resolves', async () => {
+    let resolveStart = (): void => {
+      throw new Error('Provider start resolver was not captured.')
+    }
+    const startGate = new Promise<void>((resolve) => {
+      resolveStart = resolve
+    })
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      createProviderRuntime: () => ({
+        start: async () => await startGate,
+        stop: async () => {},
+        pushAudioFrameBatch: async () => {}
+      })
+    })
+    const onSessionState = vi.fn()
+    controller.onSessionState(onSessionState)
+
+    const startPromise = controller.start(LOCAL_STREAMING_CONFIG)
+    await Promise.resolve()
+
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual(['starting'])
+    expect(controller.getState()).toBe('starting')
+
+    resolveStart()
+    await startPromise
+
+    expect(onSessionState.mock.calls.map(([event]) => event.state)).toEqual(['starting', 'active'])
+    expect(controller.getState()).toBe('active')
+  })
+
   it('rejects pushed audio frame batches when no session is active', async () => {
     const controller = new InMemoryStreamingSessionController()
 

--- a/src/main/services/streaming/streaming-session-controller.ts
+++ b/src/main/services/streaming/streaming-session-controller.ts
@@ -345,6 +345,32 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
   }
 
   private toStreamingFailure(error: unknown, code: string): StreamingSessionFailure {
+    if (error && typeof error === 'object') {
+      const maybeStructuredError = error as {
+        code?: unknown
+        message?: unknown
+        failure?: {
+          code?: unknown
+          message?: unknown
+        }
+      }
+      if (
+        maybeStructuredError.failure &&
+        typeof maybeStructuredError.failure.code === 'string' &&
+        typeof maybeStructuredError.failure.message === 'string'
+      ) {
+        return {
+          code: maybeStructuredError.failure.code,
+          message: maybeStructuredError.failure.message
+        }
+      }
+      if (typeof maybeStructuredError.code === 'string' && typeof maybeStructuredError.message === 'string') {
+        return {
+          code: maybeStructuredError.code,
+          message: maybeStructuredError.message
+        }
+      }
+    }
     return {
       code,
       message: error instanceof Error ? error.message : String(error)

--- a/src/main/services/streaming/whispercpp-streaming-adapter.test.ts
+++ b/src/main/services/streaming/whispercpp-streaming-adapter.test.ts
@@ -13,6 +13,7 @@ class FakeChildProcessStreamClient {
   private readonly stdoutListeners = new Set<(line: string) => void>()
   private readonly stderrListeners = new Set<(line: string) => void>()
   private readonly exitListeners = new Set<(payload: { code: number | null; signal: NodeJS.Signals | null }) => void>()
+  private readonly errorListeners = new Set<(error: Error) => void>()
 
   start(): void {}
 
@@ -45,6 +46,13 @@ class FakeChildProcessStreamClient {
     }
   }
 
+  onError(listener: (error: Error) => void): () => void {
+    this.errorListeners.add(listener)
+    return () => {
+      this.errorListeners.delete(listener)
+    }
+  }
+
   emitStdout(line: string): void {
     for (const listener of this.stdoutListeners) {
       listener(line)
@@ -60,6 +68,12 @@ class FakeChildProcessStreamClient {
   emitExit(payload: { code: number | null; signal: NodeJS.Signals | null }): void {
     for (const listener of this.exitListeners) {
       listener(payload)
+    }
+  }
+
+  emitError(error: Error): void {
+    for (const listener of this.errorListeners) {
+      listener(error)
     }
   }
 }
@@ -99,7 +113,9 @@ describe('WhisperCppStreamingAdapter', () => {
       createClient
     })
 
-    await adapter.start()
+    const startPromise = adapter.start()
+    fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
+    await startPromise
     await adapter.pushAudioFrameBatch({
       sampleRateHz: 16000,
       channels: 1,
@@ -153,7 +169,9 @@ describe('WhisperCppStreamingAdapter', () => {
       createClient: () => fakeClient
     })
 
-    await adapter.start()
+    const startPromise = adapter.start()
+    fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
+    await startPromise
     fakeClient.emitStdout(JSON.stringify({
       type: 'final_segment',
       sequence: 7,
@@ -193,7 +211,9 @@ describe('WhisperCppStreamingAdapter', () => {
       createClient: () => fakeClient
     })
 
-    await adapter.start()
+    const startPromise = adapter.start()
+    fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
+    await startPromise
     fakeClient.emitStderr('segmentation fault')
     fakeClient.emitExit({ code: 9, signal: null })
     await Promise.resolve()
@@ -225,7 +245,9 @@ describe('WhisperCppStreamingAdapter', () => {
       createClient: () => fakeClient
     })
 
-    await adapter.start()
+    const startPromise = adapter.start()
+    fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
+    await startPromise
     await adapter.stop('user_stop')
 
     expect(JSON.parse(fakeClient.writes.at(-1) ?? '{}')).toEqual({
@@ -252,6 +274,105 @@ describe('WhisperCppStreamingAdapter', () => {
       createClient: vi.fn()
     })
 
-    await expect(adapter.start()).rejects.toThrow('Missing whisper.cpp model file')
+    await expect(adapter.start()).rejects.toMatchObject({
+      code: 'provider_runtime_not_ready',
+      message: 'Missing whisper.cpp model file'
+    })
+  })
+
+  it('waits for a ready event before resolving start', async () => {
+    const fakeClient = new FakeChildProcessStreamClient()
+    const adapter = new WhisperCppStreamingAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_STREAMING_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      modelManager: {
+        ensureRuntimeReady: vi.fn(() => ({
+          binaryPath: '/runtime/whisper-stream',
+          modelPath: '/models/model.bin',
+          coreMlModelPath: '/models/model-encoder.mlmodelc'
+        }))
+      } as any,
+      createClient: () => fakeClient
+    })
+
+    let settled = false
+    const startPromise = adapter.start().finally(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
+    await startPromise
+    expect(settled).toBe(true)
+  })
+
+  it('rejects start when the child process emits an error before ready', async () => {
+    const fakeClient = new FakeChildProcessStreamClient()
+    const onFailure = vi.fn()
+    const adapter = new WhisperCppStreamingAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_STREAMING_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure
+      }
+    }, {
+      modelManager: {
+        ensureRuntimeReady: vi.fn(() => ({
+          binaryPath: '/runtime/whisper-stream',
+          modelPath: '/models/model.bin',
+          coreMlModelPath: '/models/model-encoder.mlmodelc'
+        }))
+      } as any,
+      createClient: () => fakeClient
+    })
+
+    const startPromise = adapter.start()
+    fakeClient.emitError(new Error('spawn ENOENT'))
+
+    await expect(startPromise).rejects.toMatchObject({
+      code: 'provider_process_error',
+      message: 'Whisper.cpp runtime process error: spawn ENOENT'
+    })
+    expect(onFailure).not.toHaveBeenCalled()
+  })
+
+  it('rejects start when ready never arrives before the timeout', async () => {
+    vi.useFakeTimers()
+    const fakeClient = new FakeChildProcessStreamClient()
+    const adapter = new WhisperCppStreamingAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_STREAMING_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      modelManager: {
+        ensureRuntimeReady: vi.fn(() => ({
+          binaryPath: '/runtime/whisper-stream',
+          modelPath: '/models/model.bin',
+          coreMlModelPath: '/models/model-encoder.mlmodelc'
+        }))
+      } as any,
+      createClient: () => fakeClient,
+      readyTimeoutMs: 25
+    })
+
+    const startPromise = adapter.start()
+    const rejectionExpectation = expect(startPromise).rejects.toMatchObject({
+      code: 'provider_ready_timeout',
+      message: 'Whisper.cpp runtime did not emit ready within 25ms.'
+    })
+    await vi.advanceTimersByTimeAsync(25)
+    await rejectionExpectation
+    vi.useRealTimers()
   })
 })

--- a/src/main/services/streaming/whispercpp-streaming-adapter.ts
+++ b/src/main/services/streaming/whispercpp-streaming-adapter.ts
@@ -23,7 +23,7 @@ import type {
 
 type ChildProcessStreamClientLike = Pick<
   ChildProcessStreamClient,
-  'start' | 'writeLine' | 'stop' | 'onStdoutLine' | 'onStderrLine' | 'onExit'
+  'start' | 'writeLine' | 'stop' | 'onStdoutLine' | 'onStderrLine' | 'onExit' | 'onError'
 >
 
 export interface WhisperCppStreamingAdapterParams {
@@ -35,6 +35,9 @@ export interface WhisperCppStreamingAdapterParams {
 export interface WhisperCppStreamingAdapterDependencies {
   modelManager?: Pick<WhisperCppModelManager, 'ensureRuntimeReady'>
   createClient?: (options: ChildProcessStreamClientOptions) => ChildProcessStreamClientLike
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  readyTimeoutMs?: number
 }
 
 type WhisperCppJsonlEvent =
@@ -53,13 +56,31 @@ type WhisperCppJsonlEvent =
   }
 
 const PROTOCOL_VERSION = 'speech-to-text-jsonl-v1'
+const WHISPERCPP_READY_TIMEOUT_MS = 5_000
+
+class WhisperCppStartupError extends Error {
+  readonly code: string
+
+  constructor(readonly failure: StreamingSessionFailure) {
+    super(failure.message)
+    this.name = 'WhisperCppStartupError'
+    this.code = failure.code
+  }
+}
 
 export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
   private readonly modelManager: Pick<WhisperCppModelManager, 'ensureRuntimeReady'>
   private readonly createClient: (options: ChildProcessStreamClientOptions) => ChildProcessStreamClientLike
+  private readonly setTimeoutFn: typeof setTimeout
+  private readonly clearTimeoutFn: typeof clearTimeout
+  private readonly readyTimeoutMs: number
   private client: ChildProcessStreamClientLike | null = null
   private expectedStop = false
   private lastStderrLine: string | null = null
+  private startupState: 'idle' | 'starting' | 'ready' | 'failed' = 'idle'
+  private resolveStartupReady: (() => void) | null = null
+  private rejectStartupReady: ((error: WhisperCppStartupError) => void) | null = null
+  private startupReadyTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     private readonly params: WhisperCppStreamingAdapterParams,
@@ -67,6 +88,9 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
   ) {
     this.modelManager = dependencies.modelManager ?? new WhisperCppModelManager()
     this.createClient = dependencies.createClient ?? ((options) => new ChildProcessStreamClient(options))
+    this.setTimeoutFn = dependencies.setTimeoutFn ?? setTimeout
+    this.clearTimeoutFn = dependencies.clearTimeoutFn ?? clearTimeout
+    this.readyTimeoutMs = dependencies.readyTimeoutMs ?? WHISPERCPP_READY_TIMEOUT_MS
   }
 
   async start(): Promise<void> {
@@ -74,7 +98,13 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
       throw new Error('Whisper.cpp streaming runtime is already active.')
     }
 
-    const runtime = this.modelManager.ensureRuntimeReady(this.params.config.model)
+    let runtime: WhisperCppRuntimePaths
+    try {
+      runtime = this.modelManager.ensureRuntimeReady(this.params.config.model)
+    } catch (error) {
+      throw this.createStartupError('provider_runtime_not_ready', error)
+    }
+
     const client = this.createClient({
       command: runtime.binaryPath,
       args: this.buildCommandArgs(runtime)
@@ -82,6 +112,7 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
     this.expectedStop = false
     this.lastStderrLine = null
     this.client = client
+    const startupReady = this.createStartupReadyPromise()
 
     client.onStdoutLine((line) => {
       void this.handleStdoutLine(line)
@@ -93,13 +124,26 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
       if (this.expectedStop) {
         return
       }
-      void this.params.callbacks.onFailure({
+      void this.handleRuntimeFailure({
         code: 'provider_exited',
         message: this.buildUnexpectedExitMessage(code, signal)
       })
     })
+    client.onError((error) => {
+      void this.handleRuntimeFailure({
+        code: 'provider_process_error',
+        message: `Whisper.cpp runtime process error: ${error.message}`
+      })
+    })
 
-    client.start()
+    try {
+      client.start()
+      await startupReady
+    } catch (error) {
+      this.startupState = 'failed'
+      this.clearStartupReadyWait()
+      throw this.asStartupError(error)
+    }
   }
 
   async stop(reason: StreamingSessionStopReason): Promise<void> {
@@ -110,6 +154,8 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
     const client = this.client
     this.expectedStop = true
     this.client = null
+    this.startupState = 'idle'
+    this.clearStartupReadyWait()
 
     try {
       client.writeLine(JSON.stringify({
@@ -154,7 +200,7 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
   private async handleStdoutLine(line: string): Promise<void> {
     const parsed = this.parseJsonlEvent(line)
     if (!parsed) {
-      await this.params.callbacks.onFailure({
+      await this.handleRuntimeFailure({
         code: 'provider_protocol_error',
         message: `Whisper.cpp runtime emitted a non-JSONL stdout line: ${line}`
       })
@@ -162,13 +208,22 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
     }
 
     if (parsed.type === 'ready') {
+      this.markReady()
       return
     }
 
     if (parsed.type === 'error') {
-      await this.params.callbacks.onFailure({
+      await this.handleRuntimeFailure({
         code: parsed.code,
         message: parsed.message
+      })
+      return
+    }
+
+    if (this.startupState !== 'ready') {
+      await this.handleRuntimeFailure({
+        code: 'provider_protocol_error',
+        message: 'Whisper.cpp runtime emitted a final segment before signaling ready.'
       })
       return
     }
@@ -218,6 +273,80 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
     } catch {
       return null
     }
+  }
+
+  private createStartupReadyPromise(): Promise<void> {
+    this.startupState = 'starting'
+    return new Promise<void>((resolve, reject) => {
+      this.resolveStartupReady = () => {
+        this.startupState = 'ready'
+        this.clearStartupReadyWait()
+        resolve()
+      }
+      this.rejectStartupReady = (error) => {
+        this.startupState = 'failed'
+        this.clearStartupReadyWait()
+        reject(error)
+      }
+      this.startupReadyTimer = this.setTimeoutFn(() => {
+        this.rejectStartup(new WhisperCppStartupError({
+          code: 'provider_ready_timeout',
+          message: this.buildReadyTimeoutMessage()
+        }))
+      }, this.readyTimeoutMs)
+    })
+  }
+
+  private markReady(): void {
+    if (this.startupState !== 'starting') {
+      return
+    }
+    this.resolveStartupReady?.()
+  }
+
+  private rejectStartup(error: WhisperCppStartupError): boolean {
+    if (this.startupState !== 'starting') {
+      return false
+    }
+    this.rejectStartupReady?.(error)
+    return true
+  }
+
+  private clearStartupReadyWait(): void {
+    if (this.startupReadyTimer !== null) {
+      this.clearTimeoutFn(this.startupReadyTimer)
+      this.startupReadyTimer = null
+    }
+    this.resolveStartupReady = null
+    this.rejectStartupReady = null
+  }
+
+  private async handleRuntimeFailure(failure: StreamingSessionFailure): Promise<void> {
+    if (this.rejectStartup(new WhisperCppStartupError(failure))) {
+      return
+    }
+    await this.params.callbacks.onFailure(failure)
+  }
+
+  private buildReadyTimeoutMessage(): string {
+    if (this.lastStderrLine) {
+      return `Whisper.cpp runtime did not emit ready within ${this.readyTimeoutMs}ms. Last stderr: ${this.lastStderrLine}`
+    }
+    return `Whisper.cpp runtime did not emit ready within ${this.readyTimeoutMs}ms.`
+  }
+
+  private createStartupError(code: string, error: unknown): WhisperCppStartupError {
+    return new WhisperCppStartupError({
+      code,
+      message: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  private asStartupError(error: unknown): WhisperCppStartupError {
+    if (error instanceof WhisperCppStartupError) {
+      return error
+    }
+    return this.createStartupError('provider_start_failed', error)
   }
 
   private buildUnexpectedExitMessage(code: number | null, signal: NodeJS.Signals | null): string {


### PR DESCRIPTION
## Summary
- wait for a real whisper.cpp `ready` signal before treating local streaming startup as active
- surface child-process `error` events and preserve structured startup failure codes through the controller
- add regressions for delayed ready, ready timeout, startup process errors, and controller startup-state sequencing

## Testing
- `pnpm typecheck`
- `pnpm vitest run src/main/services/streaming/whispercpp-streaming-adapter.test.ts src/main/infrastructure/child-process-stream-client.test.ts src/main/services/streaming/streaming-session-controller.test.ts`

## Review notes
- Sub-agent review was attempted and ended interrupted before returning findings.
- Claude second-pass review was attempted with `claude --model sonnet -p ...` and produced no output before I moved on.
