### PR TITLE
Fix streaming renderer drain handling

### DIFF
--- a/docs/decisions/2026-03-08-streaming-renderer-ingress-drain-contract.md
+++ b/docs/decisions/2026-03-08-streaming-renderer-ingress-drain-contract.md
@@ -1,0 +1,53 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-renderer-ingress-drain-contract.md
+What: Decision note for the renderer-side streaming ingress drain contract under stop and transport failure.
+Why: Record why renderer stop now waits on one shared drain promise and why automatic batch failures must enter the fatal capture path.
+-->
+
+# Decision: Renderer Ingress Uses One Shared Drain Promise
+
+## Status
+Accepted — March 8, 2026
+
+## Context
+
+The latest-dev streaming audit found two renderer-side transport bugs:
+
+- `StreamingAudioIngress.stop()` could resolve while an earlier batch push was still in flight, which allowed main to stop the session before the renderer had finished draining queued audio.
+- Automatic max-batch drains were started in the background without an observed rejection path, so transport failures could bypass the live-capture fatal cleanup flow.
+
+Those bugs lived in the same seam:
+- `StreamingAudioIngress` owns queueing and batching.
+- `BrowserStreamingLiveCapture` owns fatal capture shutdown.
+
+## Decision
+
+The renderer ingress contract is now:
+
+- `StreamingAudioIngress` owns one shared drain promise for all queued-batch transport work.
+- `flush()` and `stop()` await that same drain promise instead of returning early when a push is already in flight.
+- `pushFrame()` may return that drain promise when pushing a full batch starts or joins active transport work.
+- `BrowserStreamingLiveCapture` observes that returned promise and routes any rejection into its existing fatal cleanup path.
+- once explicit `stop()` / `cancel()` teardown begins, late drain failures must not reclassify the session as a fatal capture failure
+
+## Consequences
+
+- Renderer stop acknowledgement stays aligned with real local drain completion.
+- Automatic batch transport failures are no longer silent background rejections.
+- Explicit stop/cancel always finishes local teardown even if a drain fails while shutdown is already underway.
+- The fix stays renderer-local and does not widen the main-process stop contract.
+- `pushFrame()` is no longer purely fire-and-forget; callers that trigger transport work may observe an async rejection.
+
+## Rejected Alternatives
+
+- Replace ingress with a larger async worker/channel abstraction in this fix batch.
+  - Rejected because it is a broader refactor than needed for the current bugs.
+- Move drain responsibility into the main stop contract.
+  - Rejected because the bug originates in renderer-local queue serialization and should be fixed there first.
+
+## Out Of Scope
+
+- Groq stop timeout budgeting
+- Multi-window stop acknowledgement ownership
+- AudioWorklet migration
+- Speech chunker reset semantics

