### PR TITLE
Clean up partial streaming capture startup

### DIFF
--- a/docs/decisions/2026-03-08-streaming-live-capture-startup-cleanup.md
+++ b/docs/decisions/2026-03-08-streaming-live-capture-startup-cleanup.md
@@ -1,0 +1,45 @@
+<!--
+Where: docs/decisions/2026-03-08-streaming-live-capture-startup-cleanup.md
+What: Decision note for cleaning up partially initialized renderer audio resources during streaming live-capture startup failure.
+Why: Prevent microphone and AudioContext leaks when startup fails after getUserMedia or AudioContext creation succeeds.
+-->
+
+# Decision: Clean Up Partially Initialized Streaming Capture Resources
+
+## Status
+Accepted - March 8, 2026
+
+## Context
+
+The streaming runtime can fail after `startStreamingLiveCapture()` acquires microphone and audio-context resources. Without a shared cleanup guard, those failures can leak:
+
+- active microphone tracks
+- an open `AudioContext`
+
+Those failures are realistic because startup still performs several fallible steps after resource acquisition:
+
+- audio node creation
+- graph connection
+- `audioContext.resume()`
+
+## Decision
+
+`startStreamingLiveCapture()` now wraps renderer resource acquisition and startup wiring in one cleanup-on-failure guard.
+
+If any startup step throws after the media stream or audio context has been created:
+
+- all acquired media tracks are stopped
+- the audio context is closed best-effort
+- the original error is rethrown
+
+## Consequences
+
+- Failed starts do not leave the microphone active.
+- Failed starts do not wedge later capture attempts with a leaked audio context.
+- The successful capture path is unchanged.
+
+## Out Of Scope
+
+- `AudioWorkletNode` migration
+- streaming stop/drain contract changes
+- chunk-boundary policy

--- a/src/renderer/streaming-live-capture.test.ts
+++ b/src/renderer/streaming-live-capture.test.ts
@@ -437,4 +437,52 @@ describe('startStreamingLiveCapture', () => {
     expect(track.stop).toHaveBeenCalledOnce()
     expect(audioContext.close).toHaveBeenCalledOnce()
   })
