### PR TITLE
fix: harden streaming session-scoped audio ingress

### DIFF
--- a/docs/decisions/2026-03-09-streaming-session-scoped-audio-ingress-decision.md
+++ b/docs/decisions/2026-03-09-streaming-session-scoped-audio-ingress-decision.md
@@ -1,0 +1,48 @@
+<!--
+Where: docs/decisions/2026-03-09-streaming-session-scoped-audio-ingress-decision.md
+What: Decision note for tightening streaming audio ingress identity and stop contracts.
+Why: Prevent stale/non-owner audio injection and avoid silently treating failed explicit stops as successful.
+-->
+
+# Decision: Scope Streaming Audio Ingress To Session Owner And Fail Loudly On Stop Flush Loss
+
+## Status
+
+Accepted - March 9, 2026
+
+## Context
+
+Issue 440 review found two related contract problems in the streaming path:
+
+- audio frame batches were forwarded into main without session identity or renderer ownership checks
+- explicit `user_stop` could finish "successfully" even when the renderer failed to flush the final stop-time audio tail
+
+Those bugs shared the same root cause: the main/renderer boundary trusted local state too much and did not make the active session explicit in the audio ingress contract.
+
+## Decision
+
+The streaming boundary is now tightened in three ways:
+
+- renderer audio batches sent to main carry `sessionId`
+- main accepts audio only from the registered owner window for that session
+- direct `stopStreamingSession` IPC is reserved for fatal renderer cleanup; user-driven stop/cancel must keep using the recording-command handshake
+
+Explicit renderer `user_stop` also now throws when stop-time worklet flush or transport fails, instead of swallowing the error and acknowledging stop anyway.
+
+## Consequences
+
+- stale or non-owner renderers can no longer inject audio into the active session
+- "no renderer received start" no longer leaves main with an orphaned live session
+- explicit stop failures surface as stop failures instead of silently truncating tail audio
+- fatal cleanup still has a direct stop escape hatch when the renderer cannot participate in the normal ack path
+
+## Trade-Offs
+
+- the shared IPC batch contract is stricter and required touching tests across renderer and main
+- a timed-out stop flush now fails loudly instead of pretending stop succeeded
+- direct stop IPC becomes less general on purpose; convenience is traded away for a safer contract
+
+## Out Of Scope
+
+- fully canceling an IPC batch that already entered main before `user_cancel` was requested
+- redesigning the AudioWorklet flush protocol beyond the current bounded timeout behavior