--- a/src/renderer/streaming-audio-ingress.test.ts
+++ b/src/renderer/streaming-audio-ingress.test.ts
@@ -13,6 +13,11 @@ const makeFrame = (timestampMs: number, values: number[]) => ({
   timestampMs
 })
 
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe('StreamingAudioIngress', () => {
   it('batches frames before pushing them to the sink', async () => {
     const sink = {
@@ -76,12 +81,12 @@ describe('StreamingAudioIngress', () => {
   })
 
   it('fails fast when queued batch backpressure exceeds the configured bound', async () => {
-    const releasePushRef: { current: (() => void) | null } = { current: null }
+    const releasePushes: Array<() => void> = []
     const sink = {
       pushStreamingAudioFrameBatch: vi.fn(
         async () =>
           await new Promise<void>((resolve) => {
-            releasePushRef.current = resolve
+            releasePushes.push(resolve)
           })
       )
     }
@@ -97,9 +102,96 @@ describe('StreamingAudioIngress', () => {
 
     expect(() => ingress.pushFrame(makeFrame(3, [0.4, 0.5]))).toThrow('backpressure limit exceeded')
 
-    if (releasePushRef.current) {
-      releasePushRef.current()
+    const stopPromise = ingress.stop()
+    releasePushes.shift()?.()
+    await flushMicrotasks()
+    releasePushes.shift()?.()
+    await stopPromise
+  })
+
+  it('waits for an in-flight drain and queued follow-up batches before stop resolves', async () => {
+    let releaseFirstPush: (() => void) | null = null
+    let releaseSecondPush: (() => void) | null = null
+    const sink = {
+      pushStreamingAudioFrameBatch: vi
+        .fn()
+        .mockImplementationOnce(
+          async () =>
+            await new Promise<void>((resolve) => {
+              releaseFirstPush = resolve
+            })
+        )
+        .mockImplementationOnce(
+          async () =>
+            await new Promise<void>((resolve) => {
+              releaseSecondPush = resolve
+            })
+        )
     }
-    await ingress.stop()
+    const ingress = new StreamingAudioIngress(sink, {
+      sampleRateHz: 16000,
+      channels: 1,
+      maxFramesPerBatch: 1,
+      maxQueuedBatches: 3
+    })
+
+    ingress.pushFrame(makeFrame(1, [0.1, 0.2]))
+    ingress.pushFrame(makeFrame(2, [0.3, 0.4]))
+
+    let stopResolved = false
+    const stopPromise = ingress.stop().then(() => {
+      stopResolved = true
+    })
+
+    await Promise.resolve()
+    expect(stopResolved).toBe(false)
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(1)
+
+    releaseFirstPush?.()
+    await flushMicrotasks()
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(2)
+    expect(stopResolved).toBe(false)
+
+    releaseSecondPush?.()
+    await stopPromise
+
+    expect(stopResolved).toBe(true)
+  })
+
+  it('makes flush join an in-flight drain and reject on transport failure', async () => {
+    let releaseFirstPush: (() => void) | null = null
+    const sink = {
+      pushStreamingAudioFrameBatch: vi
+        .fn()
+        .mockImplementationOnce(
+          async () =>
+            await new Promise<void>((resolve) => {
+              releaseFirstPush = resolve
+            })
+        )
+        .mockRejectedValueOnce(new Error('push failed'))
+    }
+    const ingress = new StreamingAudioIngress(sink, {
+      sampleRateHz: 16000,
+      channels: 1,
+      maxFramesPerBatch: 1,
+      maxQueuedBatches: 3
+    })
+
+    ingress.pushFrame(makeFrame(1, [0.1, 0.2]))
+    ingress.pushFrame(makeFrame(2, [0.3, 0.4]))
+
+    let flushResolved = false
+    const flushPromise = ingress.flush('speech_pause').then(() => {
+      flushResolved = true
+    })
+
+    await Promise.resolve()
+    expect(flushResolved).toBe(false)
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(1)
+
+    releaseFirstPush?.()
+    await expect(flushPromise).rejects.toThrow('push failed')
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/streaming-audio-ingress.ts
+++ b/src/renderer/streaming-audio-ingress.ts
@@ -31,7 +31,7 @@ export class StreamingAudioIngress {
   private readonly maxQueuedBatches: number
   private readonly queuedBatches: StreamingAudioFrameBatch[] = []
   private pendingFrames: StreamingAudioFrame[] = []
-  private pushing = false
+  private activeDrain: Promise<void> | null = null
   private stopped = false
   private overflowed = false
 
@@ -43,7 +43,7 @@ export class StreamingAudioIngress {
     this.maxQueuedBatches = options.maxQueuedBatches ?? DEFAULT_STREAMING_AUDIO_INGRESS_LIMITS.maxQueuedBatches
   }
 
-  pushFrame(frame: StreamingAudioFrame): void {
+  pushFrame(frame: StreamingAudioFrame): Promise<void> | null {
     if (this.stopped) {
       throw new Error('Streaming audio ingress is stopped.')
     }
@@ -55,24 +55,30 @@ export class StreamingAudioIngress {
 
     if (this.pendingFrames.length >= this.maxFramesPerBatch) {
       this.enqueuePendingBatch(null)
-      void this.drainQueue()
+      return this.ensureDrain()
     }
+
+    return null
   }
 
   async flush(reason: StreamingAudioChunkFlushReason): Promise<void> {
     if (this.pendingFrames.length > 0) {
       this.enqueuePendingBatch(reason)
     }
-    await this.drainQueue()
+    await this.ensureDrain()
   }
 
   async stop(): Promise<void> {
     if (this.stopped && !this.overflowed) {
+      await this.activeDrain
       return
     }
     this.stopped = true
     this.overflowed = false
-    await this.flush('session_stop')
+    if (this.pendingFrames.length > 0) {
+      this.enqueuePendingBatch('session_stop')
+    }
+    await this.ensureDrain()
   }
 
   cancel(): void {
@@ -98,22 +104,29 @@ export class StreamingAudioIngress {
     this.pendingFrames = []
   }
 
-  private async drainQueue(): Promise<void> {
-    if (this.pushing) {
-      return
+  private ensureDrain(): Promise<void> {
+    if (this.activeDrain) {
+      return this.activeDrain
+    }
+    if (this.queuedBatches.length === 0) {
+      return Promise.resolve()
     }
 
-    this.pushing = true
-    try {
-      while (this.queuedBatches.length > 0) {
-        const nextBatch = this.queuedBatches.shift()
-        if (!nextBatch) {
-          continue
-        }
-        await this.sink.pushStreamingAudioFrameBatch(nextBatch)
+    // One shared drain promise lets stop/flush await in-flight transport work
+    // and also lets the capture loop observe auto-batch push failures.
+    this.activeDrain = this.drainQueue().finally(() => {
+      this.activeDrain = null
+    })
+    return this.activeDrain
+  }
+
+  private async drainQueue(): Promise<void> {
+    while (this.queuedBatches.length > 0) {
+      const nextBatch = this.queuedBatches.shift()
+      if (!nextBatch) {
+        continue
       }
-    } finally {
-      this.pushing = false
+      await this.sink.pushStreamingAudioFrameBatch(nextBatch)
     }
   }
 }

--- a/src/renderer/streaming-live-capture.test.ts
+++ b/src/renderer/streaming-live-capture.test.ts
@@ -14,6 +14,12 @@ const createTrack = () => ({
   stop: vi.fn()
 })
 
+const flushAsyncWork = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe('startStreamingLiveCapture', () => {
   it('pushes playback-timestamped frames and flushes on stop', async () => {
     const track = createTrack()
@@ -140,5 +146,202 @@ describe('startStreamingLiveCapture', () => {
 
     expect(sink.pushStreamingAudioFrameBatch).not.toHaveBeenCalled()
     expect(track.stop).toHaveBeenCalledOnce()
+  })
+
+  it('routes auto-batch drain failures into fatal cleanup', async () => {
+    const track = createTrack()
+    const mediaStream = {
+      getTracks: () => [track]
+    } as unknown as MediaStream
+    const sink = {
+      pushStreamingAudioFrameBatch: vi.fn().mockRejectedValue(new Error('push failed'))
+    }
+    const onFatalError = vi.fn()
+
+    const sourceNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn()
+    }
+    const processorNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onaudioprocess: null as ((event: { playbackTime?: number; inputBuffer: { getChannelData: () => Float32Array } }) => void) | null
+    }
+    const gainNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      gain: { value: 0 }
+    }
+    const close = vi.fn(async () => {})
+
+    const audioContext = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: {} as AudioDestinationNode,
+      createMediaStreamSource: vi.fn(() => sourceNode),
+      createScriptProcessor: vi.fn(() => processorNode),
+      createGain: vi.fn(() => gainNode),
+      resume: vi.fn(async () => {}),
+      close
+    } as unknown as AudioContext
+
+    const capture = await startStreamingLiveCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      requestedSampleRateHz: 16000,
+      channels: 1,
+      sink,
+      onFatalError,
+      getUserMedia: vi.fn(async () => mediaStream),
+      createAudioContext: () => audioContext,
+      maxFramesPerBatch: 1
+    })
+
+    processorNode.onaudioprocess?.({
+      playbackTime: 1,
+      inputBuffer: {
+        getChannelData: () => new Float32Array([0.2, 0.2, 0.2, 0.2])
+      }
+    })
+
+    await flushAsyncWork()
+    await flushAsyncWork()
+
+    expect(onFatalError).toHaveBeenCalledWith(expect.objectContaining({ message: 'push failed' }))
+    expect(track.stop).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+    expect(capture).toBeDefined()
+  })
+
+  it('tears down cleanly when an in-flight drain fails during explicit stop', async () => {
+    const track = createTrack()
+    const mediaStream = {
+      getTracks: () => [track]
+    } as unknown as MediaStream
+    let rejectPush: ((error: Error) => void) | null = null
+    const sink = {
+      pushStreamingAudioFrameBatch: vi.fn(
+        async () =>
+          await new Promise<void>((_resolve, reject) => {
+            rejectPush = reject
+          })
+      )
+    }
+    const onFatalError = vi.fn()
+
+    const processorNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onaudioprocess: null as ((event: { playbackTime?: number; inputBuffer: { getChannelData: () => Float32Array } }) => void) | null
+    }
+    const audioContext = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: {} as AudioDestinationNode,
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn()
+      })),
+      createScriptProcessor: vi.fn(() => processorNode),
+      createGain: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        gain: { value: 0 }
+      })),
+      resume: vi.fn(async () => {}),
+      close: vi.fn(async () => {})
+    } as unknown as AudioContext
+
+    const capture = await startStreamingLiveCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      requestedSampleRateHz: 16000,
+      channels: 1,
+      sink,
+      onFatalError,
+      getUserMedia: vi.fn(async () => mediaStream),
+      createAudioContext: () => audioContext,
+      maxFramesPerBatch: 1
+    })
+
+    processorNode.onaudioprocess?.({
+      playbackTime: 1,
+      inputBuffer: {
+        getChannelData: () => new Float32Array([0.2, 0.2, 0.2, 0.2])
+      }
+    })
+
+    const stopPromise = capture.stop()
+    rejectPush?.(new Error('push failed during stop'))
+    await stopPromise
+    await flushAsyncWork()
+
+    expect(onFatalError).not.toHaveBeenCalled()
+    expect(track.stop).toHaveBeenCalledOnce()
+    expect(audioContext.close).toHaveBeenCalledOnce()
+  })
+
+  it('suppresses late fatal reporting after cancel completes', async () => {
+    const track = createTrack()
+    const mediaStream = {
+      getTracks: () => [track]
+    } as unknown as MediaStream
+    let rejectPush: ((error: Error) => void) | null = null
+    const sink = {
+      pushStreamingAudioFrameBatch: vi.fn(
+        async () =>
+          await new Promise<void>((_resolve, reject) => {
+            rejectPush = reject
+          })
+      )
+    }
+    const onFatalError = vi.fn()
+
+    const processorNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onaudioprocess: null as ((event: { playbackTime?: number; inputBuffer: { getChannelData: () => Float32Array } }) => void) | null
+    }
+    const audioContext = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: {} as AudioDestinationNode,
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn()
+      })),
+      createScriptProcessor: vi.fn(() => processorNode),
+      createGain: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        gain: { value: 0 }
+      })),
+      resume: vi.fn(async () => {}),
+      close: vi.fn(async () => {})
+    } as unknown as AudioContext
+
+    const capture = await startStreamingLiveCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      requestedSampleRateHz: 16000,
+      channels: 1,
+      sink,
+      onFatalError,
+      getUserMedia: vi.fn(async () => mediaStream),
+      createAudioContext: () => audioContext,
+      maxFramesPerBatch: 1
+    })
+
+    processorNode.onaudioprocess?.({
+      playbackTime: 1,
+      inputBuffer: {
+        getChannelData: () => new Float32Array([0.2, 0.2, 0.2, 0.2])
+      }
+    })
+
+    await capture.cancel()
+    rejectPush?.(new Error('push failed after cancel'))
+    await flushAsyncWork()
+
+    expect(onFatalError).not.toHaveBeenCalled()
+    expect(track.stop).toHaveBeenCalledOnce()
+    expect(audioContext.close).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/streaming-live-capture.ts
+++ b/src/renderer/streaming-live-capture.ts
@@ -111,7 +111,12 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
       }
 
       try {
-        this.ingress.pushFrame(frame)
+        const drainPromise = this.ingress.pushFrame(frame)
+        if (drainPromise) {
+          void drainPromise.catch((error) => {
+            this.reportFatalError(error)
+          })
+        }
         const observation = this.chunker.observeFrame(frame, this.audioContext.sampleRate)
         if (observation.shouldFlush) {
           void this.ingress.flush(observation.reason ?? 'speech_pause').catch((error) => {
@@ -148,17 +153,26 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
       // Disconnect is best-effort during teardown only.
     }
 
-    if (reason === 'user_cancel' || reason === 'fatal_error') {
-      this.ingress.cancel()
-    } else {
-      await this.ingress.stop()
+    let stopError: unknown = null
+    try {
+      if (reason === 'user_cancel' || reason === 'fatal_error') {
+        this.ingress.cancel()
+      } else {
+        await this.ingress.stop()
+      }
+    } catch (error) {
+      stopError = error
+    } finally {
+      this.chunker.reset()
+      for (const track of this.mediaStream.getTracks()) {
+        track.stop()
+      }
+      await closeAudioContextSafely(this.audioContext)
     }
 
-    this.chunker.reset()
-    for (const track of this.mediaStream.getTracks()) {
-      track.stop()
+    if (stopError && reason !== 'user_stop') {
+      throw stopError
     }
-    await closeAudioContextSafely(this.audioContext)
   }
 
   async cancel(): Promise<void> {
@@ -166,7 +180,9 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
   }
 
   private reportFatalError(error: unknown): void {
-    if (this.fatalNotified) {
+    // Once an explicit stop/cancel is underway, late drain failures should not
+    // reclassify the session as fatal or reopen teardown.
+    if (this.stopped || this.fatalNotified) {
       return
     }
     this.fatalNotified = true


### PR DESCRIPTION
## Summary
- harden renderer streaming ingress drain tracking so stop and flush wait for in-flight transport work
- route automatic batch drain failures into the renderer fatal cleanup path
- add focused renderer regressions for stop-while-draining, drain failure, and post-cancel late failure handling

## Testing
- pnpm vitest run src/renderer/streaming-audio-ingress.test.ts src/renderer/streaming-live-capture.test.ts src/renderer/native-recording.test.ts