### PR TITLE
Discard short streaming chunks before flush

### DIFF
--- a/docs/decisions/2026-03-08-streaming-chunker-short-blip-reset.md
+++ b/docs/decisions/2026-03-08-streaming-chunker-short-blip-reset.md
@@ -1,0 +1,50 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-chunker-short-blip-reset.md
+What: Decision note for resetting the renderer speech chunker after below-threshold speech followed by long silence.
+Why: Prevent short noise or clipped speech from keeping a chunk armed and contaminating the next real utterance.
+-->
+
+# Decision: Reset The Streaming Chunker After Below-Threshold Speech
+
+## Status
+Accepted — March 8, 2026
+
+## Context
+
+The latest-dev streaming audit found that `StreamingSpeechChunker` would arm itself on any speech frame, but it only reset on:
+
+- a valid `speech_pause` flush, or
+- a `max_chunk` flush
+
+That left one bad state path:
+
+- short noise or clipped speech crosses the RMS threshold
+- spoken duration never reaches `minSpeechMs`
+- long silence follows
+- the chunker stays armed
+- later unrelated speech gets merged into the old chunk
+
+## Decision
+
+When total spoken duration is still below `minSpeechMs`, the chunker resets without flushing when either:
+
+- trailing silence reaches the pause threshold, or
+- the chunk lifetime reaches `maxChunkMs`
+
+That reset is paired with an explicit renderer discard signal so already-buffered partial audio is cleared instead of being merged into the next real utterance.
+
+## Consequences
+
+- Below-threshold noise does not poison the next utterance.
+- Already-buffered partial audio is dropped through an explicit `discard_pending` control batch instead of only resetting chunker-local timestamps.
+- Existing pause-triggered flush behavior stays unchanged for real speech at or above `minSpeechMs`.
+- `max_chunk` no longer overrides the below-threshold reset contract for silence-dominated chunks.
+- Threshold semantics stay explicit:
+  - below-threshold speech resets without output
+  - at-threshold or longer speech may flush on pause
+
+## Out Of Scope
+
+- Retuning RMS thresholds
+- Replacing pause-bounded chunking with a different VAD system
+- AudioWorklet migration