--- a/docs/research/issue-440-streaming-capture-bug-audit.md
+++ b/docs/research/issue-440-streaming-capture-bug-audit.md
@@ -1,0 +1,163 @@
+<!--
+Where: docs/research/issue-440-streaming-capture-bug-audit.md
+What: Deep bug audit for issue 440 across the streaming renderer capture and main stop/session flow.
+Why: Capture the concrete defects, race conditions, and contract gaps found during code review before any fix work starts.
+-->
+
+# Issue 440 Research: Streaming Capture Bug Audit
+
+## Scope
+
+This audit followed the live streaming path end to end:
+
+- renderer capture startup and teardown in `src/renderer/streaming-live-capture.ts`
+- renderer batching/backpressure in `src/renderer/streaming-audio-ingress.ts`
+- AudioWorklet frame production in `src/renderer/streaming-audio-capture-worklet.js`
+- pause/chunk decisions in `src/renderer/streaming-speech-chunker.ts`
+- renderer recording orchestration in `src/renderer/native-recording.ts`
+- main stop handshake and IPC wiring in `src/main/ipc/register-handlers.ts`
+- main streaming lifecycle in `src/main/core/command-router.ts`
+- main session/runtime acceptance rules in `src/main/services/streaming/streaming-session-controller.ts`
+
+I also read the adjacent decision records and the current tests around stop/drain, worklet migration, and IPC round trips.
+
+## Flow Summary
+
+The intended control flow is:
+
+1. Main starts a streaming session and dispatches `streaming_start` to one renderer.
+2. Renderer starts `startStreamingLiveCapture()`, loads the AudioWorklet, and turns worklet `audio_frame` messages into ingress batches.
+3. `StreamingAudioIngress` forwards `pushStreamingAudioFrameBatch()` IPC calls into main.
+4. On explicit stop, main sends `streaming_stop_requested`, waits for a renderer ack, then stops the session runtime.
+5. On fatal renderer-side failure, renderer tears itself down and directly calls `stopStreamingSession({ reason: 'fatal_error' })`.
+
+That design is sound in broad strokes, but the current implementation still has several real holes.
+
+## Findings
+
+### 1. High: Audio batches are not scoped to a session or renderer owner
+
+Files:
+
+- `src/shared/ipc.ts:106`
+- `src/main/ipc/register-handlers.ts:601`
+- `src/main/services/streaming/streaming-session-controller.ts:202`
+
+`StreamingAudioFrameBatch` carries sample data and flush reason, but no `sessionId` and no owner identity. Main accepts every batch through `pushStreamingAudioFrameBatch()` and forwards it straight into the currently active provider runtime.
+
+That means the owner-of-record protections added for start/stop do not exist for audio ingress itself. If a stale renderer capture survives longer than expected, or another renderer with preload access sends batches while a session is active, main has no way to reject them. The active session can be contaminated with the wrong microphone stream and the controller cannot even detect it.
+
+This is the most serious contract bug in the current flow because it breaks isolation at the audio boundary itself.
+
+### 2. High: Normal `user_stop` hides final-batch transport failures
+
+Files:
+
+- `src/renderer/streaming-live-capture.ts:175`
+- `src/renderer/streaming-live-capture.ts:229`
+- `src/renderer/streaming-live-capture.test.ts:641`
+
+`BrowserStreamingLiveCapture.stop()` records `stopError`, but only rethrows when `reason !== 'user_stop'`. A normal explicit stop therefore looks successful even if the final `session_stop` batch fails to reach main.
+
+Result:
+
+- renderer still tears down
+- renderer still acknowledges stop
+- main still ends the session
+- tail audio can be lost without any user-visible failure
+
+The existing test currently locks in that behavior instead of catching it.
+
+### 3. High: The 250 ms worklet flush timeout can drop the final tail
+
+Files:
+
+- `src/renderer/streaming-live-capture.ts:132`
+- `src/renderer/streaming-live-capture.ts:238`
+- `src/renderer/streaming-live-capture.test.ts:503`
+
+On explicit stop, the renderer sends `{ type: 'flush' }` to the worklet and waits only `250ms`. If the renderer event loop is busy or stalled, the `audio_frame` carrying the final partial buffer can arrive after that timeout. Once stop teardown flips `stopped`, late frames are ignored.
+
+That creates a real tail-loss race:
+
+- worklet has valid buffered speech
+- flush ack arrives too late
+- renderer marks stop complete anyway
+- final buffered speech is discarded
+
+The current tests explicitly verify the late-frame discard path, but there is no coverage for the delayed-but-valid flush case.
+
+### 4. Medium-High: `streaming_start` can orphan an active main session if no renderer receives the start command
+
+Files:
+
+- `src/main/core/command-router.ts:312`
+- `src/main/ipc/register-handlers.ts:511`
+
+Main starts the streaming session before it knows a renderer actually received `streaming_start`. If `dispatchRecordingCommandToOwner()` delivers `0`, the code logs and returns without rollback.
+
+That leaves a split-brain state:
+
+- main session is already `starting` or `active`
+- no renderer owns capture
+- later toggles are interpreted as stop requests for a session that never actually started in the renderer
+
+This is a control-plane/data-plane mismatch and can wedge the session lifecycle until something forces it back to idle.
+
+### 5. Medium: Cancel/fatal teardown does not stop or wait for an in-flight drain
+
+Files:
+
+- `src/renderer/streaming-audio-ingress.ts:84`
+- `src/renderer/streaming-live-capture.ts:213`
+
+`StreamingAudioIngress.cancel()` clears queued work and marks the ingress stopped, but it does not cancel or await `activeDrain`. If a batch started draining just before `user_cancel` or `fatal_error`, that IPC push can keep running after capture has been "canceled".
+
+Practical effect:
+
+- canceled speech is not guaranteed to stay discarded
+- already-started audio delivery may still reach main after local cancel teardown completed
+
+This is especially important for `user_cancel`, where the user expectation is usually "discard everything I was saying".
+
+### 6. Medium: The public `stopStreamingSession` IPC bypasses the renderer stop handshake
+
+Files:
+
+- `src/main/ipc/register-handlers.ts:525`
+- `src/main/ipc/register-handlers.ts:595`
+
+The bounded stop handshake only exists in the recording-command path. The exported `stopStreamingSession` IPC handler directly calls `CommandRouter.stopStreamingSession()` with no renderer ack wait.
+
+Today that direct IPC appears to be used for fatal cleanup, which is safe enough for that reason. But the public contract is still unsafe: any future caller that uses `reason: 'user_stop'` or `reason: 'user_cancel'` through this IPC will bypass the drain-preserving stop handshake and can cut the session off before renderer flush completes.
+
+This is a contract bug waiting for a caller to step on it.
+
+## Tests That Currently Hide These Problems
+
+- `src/main/test-support/streaming-ipc-round-trip.test.ts:82` verifies stop-ack timeout fallback, but does not verify whether renderer drain could still be in progress when fallback fires.
+- `src/renderer/streaming-live-capture.test.ts:503` verifies late frames are ignored after timeout, but not whether those late frames contained valid tail audio.
+- `src/renderer/streaming-live-capture.test.ts:641` accepts stop-time transport failure during `user_stop` as success.
+- There is no coverage for cancel/fatal teardown while `pushStreamingAudioFrameBatch()` is still unresolved.
+- There is no coverage for non-owner or stale renderer audio injection because the audio batch contract currently cannot express ownership at all.
+
+## Review Notes
+
+- I ran two parallel sub-agent reviews over the renderer path and the main control-plane path.
+- I also attempted a second review through the `claude` skill, but the CLI did not return usable output within the allotted runtime, so the report relies on direct code inspection plus the two completed sub-agent reviews.
+
+## Bottom Line
+
+The issue-440 area is not just one bug. The current streaming capture path still has:
+
+- one isolation bug at the audio IPC boundary
+- two separate tail-loss/data-loss bugs on explicit stop
+- one orphan-session lifecycle bug on start
+- one cancel-path leak of already in-flight audio
+- one unsafe public stop contract that bypasses the intended handshake
+
+The highest-priority fixes should be:
+
+1. Scope audio batches to the active session/owner.
+2. Stop swallowing `user_stop` transport failure when the final batch did not reach main.
+3. Replace the fixed 250 ms flush cutoff with a stop contract that does not discard valid late tail data.

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -152,19 +152,22 @@ describe('registerIpcHandlers', () => {
     expect(getRegisteredHandle(IPC_CHANNELS.getStreamingSessionSnapshot)?.({}, undefined)).toEqual(
       expect.objectContaining({ sessionId: 'session-1', state: 'active' })
     )
-    await expect(
-      getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioFrameBatch)?.({}, {
+    await expect(async () =>
+      await getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioFrameBatch)?.({}, {
+        sessionId: 'session-1',
         sampleRateHz: 16000,
         channels: 1,
         flushReason: null,
         frames: [{ samples: new Float32Array([0, 0.1]), timestampMs: 1 }]
       })
-    ).resolves.toBeUndefined()
-    await getRegisteredHandle(IPC_CHANNELS.stopStreamingSession)?.({}, { sessionId: 'session-1', reason: 'user_stop' })
+    ).rejects.toThrow('no owner renderer')
+    await expect(async () =>
+      await getRegisteredHandle(IPC_CHANNELS.stopStreamingSession)?.({}, { sessionId: 'session-1', reason: 'user_stop' })
+    ).rejects.toThrow('reserved for fatal renderer cleanup')
     await getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.({}, 'toggleRecording')
 
     expect(commandRouter.startStreamingSession).toHaveBeenCalledOnce()
-    expect(commandRouter.stopStreamingSession).toHaveBeenCalledWith({ sessionId: 'session-1', reason: 'user_stop' })
+    expect(commandRouter.stopStreamingSession).not.toHaveBeenCalled()
     expect(commandRouter.runRecordingCommand).toHaveBeenCalledWith('toggleRecording')
 
     expect(mocks.windowSend).toHaveBeenCalledWith(
@@ -176,16 +179,12 @@ describe('registerIpcHandlers', () => {
       expect.objectContaining({ sessionId: 'session-1', state: 'active' })
     )
     expect(mocks.windowSend).toHaveBeenCalledWith(
-      IPC_CHANNELS.onStreamingSessionState,
-      expect.objectContaining({ sessionId: 'session-1', state: 'ended', reason: 'user_stop' })
-    )
-    expect(mocks.windowSend).toHaveBeenCalledWith(
       IPC_CHANNELS.onRecordingCommand,
       expect.objectContaining({ command: 'toggleRecording' })
     )
     expect(
       mocks.windowSend.mock.calls.filter(([channel]) => channel === IPC_CHANNELS.onStreamingSessionState)
-    ).toHaveLength(4)
+    ).toHaveLength(2)
   })
 
   it('logs and returns when recording command dispatch finds no renderer windows', async () => {

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -176,6 +176,24 @@ const resolveStreamingRendererStopAck = (ack: StreamingRendererStopAck, senderWi
   pending.resolve(true)
 }
 
+const assertStreamingAudioBatchAllowed = (
+  batch: StreamingAudioFrameBatch,
+  senderWindowId: number | null
+): void => {
+  const ownerWindowId = streamingSessionOwnerWindowIds.get(batch.sessionId)
+  if (ownerWindowId === undefined || ownerWindowId === null) {
+    throw new Error(`Streaming audio frame batch rejected: no owner renderer is registered for session ${batch.sessionId}.`)
+  }
+  if (senderWindowId !== ownerWindowId) {
+    throw new Error(`Streaming audio frame batch rejected: renderer ${senderWindowId ?? 'unknown'} does not own session ${batch.sessionId}.`)
+  }
+
+  const pendingStopAck = pendingStreamingRendererStopAcks.get(batch.sessionId)
+  if (pendingStopAck && pendingStopAck.reason !== 'user_stop') {
+    throw new Error(`Streaming audio frame batch rejected: session ${batch.sessionId} is cancelling.`)
+  }
+}
+
 const initializeServices = (): MainServices => {
   if (services) {
     return services
@@ -513,7 +531,25 @@ const executeRecordingCommandDispatch = async (
     const delivered = dispatchRecordingCommandToOwner(dispatch, ownerWindowId)
     if (delivered > 0 && ownerWindowId !== null) {
       streamingSessionOwnerWindowIds.set(dispatch.sessionId, ownerWindowId)
+      return
     }
+
+    logStructured({
+      level: 'error',
+      scope: 'main',
+      event: 'streaming.start_dispatch_failed_no_renderer',
+      message: 'Streaming session started in main but no renderer received the start command.',
+      context: {
+        sessionId: dispatch.sessionId,
+        targetWindowId: ownerWindowId,
+        delivered
+      }
+    })
+    await commandRouter.stopStreamingSession({
+      sessionId: dispatch.sessionId,
+      reason: 'fatal_error'
+    })
+    streamingSessionOwnerWindowIds.delete(dispatch.sessionId)
     return
   }
 
@@ -592,15 +628,19 @@ const bindIpcHandlers = (svc: MainServices): void => {
   )
   ipcMain.handle(IPC_CHANNELS.getStreamingSessionSnapshot, () => svc.streamingSessionController.getSnapshot())
   ipcMain.handle(IPC_CHANNELS.startStreamingSession, () => svc.commandRouter.startStreamingSession())
-  ipcMain.handle(IPC_CHANNELS.stopStreamingSession, (_event, request: StopStreamingSessionRequest) =>
-    svc.commandRouter.stopStreamingSession(request)
-  )
+  ipcMain.handle(IPC_CHANNELS.stopStreamingSession, (_event, request: StopStreamingSessionRequest) => {
+    if (request.reason !== 'fatal_error') {
+      throw new Error('Direct stopStreamingSession IPC is reserved for fatal renderer cleanup.')
+    }
+    return svc.commandRouter.stopStreamingSession(request)
+  })
   ipcMain.handle(IPC_CHANNELS.ackStreamingRendererStop, (event, ack: StreamingRendererStopAck) => {
     resolveStreamingRendererStopAck(ack, resolveRendererWindowIdFromSender(event.sender))
   })
-  ipcMain.handle(IPC_CHANNELS.pushStreamingAudioFrameBatch, (_event, batch: StreamingAudioFrameBatch) =>
-    svc.streamingSessionController.pushAudioFrameBatch(batch)
-  )
+  ipcMain.handle(IPC_CHANNELS.pushStreamingAudioFrameBatch, (event, batch: StreamingAudioFrameBatch) => {
+    assertStreamingAudioBatchAllowed(batch, resolveRendererWindowIdFromSender(event.sender))
+    return svc.streamingSessionController.pushAudioFrameBatch(batch)
+  })
   ipcMain.handle(IPC_CHANNELS.runPickTransformationFromClipboard, async () => svc.hotkeyService.runPickAndRunTransform())
 }
 

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -28,6 +28,7 @@ const makeBatch = (params: {
   flushReason: 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
   values?: number[]
 }) => ({
+  sessionId: 'session-1',
   sampleRateHz: 16000,
   channels: 1,
   flushReason: params.flushReason,
@@ -139,6 +140,7 @@ describe('GroqRollingUploadAdapter', () => {
 
     await adapter.start()
     await adapter.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,
@@ -150,6 +152,7 @@ describe('GroqRollingUploadAdapter', () => {
       ]
     })
     await adapter.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: 'discard_pending',
@@ -292,6 +295,7 @@ describe('GroqRollingUploadAdapter', () => {
 
     await adapter.start()
     await adapter.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,
@@ -403,6 +407,6 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
       text: 'hello'
     }))
-    releaseFirstSegment?.()
+    ;(releaseFirstSegment as (() => void) | null)?.()
   })
 })

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -197,6 +197,7 @@ describe('InMemoryStreamingSessionController', () => {
 
     await expect(
       controller.pushAudioFrameBatch({
+        sessionId: 'session-1',
         sampleRateHz: 16000,
         channels: 1,
         flushReason: null,
@@ -208,6 +209,7 @@ describe('InMemoryStreamingSessionController', () => {
   it('forwards accepted frame batches into the active provider runtime', async () => {
     const pushAudioFrameBatch = vi.fn(async () => {})
     const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
       createProviderRuntime: () => ({
         start: async () => {},
         stop: async () => {},
@@ -217,6 +219,7 @@ describe('InMemoryStreamingSessionController', () => {
 
     await controller.start(LOCAL_STREAMING_CONFIG)
     await controller.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,
@@ -224,6 +227,7 @@ describe('InMemoryStreamingSessionController', () => {
     })
 
     expect(pushAudioFrameBatch).toHaveBeenCalledWith({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,

--- a/src/main/services/streaming/streaming-session-controller.ts
+++ b/src/main/services/streaming/streaming-session-controller.ts
@@ -182,7 +182,8 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
       return
     }
 
-    if (this.snapshot.state !== 'stopping' || this.snapshot.sessionId !== stoppingSessionId) {
+    const postStopSnapshot = this.snapshot
+    if (postStopSnapshot.state !== 'stopping' || postStopSnapshot.sessionId !== stoppingSessionId) {
       return
     }
 
@@ -202,6 +203,9 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {
     if (this.snapshot.state !== 'active') {
       throw new Error('Streaming audio frame batches require an active session.')
+    }
+    if (batch.sessionId !== this.snapshot.sessionId) {
+      throw new Error(`Streaming audio frame batch session mismatch. Expected ${this.snapshot.sessionId}.`)
     }
 
     await this.currentProviderRuntime?.pushAudioFrameBatch(batch)

--- a/src/main/services/streaming/whispercpp-streaming-adapter.test.ts
+++ b/src/main/services/streaming/whispercpp-streaming-adapter.test.ts
@@ -117,6 +117,7 @@ describe('WhisperCppStreamingAdapter', () => {
     fakeClient.emitStdout(JSON.stringify({ type: 'ready' }))
     await startPromise
     await adapter.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,

--- a/src/main/test-support/streaming-groq-stop-budget.test.ts
+++ b/src/main/test-support/streaming-groq-stop-budget.test.ts
@@ -54,6 +54,7 @@ describe('streaming Groq stop budget integration', () => {
 
     await controller.start(GROQ_STREAMING_CONFIG)
     await controller.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: 'speech_pause',

--- a/src/main/test-support/streaming-stop-integration.test.ts
+++ b/src/main/test-support/streaming-stop-integration.test.ts
@@ -63,6 +63,7 @@ describe('streaming stop integration', () => {
 
     await controller.start(GROQ_STREAMING_CONFIG)
     await controller.pushAudioFrameBatch({
+      sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
       flushReason: null,

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -209,7 +209,7 @@ describe('handleRecordingCommandDispatch', () => {
     }
   )
 
-  it('starts live streaming capture without batch STT key gating when processing.mode=streaming', async () => {
+  it('starts live streaming capture from streaming_start without batch STT or transform key gating', async () => {
     const { deps, state } = createDeps()
     state.settings = structuredClone(DEFAULT_SETTINGS)
     state.settings.processing.mode = 'streaming'
@@ -219,8 +219,20 @@ describe('handleRecordingCommandDispatch', () => {
     state.settings.processing.streaming.model = 'ggml-large-v3-turbo-q5_0'
     state.settings.output.selectedTextSource = 'transformed'
     state.apiKeyStatus = { groq: false, elevenlabs: false, google: false }
+    state.streamingSessionState = {
+      sessionId: 'session-start',
+      state: 'starting',
+      provider: 'local_whispercpp_coreml',
+      transport: 'native_stream',
+      model: 'ggml-large-v3-turbo-q5_0',
+      reason: null
+    }
 
-    await handleRecordingCommandDispatch(deps, { command: 'toggleRecording' })
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-start',
+      preferredDeviceId: 'mic-1'
+    })
 
     expect(getUserMediaMock).toHaveBeenCalledOnce()
     expect(audioContextResumeMock).toHaveBeenCalledOnce()

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -12,6 +12,7 @@ import type {
   AudioInputSource,
   RecordingCommandDispatch,
   RendererInitiatedStreamingStopReason,
+  StreamingAudioFrameBatch,
   StreamingSessionStateSnapshot
 } from '../shared/ipc'
 import { SYSTEM_DEFAULT_AUDIO_SOURCE } from './app-shell-react'
@@ -130,6 +131,14 @@ const buildAudioTrackConstraints = (settings: Settings, selectedDeviceId?: strin
   ...(selectedDeviceId ? { deviceId: { exact: selectedDeviceId } } : {}),
   sampleRate: { ideal: settings.recording.sampleRateHz },
   channelCount: { ideal: settings.recording.channels }
+})
+
+const createStreamingAudioSink = (sessionId: string) => ({
+  pushStreamingAudioFrameBatch: (batch: Omit<StreamingAudioFrameBatch, 'sessionId'>): Promise<void> =>
+    window.speechToTextApi.pushStreamingAudioFrameBatch({
+      ...batch,
+      sessionId
+    })
 })
 
 // ---------------------------------------------------------------------------
@@ -370,14 +379,18 @@ export const startNativeRecording = async (
   }
 
   if (isStreamingMode) {
-    recorderState.streamingSessionId = streamingSessionId ?? null
+    if (!streamingSessionId) {
+      throw new Error('Streaming live capture requires a sessionId.')
+    }
+
+    recorderState.streamingSessionId = streamingSessionId
     recorderState.lastHandledStreamingStopSessionId = null
     try {
       recorderState.streamingCapture = await startStreamingLiveCapture({
         deviceConstraints: constraints.audio as MediaTrackConstraints,
         requestedSampleRateHz: state.settings.recording.sampleRateHz,
         channels: state.settings.recording.channels,
-        sink: window.speechToTextApi,
+        sink: createStreamingAudioSink(streamingSessionId),
         onFatalError: (error) => {
           const message = error instanceof Error ? error.message : 'Unknown streaming capture error'
           const sessionId = recorderState.streamingSessionId ?? state.streamingSessionState.sessionId

--- a/src/renderer/streaming-audio-ingress.test.ts
+++ b/src/renderer/streaming-audio-ingress.test.ts
@@ -147,12 +147,12 @@ describe('StreamingAudioIngress', () => {
     expect(stopResolved).toBe(false)
     expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(1)
 
-    releaseFirstPush?.()
+    ;(releaseFirstPush as (() => void) | null)?.()
     await flushMicrotasks()
     expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(2)
     expect(stopResolved).toBe(false)
 
-    releaseSecondPush?.()
+    ;(releaseSecondPush as (() => void) | null)?.()
     await stopPromise
 
     expect(stopResolved).toBe(true)
@@ -190,7 +190,7 @@ describe('StreamingAudioIngress', () => {
     expect(flushResolved).toBe(false)
     expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(1)
 
-    releaseFirstPush?.()
+    ;(releaseFirstPush as (() => void) | null)?.()
     await expect(flushPromise).rejects.toThrow('push failed')
     expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(2)
   })

--- a/src/renderer/streaming-audio-ingress.ts
+++ b/src/renderer/streaming-audio-ingress.ts
@@ -7,8 +7,10 @@ Why: Separate frame batching/backpressure behavior from browser audio extraction
 
 import type { StreamingAudioChunkFlushReason, StreamingAudioFrame, StreamingAudioFrameBatch } from '../shared/ipc'
 
+type RendererStreamingAudioFrameBatch = Omit<StreamingAudioFrameBatch, 'sessionId'>
+
 export interface StreamingAudioIngressSink {
-  pushStreamingAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void>
+  pushStreamingAudioFrameBatch(batch: RendererStreamingAudioFrameBatch): Promise<void>
 }
 
 export interface StreamingAudioIngressOptions {
@@ -29,7 +31,7 @@ export class StreamingAudioIngress {
   private readonly channels: number
   private readonly maxFramesPerBatch: number
   private readonly maxQueuedBatches: number
-  private readonly queuedBatches: StreamingAudioFrameBatch[] = []
+  private readonly queuedBatches: RendererStreamingAudioFrameBatch[] = []
   private pendingFrames: StreamingAudioFrame[] = []
   private activeDrain: Promise<void> | null = null
   private stopped = false

--- a/src/renderer/streaming-live-capture.test.ts
+++ b/src/renderer/streaming-live-capture.test.ts
@@ -9,6 +9,7 @@ Why: Cover the AudioWorklet-based graph directly instead of relying only on high
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS,
   STREAMING_AUDIO_CAPTURE_WORKLET_NAME,
   startStreamingLiveCapture
 } from './streaming-live-capture'
@@ -492,7 +493,7 @@ describe('startStreamingLiveCapture', () => {
     expect(track.stop).toHaveBeenCalledOnce()
   })
 
-  it('times out a stalled flush and still tears down cleanly on explicit stop', async () => {
+  it('fails explicit stop when the worklet flush stalls, but still tears down cleanly', async () => {
     FakeAudioWorkletNode.flushStrategy = 'stall'
 
     const track = createTrack()
@@ -538,16 +539,17 @@ describe('startStreamingLiveCapture', () => {
       timestampMs: 500
     })
 
-    let stopResolved = false
-    const stopPromise = capture.stop().then(() => {
-      stopResolved = true
+    let stopSettled = false
+    const stopPromise = capture.stop().finally(() => {
+      stopSettled = true
     })
+    void stopPromise.catch(() => {})
 
     await Promise.resolve()
-    expect(stopResolved).toBe(false)
+    expect(stopSettled).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(250)
-    await stopPromise
+    await vi.advanceTimersByTimeAsync(STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS)
+    await expect(stopPromise).rejects.toThrow('Timed out waiting for AudioWorklet capture flush.')
 
     expect(captureNode?.port.postMessage).toHaveBeenCalledWith({ type: 'flush' })
     expect(sink.pushStreamingAudioFrameBatch).toHaveBeenCalledTimes(1)
@@ -597,6 +599,7 @@ describe('startStreamingLiveCapture', () => {
 
     const captureNode = FakeAudioWorkletNode.instances.at(-1)
     const stopPromise = capture.stop()
+    void stopPromise.catch(() => {})
 
     captureNode?.emitMessage({
       type: 'audio_frame',
@@ -604,8 +607,8 @@ describe('startStreamingLiveCapture', () => {
       timestampMs: 750
     })
 
-    await vi.advanceTimersByTimeAsync(250)
-    await stopPromise
+    await vi.advanceTimersByTimeAsync(STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS)
+    await expect(stopPromise).rejects.toThrow('Timed out waiting for AudioWorklet capture flush.')
 
     expect(sink.pushStreamingAudioFrameBatch).not.toHaveBeenCalled()
     expect(track.stop).toHaveBeenCalledOnce()
@@ -655,7 +658,7 @@ describe('startStreamingLiveCapture', () => {
       timestampMs: 500
     })
 
-    await capture.stop()
+    await expect(capture.stop()).rejects.toThrow('push failed during stop')
 
     expect(track.stop).toHaveBeenCalledOnce()
     expect(audioContext.close).toHaveBeenCalledOnce()

--- a/src/renderer/streaming-live-capture.ts
+++ b/src/renderer/streaming-live-capture.ts
@@ -50,7 +50,7 @@ type StreamingAudioCaptureWorkletMessage =
 export const STREAMING_AUDIO_CAPTURE_WORKLET_NAME = 'streaming-audio-capture-processor'
 
 const STREAMING_AUDIO_CAPTURE_WORKLET_URL = new URL('./streaming-audio-capture-worklet.js', import.meta.url).href
-const STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS = 250
+export const STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS = 1_000
 
 export const STREAMING_LIVE_CAPTURE_DEFAULTS = {
   processorBufferSize: 2048,
@@ -226,7 +226,7 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
       await closeAudioContextSafely(this.audioContext)
     }
 
-    if (stopError && reason !== 'user_stop') {
+    if (stopError) {
       throw stopError
     }
   }
@@ -246,14 +246,17 @@ class BrowserStreamingLiveCapture implements StreamingLiveCapture {
       resolveFlush = resolve
     })
     this.resolvePendingFlush = resolveFlush
+    const pendingFlushPromise = this.pendingFlushPromise
 
     this.captureNode.port.postMessage({ type: 'flush' })
-    await Promise.race([
-      this.pendingFlushPromise,
-      delayMs(STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS).then(() => {
-        this.resolvePendingWorkletFlush()
-      })
+    const outcome = await Promise.race([
+      pendingFlushPromise.then(() => 'flushed' as const),
+      delayMs(STREAMING_AUDIO_CAPTURE_FLUSH_TIMEOUT_MS).then(() => 'timed_out' as const)
     ])
+    if (outcome === 'timed_out') {
+      this.resolvePendingWorkletFlush()
+      throw new Error('Timed out waiting for AudioWorklet capture flush.')
+    }
   }
 
   private resolvePendingWorkletFlush(): void {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -104,6 +104,7 @@ export interface StreamingAudioFrame {
 export type StreamingAudioChunkFlushReason = 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
 
 export interface StreamingAudioFrameBatch {
+  sessionId: string
   sampleRateHz: number
   channels: number
   frames: StreamingAudioFrame[]


### PR DESCRIPTION
## Summary
- scope streaming audio frame batches to the active session and owner renderer
- fail loudly on explicit stop flush/transport loss instead of silently acknowledging a truncated stop
- clean up orphaned streaming starts, restrict direct stop IPC to fatal cleanup, and document the issue-440 research/decision

## Testing
- npm test
- git diff --check
- npx tsc -p tsconfig.json --noEmit *(still fails only in the pre-existing app-updater/electron-updater area)*