### PR TITLE
Scope streaming stop acknowledgements to owner window

### DIFF
--- a/docs/decisions/2026-03-08-streaming-renderer-owner-of-record.md
+++ b/docs/decisions/2026-03-08-streaming-renderer-owner-of-record.md
@@ -1,0 +1,40 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-renderer-owner-of-record.md
+What: Decision note for establishing a single renderer owner-of-record for streaming session start/stop dispatch.
+Why: Prevent multi-window stop acknowledgements from completing the wrong session shutdown.
+-->
+
+# Decision: Track One Renderer Owner Of Record Per Streaming Session
+
+## Status
+Accepted — March 8, 2026
+
+## Context
+
+The latest-dev stop handshake only tracked `sessionId` + `reason`, while main broadcast streaming start/stop commands to every renderer window.
+
+That made stop acknowledgement unsafe in multi-window cases:
+
+- first matching ack won
+- main could stop the session while the real capture owner was still draining
+
+## Decision
+
+Main now tracks one renderer owner window per streaming session.
+
+- Renderer-initiated starts use the sender window as owner.
+- Hotkey-initiated starts fall back to the focused renderer window, then the first open renderer window.
+- Streaming start and stop commands are dispatched only to that owner window.
+- Renderer stop acknowledgements are validated against the sender window ID before they resolve the pending stop wait.
+
+## Consequences
+
+- Non-owner renderer acks can no longer complete stop for another window.
+- The start and stop paths now share one owner-of-record.
+- Missing owner acks still fall back through the existing timeout path instead of hanging forever.
+
+## Out Of Scope
+
+- Cross-window renderer capture handoff
+- Audio transport changes
+- Startup cleanup or AudioWorklet migration