+
+  it('cleans up the media stream and audio context if startup fails after resources are acquired', async () => {
+    const track = createTrack()
+    const mediaStream = {
+      getTracks: () => [track]
+    } as unknown as MediaStream
+    const resumeError = new Error('resume failed')
+    const close = vi.fn(async () => {})
+
+    const audioContext = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: {} as AudioDestinationNode,
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn()
+      })),
+      createScriptProcessor: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        onaudioprocess: null
+      })),
+      createGain: vi.fn(() => ({
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        gain: { value: 0 }
+      })),
+      resume: vi.fn(async () => {
+        throw resumeError
+      }),
+      close
+    } as unknown as AudioContext
+
+    await expect(startStreamingLiveCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      requestedSampleRateHz: 16000,
+      channels: 1,
+      sink: {
+        pushStreamingAudioFrameBatch: vi.fn().mockResolvedValue(undefined)
+      },
+      onFatalError: vi.fn(),
+      getUserMedia: vi.fn(async () => mediaStream),
+      createAudioContext: () => audioContext
+    })).rejects.toThrow('resume failed')
+
+    expect(track.stop).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/streaming-live-capture.ts
+++ b/src/renderer/streaming-live-capture.ts
@@ -212,55 +212,65 @@ export const startStreamingLiveCapture = async (options: StreamingLiveCaptureOpt
 
   const createAudioContext = options.createAudioContext ?? ((contextOptions?: AudioContextOptions) => new AudioContext(contextOptions))
   const nowMs = options.nowMs ?? (() => performance.now())
+  let mediaStream: MediaStream | null = null
+  let audioContext: AudioContext | null = null
 
-  const mediaStream = await getUserMedia({
-    audio: options.deviceConstraints
-  })
-  const audioContext = createAudioContext({
-    sampleRate: options.requestedSampleRateHz
-  })
+  try {
+    mediaStream = await getUserMedia({
+      audio: options.deviceConstraints
+    })
+    audioContext = createAudioContext({
+      sampleRate: options.requestedSampleRateHz
+    })
 
-  if (typeof audioContext.createScriptProcessor !== 'function') {
-    for (const track of mediaStream.getTracks()) {
-      track.stop()
+    if (typeof audioContext.createScriptProcessor !== 'function') {
+      throw new Error('This environment does not support live PCM streaming capture.')
     }
-    await closeAudioContextSafely(audioContext)
-    throw new Error('This environment does not support live PCM streaming capture.')
+
+    const sourceNode = audioContext.createMediaStreamSource(mediaStream)
+    const processorNode = audioContext.createScriptProcessor(
+      options.processorBufferSize ?? STREAMING_LIVE_CAPTURE_DEFAULTS.processorBufferSize,
+      options.channels,
+      options.channels
+    )
+    const muteGainNode = audioContext.createGain()
+    muteGainNode.gain.value = 0
+
+    sourceNode.connect(processorNode)
+    processorNode.connect(muteGainNode)
+    muteGainNode.connect(audioContext.destination)
+
+    const ingress = new StreamingAudioIngress(options.sink, {
+      sampleRateHz: audioContext.sampleRate,
+      channels: options.channels,
+      maxFramesPerBatch: options.maxFramesPerBatch ?? STREAMING_LIVE_CAPTURE_DEFAULTS.maxFramesPerBatch,
+      maxQueuedBatches: options.maxQueuedBatches ?? STREAMING_LIVE_CAPTURE_DEFAULTS.maxQueuedBatches
+    })
+
+    const chunker = new StreamingSpeechChunker(options.chunker ?? STREAMING_LIVE_CAPTURE_DEFAULTS.chunker)
+
+    await audioContext.resume()
+
+    return new BrowserStreamingLiveCapture({
+      mediaStream,
+      audioContext,
+      sourceNode,
+      processorNode,
+      muteGainNode,
+      ingress,
+      chunker,
+      onFatalError: options.onFatalError,
+      nowMs
+    })
+  } catch (error) {
+    if (mediaStream) {
+      for (const track of mediaStream.getTracks()) {
+        track.stop()
+      }
+    }
+    if (audioContext) {
+      await closeAudioContextSafely(audioContext)
+    }
+    throw error
   }
-
-  const sourceNode = audioContext.createMediaStreamSource(mediaStream)
-  const processorNode = audioContext.createScriptProcessor(
-    options.processorBufferSize ?? STREAMING_LIVE_CAPTURE_DEFAULTS.processorBufferSize,
-    options.channels,
-    options.channels
-  )
-  const muteGainNode = audioContext.createGain()
-  muteGainNode.gain.value = 0
-
-  sourceNode.connect(processorNode)
-  processorNode.connect(muteGainNode)
-  muteGainNode.connect(audioContext.destination)
-
-  const ingress = new StreamingAudioIngress(options.sink, {
-    sampleRateHz: audioContext.sampleRate,
-    channels: options.channels,
-    maxFramesPerBatch: options.maxFramesPerBatch ?? STREAMING_LIVE_CAPTURE_DEFAULTS.maxFramesPerBatch,
-    maxQueuedBatches: options.maxQueuedBatches ?? STREAMING_LIVE_CAPTURE_DEFAULTS.maxQueuedBatches
-  })
-
-  const chunker = new StreamingSpeechChunker(options.chunker ?? STREAMING_LIVE_CAPTURE_DEFAULTS.chunker)
-
-  await audioContext.resume()
-
-  return new BrowserStreamingLiveCapture({
-    mediaStream,
-    audioContext,
-    sourceNode,
-    processorNode,
-    muteGainNode,
-    ingress,
-    chunker,
-    onFatalError: options.onFatalError,
-    nowMs
-  })
 }


### PR DESCRIPTION
## Summary
- clean up media stream and audio context resources when streaming live-capture startup fails after acquisition
- keep startup cleanup best-effort and localized to the renderer capture path
- add focused startup failure regression coverage

## Testing
- pnpm vitest run src/renderer/streaming-live-capture.test.ts src/renderer/native-recording.test.ts