--- a/src/main/services/streaming/chunk-window-policy.test.ts
+++ b/src/main/services/streaming/chunk-window-policy.test.ts
@@ -12,6 +12,7 @@ describe('chunk-window-policy', () => {
   it('uses overlap only for max_chunk continuation uploads', () => {
     expect(resolveOverlapMsForFlushReason('speech_pause')).toBe(0)
     expect(resolveOverlapMsForFlushReason('session_stop')).toBe(0)
+    expect(resolveOverlapMsForFlushReason('discard_pending')).toBe(0)
     expect(resolveOverlapMsForFlushReason('max_chunk')).toBeGreaterThan(0)
   })
 

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -25,7 +25,7 @@ const LOCAL_CONFIG = {
 
 const makeBatch = (params: {
   startMs: number
-  flushReason: 'speech_pause' | 'max_chunk' | 'session_stop'
+  flushReason: 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
   values?: number[]
 }) => ({
   sampleRateHz: 16000,
@@ -116,6 +116,52 @@ describe('GroqRollingUploadAdapter', () => {
 
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first chunk', 'second chunk'])
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1000])
+  })
+
+  it('clears buffered audio when discard_pending is received before the next pause flush', async () => {
+    const onFinalSegment = vi.fn()
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({
+        text: 'later',
+        segments: [
+          { start: 0, end: 0.5, text: 'later' }
+        ]
+      }), { status: 200 }))
+    })
+
+    await adapter.start()
+    await adapter.pushAudioFrameBatch({
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: null,
+      frames: [
+        {
+          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
+          timestampMs: 0
+        }
+      ]
+    })
+    await adapter.pushAudioFrameBatch({
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: 'discard_pending',
+      frames: []
+    })
+    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 1000, flushReason: 'speech_pause' }))
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'later',
+      startedAt: '1970-01-01T00:00:01.000Z'
+    }))
   })
 
   it('retries one transient Groq failure without duplicating committed text', async () => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -158,6 +158,11 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     if (batch.channels !== 1) {
       throw new Error(`Groq rolling upload currently requires mono audio. Received channels=${batch.channels}.`)
     }
+    if (batch.flushReason === 'discard_pending') {
+      this.currentChunkFrames.length = 0
+      this.carryoverFrames = []
+      return
+    }
     if (batch.frames.length === 0) {
       return
     }

--- a/src/main/services/streaming/whispercpp-streaming-adapter.ts
+++ b/src/main/services/streaming/whispercpp-streaming-adapter.ts
@@ -172,6 +172,9 @@ export class WhisperCppStreamingAdapter implements StreamingProviderRuntime {
     if (!this.client) {
       throw new Error('Whisper.cpp streaming runtime is not active.')
     }
+    if (batch.flushReason === 'discard_pending') {
+      return
+    }
 
     this.client.writeLine(JSON.stringify({
       type: 'push_audio_batch',

--- a/src/renderer/streaming-audio-ingress.ts
+++ b/src/renderer/streaming-audio-ingress.ts
@@ -2,7 +2,7 @@
 Where: src/renderer/streaming-audio-ingress.ts
 What: Provider-neutral renderer-side batching and transport helper for streaming audio frames.
 Why: Separate frame batching/backpressure behavior from browser audio extraction so PR-4 can lock transport
-     semantics before wiring a real AudioWorklet or equivalent capture source.
+     semantics before wiring browser audio extraction into the ingress path.
 */
 
 import type { StreamingAudioChunkFlushReason, StreamingAudioFrame, StreamingAudioFrameBatch } from '../shared/ipc'
@@ -87,6 +87,16 @@ export class StreamingAudioIngress {
     this.stopped = true
   }
 
+  async discardPendingChunk(): Promise<void> {
+    if (this.stopped) {
+      throw new Error('Streaming audio ingress is stopped.')
+    }
+
+    this.pendingFrames = []
+    this.enqueueControlBatch('discard_pending')
+    await this.ensureDrain()
+  }
+
   private enqueuePendingBatch(flushReason: StreamingAudioChunkFlushReason | null): void {
     if (this.queuedBatches.length >= this.maxQueuedBatches) {
       this.pendingFrames = []
@@ -102,6 +112,22 @@ export class StreamingAudioIngress {
       flushReason
     })
     this.pendingFrames = []
+  }
+
+  private enqueueControlBatch(flushReason: StreamingAudioChunkFlushReason): void {
+    if (this.queuedBatches.length >= this.maxQueuedBatches) {
+      this.pendingFrames = []
+      this.stopped = true
+      this.overflowed = true
+      throw new Error('Streaming audio backpressure limit exceeded.')
+    }
+
+    this.queuedBatches.push({
+      sampleRateHz: this.sampleRateHz,
+      channels: this.channels,
+      frames: [],
+      flushReason
+    })
   }
 
   private ensureDrain(): Promise<void> {

--- a/src/renderer/streaming-live-capture.test.ts
+++ b/src/renderer/streaming-live-capture.test.ts
@@ -148,6 +148,99 @@ describe('startStreamingLiveCapture', () => {
     expect(track.stop).toHaveBeenCalledOnce()
   })
 
+  it('discards a below-threshold blip before the next real utterance flushes', async () => {
+    const track = createTrack()
+    const mediaStream = {
+      getTracks: () => [track]
+    } as unknown as MediaStream
+    const sink = {
+      pushStreamingAudioFrameBatch: vi.fn().mockResolvedValue(undefined)
+    }
+
+    const processorNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onaudioprocess: null as ((event: { playbackTime?: number; inputBuffer: { getChannelData: () => Float32Array } }) => void) | null
+    }
+    const audioContext = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: {} as AudioDestinationNode,
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn()
+      })),
+      createScriptProcessor: vi.fn(() => processorNode),
+      createGain: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        gain: { value: 0 }
+      })),
+      resume: vi.fn(async () => {}),
+      close: vi.fn(async () => {})
+    } as unknown as AudioContext
+
+    const capture = await startStreamingLiveCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      requestedSampleRateHz: 16000,
+      channels: 1,
+      sink,
+      onFatalError: vi.fn(),
+      getUserMedia: vi.fn(async () => mediaStream),
+      createAudioContext: () => audioContext,
+      maxFramesPerBatch: 10
+    })
+
+    processorNode.onaudioprocess?.({
+      playbackTime: 0,
+      inputBuffer: {
+        getChannelData: () => new Float32Array(1600).fill(0.2)
+      }
+    })
+    processorNode.onaudioprocess?.({
+      playbackTime: 0.7,
+      inputBuffer: {
+        getChannelData: () => new Float32Array(1600).fill(0)
+      }
+    })
+    processorNode.onaudioprocess?.({
+      playbackTime: 1.2,
+      inputBuffer: {
+        getChannelData: () => new Float32Array(1600).fill(0.2)
+      }
+    })
+    processorNode.onaudioprocess?.({
+      playbackTime: 1.3,
+      inputBuffer: {
+        getChannelData: () => new Float32Array(1600).fill(0.2)
+      }
+    })
+    processorNode.onaudioprocess?.({
+      playbackTime: 1.9,
+      inputBuffer: {
+        getChannelData: () => new Float32Array(1600).fill(0)
+      }
+    })
+
+    await flushAsyncWork()
+    await capture.cancel()
+
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenNthCalledWith(1, {
+      sampleRateHz: 16000,
+      channels: 1,
+      flushReason: 'discard_pending',
+      frames: []
+    })
+    expect(sink.pushStreamingAudioFrameBatch).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      flushReason: 'speech_pause',
+      frames: expect.arrayContaining([
+        expect.objectContaining({ timestampMs: 1200 }),
+        expect.objectContaining({ timestampMs: 1300 }),
+        expect.objectContaining({ timestampMs: 1900 })
+      ])
+    }))
+  })
+
   it('routes auto-batch drain failures into fatal cleanup', async () => {
     const track = createTrack()
     const mediaStream = {

--- a/src/renderer/streaming-live-capture.ts
+++ b/src/renderer/streaming-live-capture.ts
@@ -118,6 +118,11 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
           })
         }
         const observation = this.chunker.observeFrame(frame, this.audioContext.sampleRate)