--- a/src/main/ipc/recording-command-dispatcher.test.ts
+++ b/src/main/ipc/recording-command-dispatcher.test.ts
@@ -5,6 +5,7 @@ import { dispatchRecordingCommandToRenderers, type RendererWindowLike } from './
 const DISPATCH: RecordingCommandDispatch = { command: 'toggleRecording', preferredDeviceId: 'mic-1' }
 
 const makeWindow = (overrides?: Partial<RendererWindowLike>): RendererWindowLike => ({
+  id: 1,
   isDestroyed: () => false,
   webContents: {
     isDestroyed: () => false,
@@ -16,8 +17,8 @@ const makeWindow = (overrides?: Partial<RendererWindowLike>): RendererWindowLike
 
 describe('dispatchRecordingCommandToRenderers', () => {
   it('dispatches to active windows and returns delivery count', () => {
-    const first = makeWindow()
-    const second = makeWindow()
+    const first = makeWindow({ id: 1 })
+    const second = makeWindow({ id: 2 })
 
     const delivered = dispatchRecordingCommandToRenderers([first, second], DISPATCH)
 
@@ -27,9 +28,10 @@ describe('dispatchRecordingCommandToRenderers', () => {
   })
 
   it('skips destroyed and crashed windows', () => {
-    const active = makeWindow()
-    const destroyed = makeWindow({ isDestroyed: () => true })
+    const active = makeWindow({ id: 1 })
+    const destroyed = makeWindow({ id: 2, isDestroyed: () => true })
     const crashed = makeWindow({
+      id: 3,
       webContents: {
         isDestroyed: () => false,
         isCrashed: () => true,
@@ -46,6 +48,7 @@ describe('dispatchRecordingCommandToRenderers', () => {
 
   it('continues when send throws for one window', () => {
     const broken = makeWindow({
+      id: 1,
       webContents: {
         isDestroyed: () => false,
         isCrashed: () => false,
@@ -54,11 +57,22 @@ describe('dispatchRecordingCommandToRenderers', () => {
         })
       }
     })
-    const healthy = makeWindow()
+    const healthy = makeWindow({ id: 2 })
 
     const delivered = dispatchRecordingCommandToRenderers([broken, healthy], DISPATCH)
 
     expect(delivered).toBe(1)
     expect(healthy.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches only to the targeted renderer window when a target id is provided', () => {
+    const first = makeWindow({ id: 1 })
+    const second = makeWindow({ id: 2 })
+
+    const delivered = dispatchRecordingCommandToRenderers([first, second], DISPATCH, 2)
+
+    expect(delivered).toBe(1)
+    expect(first.webContents.send).not.toHaveBeenCalled()
+    expect(second.webContents.send).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ipc/recording-command-dispatcher.ts
+++ b/src/main/ipc/recording-command-dispatcher.ts
@@ -1,6 +1,7 @@
 import { IPC_CHANNELS, type RecordingCommandDispatch } from '../../shared/ipc'
 
 export interface RendererWindowLike {
+  id: number
   isDestroyed: () => boolean
   webContents: {
     isDestroyed: () => boolean
@@ -11,11 +12,15 @@ export interface RendererWindowLike {
 
 export const dispatchRecordingCommandToRenderers = (
   windows: RendererWindowLike[],
-  dispatch: RecordingCommandDispatch
+  dispatch: RecordingCommandDispatch,
+  targetWindowId?: number | null
 ): number => {
   let delivered = 0
 
   for (const window of windows) {
+    if (targetWindowId !== undefined && targetWindowId !== null && window.id !== targetWindowId) {
+      continue
+    }
     if (window.isDestroyed()) {
       continue
     }

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -14,6 +14,16 @@ const mocks = vi.hoisted(() => {
   const showErrorBox = vi.fn()
   const windowSend = vi.fn()
   const logStructured = vi.fn()
+  const windows = [
+    {
+      id: 1,
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        send: windowSend
+      }
+    }
+  ]
   return {
     quit,
     showErrorBox,
@@ -21,15 +31,10 @@ const mocks = vi.hoisted(() => {
     logStructured,
     ipcHandle: vi.fn(),
     ipcOn: vi.fn(),
-    getAllWindows: vi.fn(() => [
-      {
-        isDestroyed: () => false,
-        webContents: {
-          isDestroyed: () => false,
-          send: windowSend
-        }
-      }
-    ]),
+    windows,
+    getAllWindows: vi.fn(() => windows),
+    fromWebContents: vi.fn((webContents) => windows.find((window) => window.webContents === webContents) ?? null),
+    getFocusedWindow: vi.fn(() => windows[0] ?? null),
     settingsCtor: vi.fn(() => {
       throw new Error('invalid settings payload')
     })
@@ -40,7 +45,9 @@ vi.mock('electron', () => ({
   app: { quit: mocks.quit },
   dialog: { showErrorBox: mocks.showErrorBox },
   BrowserWindow: {
-    getAllWindows: mocks.getAllWindows
+    getAllWindows: mocks.getAllWindows,
+    fromWebContents: mocks.fromWebContents,
+    getFocusedWindow: mocks.getFocusedWindow
   },
   ipcMain: {
     handle: mocks.ipcHandle,

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -78,10 +78,12 @@ type MainServices = {
 let services: MainServices | null = null
 const wiredStreamingControllers = new WeakSet<object>()
 const STREAMING_RENDERER_STOP_ACK_TIMEOUT_MS = 1500
+const streamingSessionOwnerWindowIds = new Map<string, number>()
 const pendingStreamingRendererStopAcks = new Map<
   string,
   {
     reason: RendererInitiatedStreamingStopReason
+    ownerWindowId: number | null
     resolve: (acked: boolean) => void
     timeoutHandle: ReturnType<typeof setTimeout>
   }
@@ -96,7 +98,8 @@ const isStreamingStopRequestedDispatch = (
 
 const createStreamingRendererStopAckWait = (
   sessionId: string,
-  reason: RendererInitiatedStreamingStopReason
+  reason: RendererInitiatedStreamingStopReason,
+  ownerWindowId: number | null
 ): {
   promise: Promise<boolean>
   dispose: () => void
@@ -146,6 +149,7 @@ const createStreamingRendererStopAckWait = (
 
   pendingStreamingRendererStopAcks.set(sessionId, {
     reason,
+    ownerWindowId,
     resolve: settle,
     timeoutHandle
   })
@@ -158,12 +162,15 @@ const createStreamingRendererStopAckWait = (
   }
 }
 
-const resolveStreamingRendererStopAck = (ack: StreamingRendererStopAck): void => {
+const resolveStreamingRendererStopAck = (ack: StreamingRendererStopAck, senderWindowId: number | null): void => {
   const pending = pendingStreamingRendererStopAcks.get(ack.sessionId)
   if (!pending) {
     return
   }
   if (pending.reason !== ack.reason) {
+    return
+  }
+  if (pending.ownerWindowId !== null && pending.ownerWindowId !== senderWindowId) {
     return
   }
   pending.resolve(true)
@@ -399,7 +406,67 @@ const broadcastRecordingCommand = (dispatch: RecordingCommandDispatch): number =
   return delivered
 }
 
+const resolveRendererWindowIdFromSender = (sender: Electron.WebContents): number | null =>
+  BrowserWindow.fromWebContents(sender)?.id ?? null
+
+const resolveStreamingOwnerWindowId = (initiatorWindowId: number | null): number | null => {
+  const windows = BrowserWindow.getAllWindows().filter((window) => {
+    if (window.isDestroyed()) {
+      return false
+    }
+    if (window.webContents.isDestroyed()) {
+      return false
+    }
+    if (typeof window.webContents.isCrashed === 'function' && window.webContents.isCrashed()) {
+      return false
+    }
+    return true
+  })
+
+  if (initiatorWindowId !== null && windows.some((window) => window.id === initiatorWindowId)) {
+    return initiatorWindowId
+  }
+
+  const focusedWindow = BrowserWindow.getFocusedWindow?.()
+  if (
+    focusedWindow &&
+    !focusedWindow.isDestroyed() &&
+    !focusedWindow.webContents.isDestroyed() &&
+    (typeof focusedWindow.webContents.isCrashed !== 'function' || !focusedWindow.webContents.isCrashed())
+  ) {
+    return focusedWindow.id
+  }
+
+  return windows[0]?.id ?? null
+}
+
+const dispatchRecordingCommandToOwner = (
+  dispatch: RecordingCommandDispatch,
+  ownerWindowId: number | null
+): number => {
+  const windows = BrowserWindow.getAllWindows()
+  const delivered = dispatchRecordingCommandToRenderers(windows, dispatch, ownerWindowId)
+  if (delivered === 0) {
+    const commandLabel = 'kind' in dispatch ? dispatch.kind : dispatch.command
+    logStructured({
+      level: 'warn',
+      scope: 'main',
+      event: 'recording.dispatch_skipped_no_renderer',
+      message: 'Recording command dispatch skipped because no target renderer window is ready.',
+      context: {
+        command: commandLabel,
+        targetWindowId: ownerWindowId,
+        windowCount: windows.length
+      }
+    })
+  }
+  return delivered
+}
+
 const broadcastStreamingSessionState = (state: StreamingSessionStateSnapshot): void => {
+  if (state.sessionId && (state.state === 'ended' || state.state === 'failed')) {
+    streamingSessionOwnerWindowIds.delete(state.sessionId)
+  }
   forEachOpenWindow((window) => {
     window.webContents.send(IPC_CHANNELS.onStreamingSessionState, state)
   })
@@ -438,21 +505,33 @@ const wireStreamingControllerEvents = (
 
 const executeRecordingCommandDispatch = async (
   commandRouter: RecordingCommandRoutingSurface,
-  dispatch: RecordingCommandDispatch
+  dispatch: RecordingCommandDispatch,
+  initiatorWindowId: number | null = null
 ): Promise<void> => {
+  if ('kind' in dispatch && dispatch.kind === 'streaming_start') {
+    const ownerWindowId = resolveStreamingOwnerWindowId(initiatorWindowId)
+    const delivered = dispatchRecordingCommandToOwner(dispatch, ownerWindowId)
+    if (delivered > 0 && ownerWindowId !== null) {
+      streamingSessionOwnerWindowIds.set(dispatch.sessionId, ownerWindowId)
+    }
+    return
+  }
+
   if (!isStreamingStopRequestedDispatch(dispatch)) {
     broadcastRecordingCommand(dispatch)
     return
   }
 
-  const ackWait = createStreamingRendererStopAckWait(dispatch.sessionId, dispatch.reason)
-  const delivered = broadcastRecordingCommand(dispatch)
+  const ownerWindowId = streamingSessionOwnerWindowIds.get(dispatch.sessionId) ?? null
+  const ackWait = createStreamingRendererStopAckWait(dispatch.sessionId, dispatch.reason, ownerWindowId)
+  const delivered = dispatchRecordingCommandToOwner(dispatch, ownerWindowId)
   if (delivered === 0) {
     ackWait.dispose()
     await commandRouter.stopStreamingSession({
       sessionId: dispatch.sessionId,
       reason: dispatch.reason
     })
+    streamingSessionOwnerWindowIds.delete(dispatch.sessionId)
     return
   }
 
@@ -461,15 +540,17 @@ const executeRecordingCommandDispatch = async (
     sessionId: dispatch.sessionId,
     reason: dispatch.reason
   })
+  streamingSessionOwnerWindowIds.delete(dispatch.sessionId)
 }
 
 const runRecordingCommandThroughRouter = async (
   commandRouter: RecordingCommandRoutingSurface,
-  command: RecordingCommand
+  command: RecordingCommand,
+  initiatorWindowId: number | null = null
 ): Promise<void> => {
   const dispatch = await commandRouter.runRecordingCommand(command)
   if (dispatch) {
-    await executeRecordingCommandDispatch(commandRouter, dispatch)
+    await executeRecordingCommandDispatch(commandRouter, dispatch, initiatorWindowId)
   }
 }
 
@@ -500,8 +581,8 @@ const bindIpcHandlers = (svc: MainServices): void => {
   ipcMain.on(IPC_CHANNELS.playSound, (_event, event: SoundEvent) => {
     svc.soundService.play(event)
   })
-  ipcMain.handle(IPC_CHANNELS.runRecordingCommand, async (_event, command: RecordingCommand) => {
-    await runRecordingCommandThroughRouter(svc.commandRouter, command)
+  ipcMain.handle(IPC_CHANNELS.runRecordingCommand, async (event, command: RecordingCommand) => {
+    await runRecordingCommandThroughRouter(svc.commandRouter, command, resolveRendererWindowIdFromSender(event.sender))
   })
   ipcMain.handle(
     IPC_CHANNELS.submitRecordedAudio,
@@ -514,8 +595,8 @@ const bindIpcHandlers = (svc: MainServices): void => {
   ipcMain.handle(IPC_CHANNELS.stopStreamingSession, (_event, request: StopStreamingSessionRequest) =>
     svc.commandRouter.stopStreamingSession(request)
   )
-  ipcMain.handle(IPC_CHANNELS.ackStreamingRendererStop, (_event, ack: StreamingRendererStopAck) => {
-    resolveStreamingRendererStopAck(ack)
+  ipcMain.handle(IPC_CHANNELS.ackStreamingRendererStop, (event, ack: StreamingRendererStopAck) => {
+    resolveStreamingRendererStopAck(ack, resolveRendererWindowIdFromSender(event.sender))
   })
   ipcMain.handle(IPC_CHANNELS.pushStreamingAudioFrameBatch, (_event, batch: StreamingAudioFrameBatch) =>
     svc.streamingSessionController.pushAudioFrameBatch(batch)
@@ -543,6 +624,7 @@ export const resetMainServicesForTest = (): void => {
     pending.resolve(false)
   }
   pendingStreamingRendererStopAcks.clear()
+  streamingSessionOwnerWindowIds.clear()
 }
 
 export const unregisterGlobalHotkeys = (): void => {

--- a/src/main/test-support/streaming-ipc-round-trip.test.ts
+++ b/src/main/test-support/streaming-ipc-round-trip.test.ts
@@ -9,20 +9,33 @@ import { IPC_CHANNELS } from '../../shared/ipc'
 const mocks = vi.hoisted(() => {
   const windowSend = vi.fn()
   const logStructured = vi.fn()
+  const windows = [
+    {
+      id: 1,
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        send: windowSend
+      }
+    },
+    {
+      id: 2,
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        send: windowSend
+      }
+    }
+  ]
   return {
     windowSend,
     logStructured,
     ipcHandle: vi.fn(),
     ipcOn: vi.fn(),
-    getAllWindows: vi.fn(() => [
-      {
-        isDestroyed: () => false,
-        webContents: {
-          isDestroyed: () => false,
-          send: windowSend
-        }
-      }
-    ])
+    windows,
+    getAllWindows: vi.fn(() => windows),
+    fromWebContents: vi.fn((webContents) => windows.find((window) => window.webContents === webContents) ?? null),
+    getFocusedWindow: vi.fn(() => windows[0] ?? null)
   }
 })
 
@@ -30,7 +43,9 @@ vi.mock('electron', () => ({
   app: {},
   dialog: {},
   BrowserWindow: {
-    getAllWindows: mocks.getAllWindows
+    getAllWindows: mocks.getAllWindows,
+    fromWebContents: mocks.fromWebContents,
+    getFocusedWindow: mocks.getFocusedWindow
   },
   ipcMain: {
     handle: mocks.ipcHandle,
@@ -67,11 +82,18 @@ describe('streaming stop IPC handshake', () => {
   it('times out missing renderer stop acknowledgements and falls back to direct stop', async () => {
     const commandRouter = {
       getAudioInputSources: vi.fn().mockResolvedValue([]),
-      runRecordingCommand: vi.fn().mockResolvedValue({
-        kind: 'streaming_stop_requested',
-        sessionId: 'session-timeout',
-        reason: 'user_stop'
-      }),
+      runRecordingCommand: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: 'streaming_start',
+          sessionId: 'session-timeout',
+          preferredDeviceId: 'mic-1'
+        })
+        .mockResolvedValueOnce({
+          kind: 'streaming_stop_requested',
+          sessionId: 'session-timeout',
+          reason: 'user_stop'
+        }),
       submitRecordedAudio: vi.fn(),
       startStreamingSession: vi.fn(),
       stopStreamingSession: vi.fn(async () => {})
@@ -111,8 +133,10 @@ describe('streaming stop IPC handshake', () => {
     const runRecordingCommand = getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)
     expect(runRecordingCommand).toBeTypeOf('function')
 
+    await runRecordingCommand?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
     let settled = false
-    const stopPromise = runRecordingCommand?.({}, 'toggleRecording') as Promise<void>
+    const stopPromise = runRecordingCommand?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording') as Promise<void>
     void stopPromise.finally(() => {
       settled = true
     })
@@ -144,5 +168,92 @@ describe('streaming stop IPC handshake', () => {
         event: 'streaming.renderer_stop_ack_timeout'
       })
     )
+  })
+
+  it('ignores non-owner stop acknowledgements until the owner renderer acks', async () => {
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: 'streaming_start',
+          sessionId: 'session-owner',
+          preferredDeviceId: 'mic-1'
+        })
+        .mockResolvedValueOnce({
+          kind: 'streaming_stop_requested',
+          sessionId: 'session-owner',
+          reason: 'user_stop'
+        }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession: vi.fn(async () => {})
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: {
+        onSessionState: vi.fn(),
+        onSegment: vi.fn(),
+        onError: vi.fn(),
+        pushAudioFrameBatch: vi.fn()
+      } as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    const runRecordingCommand = getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)
+    expect(runRecordingCommand).toBeTypeOf('function')
+
+    const ackRendererStop = getRegisteredHandle(IPC_CHANNELS.ackStreamingRendererStop)
+
+    await runRecordingCommand?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
+    let settled = false
+    const stopPromise = runRecordingCommand?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording') as Promise<void>
+    void stopPromise.finally(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+
+    await ackRendererStop?.(
+      { sender: mocks.windows[1]?.webContents },
+      { sessionId: 'session-owner', reason: 'user_stop' }
+    )
+    await Promise.resolve()
+
+    expect(commandRouter.stopStreamingSession).not.toHaveBeenCalled()
+    expect(settled).toBe(false)
+
+    await ackRendererStop?.(
+      { sender: mocks.windows[0]?.webContents },
+      { sessionId: 'session-owner', reason: 'user_stop' }
+    )
+    await stopPromise
+
+    expect(commandRouter.stopStreamingSession).toHaveBeenCalledWith({
+      sessionId: 'session-owner',
+      reason: 'user_stop'
+    })
   })
 })


### PR DESCRIPTION
## Summary
- track one renderer owner window per streaming session in main
- target start and stop dispatches to that owner window and validate stop acknowledgements against the sender
- add focused IPC and round-trip regressions for multi-window stop ownership handling

## Testing
- pnpm vitest run src/main/ipc/recording-command-dispatcher.test.ts src/main/ipc/register-handlers.test.ts src/main/test-support/streaming-ipc-round-trip.test.ts