+        if (observation.shouldDiscardPending) {
+          void this.ingress.discardPendingChunk().catch((error) => {
+            this.reportFatalError(error)
+          })
+        }
         if (observation.shouldFlush) {
           void this.ingress.flush(observation.reason ?? 'speech_pause').catch((error) => {
             this.reportFatalError(error)

--- a/src/renderer/streaming-speech-chunker.test.ts
+++ b/src/renderer/streaming-speech-chunker.test.ts
@@ -6,28 +6,68 @@ Why: Lock the intended chunk boundary semantics before browser audio capture
 */
 
 import { describe, expect, it } from 'vitest'
-import { StreamingSpeechChunker } from './streaming-speech-chunker'
+import { DEFAULT_STREAMING_SPEECH_CHUNKER_OPTIONS, StreamingSpeechChunker } from './streaming-speech-chunker'
 
 const makeFrame = (amplitude: number, timestampMs: number, sampleCount = 1600) => ({
   samples: new Float32Array(sampleCount).fill(amplitude),
   timestampMs
 })
 
+const sampleCountForMs = (durationMs: number, sampleRateHz = 16000): number => (durationMs / 1000) * sampleRateHz
+
 describe('StreamingSpeechChunker', () => {
   it('does not flush during leading silence', () => {
     const chunker = new StreamingSpeechChunker()
 
-    expect(chunker.observeFrame(makeFrame(0, 0), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0, 100), 16000)).toEqual({ shouldFlush: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 0), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 100), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
   })
 
   it('flushes after speech followed by trailing silence', () => {
     const chunker = new StreamingSpeechChunker()
 
-    expect(chunker.observeFrame(makeFrame(0.2, 0), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0.2, 100), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0, 300), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: true, reason: 'speech_pause' })
+    expect(chunker.observeFrame(makeFrame(0.2, 0), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0.2, 100), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 300), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: true, shouldDiscardPending: false, reason: 'speech_pause' })
+  })
+
+  it('resets after below-threshold speech followed by long silence so a later utterance starts fresh', () => {
+    const chunker = new StreamingSpeechChunker()
+
+    expect(chunker.observeFrame(makeFrame(0.2, 0), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: true, reason: null })
+
+    expect(chunker.observeFrame(makeFrame(0.2, 1200), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0.2, 1300), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 1900), 16000)).toEqual({ shouldFlush: true, shouldDiscardPending: false, reason: 'speech_pause' })
+  })
+
+  it('does not flush just-below-threshold speech after trailing silence', () => {
+    const chunker = new StreamingSpeechChunker()
+    const justBelowMinSpeechMs = DEFAULT_STREAMING_SPEECH_CHUNKER_OPTIONS.minSpeechMs - 10
+
+    expect(chunker.observeFrame(makeFrame(0.2, 0, sampleCountForMs(justBelowMinSpeechMs)), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: true, reason: null })
+  })
+
+  it('still flushes speech at or above the minimum duration threshold', () => {
+    const chunker = new StreamingSpeechChunker()
+    const atMinSpeechMs = DEFAULT_STREAMING_SPEECH_CHUNKER_OPTIONS.minSpeechMs
+
+    expect(chunker.observeFrame(makeFrame(0.2, 0, sampleCountForMs(atMinSpeechMs)), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: true, shouldDiscardPending: false, reason: 'speech_pause' })
+  })
+
+  it('resets without flushing when a short blip reaches the max chunk limit mostly through silence', () => {
+    const chunker = new StreamingSpeechChunker({
+      maxChunkMs: 500
+    })
+
+    expect(chunker.observeFrame(makeFrame(0.2, 0), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0, 420), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: true, reason: null })
+
+    expect(chunker.observeFrame(makeFrame(0.2, 800), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
   })
 
   it('flushes long uninterrupted speech at the max chunk limit', () => {
@@ -35,9 +75,9 @@ describe('StreamingSpeechChunker', () => {
       maxChunkMs: 500
     })
 
-    expect(chunker.observeFrame(makeFrame(0.25, 0), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0.25, 200), 16000)).toEqual({ shouldFlush: false, reason: null })
-    expect(chunker.observeFrame(makeFrame(0.25, 420), 16000)).toEqual({ shouldFlush: true, reason: 'max_chunk' })
+    expect(chunker.observeFrame(makeFrame(0.25, 0), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0.25, 200), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0.25, 420), 16000)).toEqual({ shouldFlush: true, shouldDiscardPending: false, reason: 'max_chunk' })
   })
 
   it('resets after a flush so the next utterance can form a new chunk', () => {
@@ -45,8 +85,8 @@ describe('StreamingSpeechChunker', () => {
 
     chunker.observeFrame(makeFrame(0.2, 0), 16000)
     chunker.observeFrame(makeFrame(0.2, 100), 16000)
-    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: true, reason: 'speech_pause' })
+    expect(chunker.observeFrame(makeFrame(0, 700), 16000)).toEqual({ shouldFlush: true, shouldDiscardPending: false, reason: 'speech_pause' })
 
-    expect(chunker.observeFrame(makeFrame(0.2, 1200), 16000)).toEqual({ shouldFlush: false, reason: null })
+    expect(chunker.observeFrame(makeFrame(0.2, 1200), 16000)).toEqual({ shouldFlush: false, shouldDiscardPending: false, reason: null })
   })
 })

--- a/src/renderer/streaming-speech-chunker.ts
+++ b/src/renderer/streaming-speech-chunker.ts
@@ -16,6 +16,7 @@ export interface StreamingSpeechChunkerOptions {
 
 export interface StreamingSpeechChunkObservation {
   shouldFlush: boolean
+  shouldDiscardPending: boolean
   reason: 'speech_pause' | 'max_chunk' | null
 }
 
@@ -56,24 +57,35 @@ export class StreamingSpeechChunker {
     }
 
     if (this.chunkStartedAtMs === null || !this.hasSpeech) {
-      return { shouldFlush: false, reason: null }
+      return { shouldFlush: false, shouldDiscardPending: false, reason: null }
     }
 
+    const spokenMs = this.lastSpeechAtMs !== null ? this.lastSpeechAtMs - this.chunkStartedAtMs : 0
+
     if (frameEndMs - this.chunkStartedAtMs >= this.maxChunkMs) {
+      if (spokenMs < this.minSpeechMs) {
+        this.reset()
+        return { shouldFlush: false, shouldDiscardPending: true, reason: null }
+      }
       this.reset()
-      return { shouldFlush: true, reason: 'max_chunk' }
+      return { shouldFlush: true, shouldDiscardPending: false, reason: 'max_chunk' }
     }
 
     if (!isSpeech && this.lastSpeechAtMs !== null) {
       const trailingSilenceMs = frameEndMs - this.lastSpeechAtMs
-      const spokenMs = this.lastSpeechAtMs - this.chunkStartedAtMs
       if (trailingSilenceMs >= this.trailingSilenceMs && spokenMs >= this.minSpeechMs) {
         this.reset()
-        return { shouldFlush: true, reason: 'speech_pause' }
+        return { shouldFlush: true, shouldDiscardPending: false, reason: 'speech_pause' }
+      }
+      if (trailingSilenceMs >= this.trailingSilenceMs && spokenMs < this.minSpeechMs) {
+        // Short below-threshold blips should not keep the chunk armed across a
+        // long silence, or later unrelated speech gets merged incorrectly.
+        this.reset()
+        return { shouldFlush: false, shouldDiscardPending: true, reason: null }
       }
     }
 
-    return { shouldFlush: false, reason: null }
+    return { shouldFlush: false, shouldDiscardPending: false, reason: null }
   }
 
   reset(): void {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -101,7 +101,7 @@ export interface StreamingAudioFrame {
   timestampMs: number
 }
 
-export type StreamingAudioChunkFlushReason = 'speech_pause' | 'max_chunk' | 'session_stop'
+export type StreamingAudioChunkFlushReason = 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
 
 export interface StreamingAudioFrameBatch {
   sampleRateHz: number


### PR DESCRIPTION
## Summary
- reset the streaming speech chunker on below-threshold blips and send an explicit discard control signal
- clear provider-side buffered chunk audio on discard so short noise does not contaminate the next utterance
- add focused regressions for chunker reset semantics and discard propagation through the renderer/main adapter path

## Testing
- pnpm vitest run src/renderer/streaming-speech-chunker.test.ts src/renderer/streaming-live-capture.test.ts src/main/services/streaming/chunk-window-policy.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts src/main/services/streaming/whispercpp-streaming-adapter.test.ts