### PR TITLE
docs: plan Groq browser VAD execution

### DIFF
--- a/docs/decisions/2026-03-09-groq-browser-vad-utterance-architecture-decision.md
+++ b/docs/decisions/2026-03-09-groq-browser-vad-utterance-architecture-decision.md
@@ -1,0 +1,73 @@
+<!--
+Where: docs/decisions/2026-03-09-groq-browser-vad-utterance-architecture-decision.md
+What: Decision note selecting a Whispering-style browser VAD utterance architecture for Groq only.
+Why: Groq is a rolling-upload provider and benefits from better utterance detection, while whisper.cpp should remain on a continuous ingestion path.
+-->
+
+# Decision: Groq Uses Browser VAD Utterance Chunking
+
+## Status
+
+Proposed
+
+## Decision
+
+For `groq_whisper_large_v3_turbo`, we should replace the current renderer RMS chunker with a Whispering-style browser VAD utterance pipeline.
+
+For `local_whispercpp_coreml`, we should keep the current continuous frame-stream model.
+
+## Why
+
+The current Groq path is inherently rolling upload, not native streaming.
+That means utterance boundary quality matters more than frame-level transport semantics.
+
+The current RMS-based chunker is too coarse and too fragile around:
+
+- quiet starts
+- short utterances
+- pause boundaries
+- end-of-utterance clipping
+
+Whispering’s browser VAD model is a better architectural fit for Groq because it emits complete utterance audio on speech end.
+
+The decision is also constrained by these facts:
+
+- `vad-web` does not expose a native mid-utterance split primitive, so the first implementation must stay pause-bounded plus stop-safe
+- utterance-sized audio payloads are too large to treat like the current frame-batch IPC, so the Groq path needs a dedicated transfer-aware utterance contract
+- `whisper.cpp` remains conceptually different because it already has a continuous ingestion runtime
+
+## Consequences
+
+1. The renderer capture path becomes provider-specific.
+2. Groq should get a dedicated transfer-aware utterance IPC contract rather than reusing frame-batch transport.
+3. Groq renderer capture must keep a bounded shadow PCM buffer alongside `MicVAD` so explicit stop can flush safely and utterance timing stays sample-derived enough for ordering and diagnostics.
+4. The first Groq implementation should be pause-bounded plus stop-safe; forced long-speech splitting is deferred to a separate follow-up design.
+5. Groq should preserve ordered emission and model-level dedupe even without audio-overlap between normal VAD utterances.
+6. Normal VAD-completed utterances should not use overlap in the first implementation; any future continuation overlap belongs only to a separate forced-split follow-up.
+7. `whisper.cpp` should remain on the continuous frame transport path.
+
+## Rejected alternatives
+
+### Tune the current RMS chunker only
+
+Rejected because the main weakness is the detector quality, not just the threshold values.
+
+### Force both Groq and whisper.cpp through the same VAD chunking path
+
+Rejected because it would degrade the conceptual model for `whisper.cpp`, which is closer to a true continuous stream.
+
+### Keep Groq on frame batches but improve overlap/dedupe only
+
+Rejected because the largest problem is earlier: utterance boundaries are currently weak before the adapter ever sees them.
+
+## Follow-up
+
+Implementation should follow the design in:
+
+- [2026-03-09-groq-browser-vad-utterance-chunking-design.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md)
+
+Implementation must also verify before coding:
+
+- the pinned `vad-web` package version and callback surface
+- Electron preload support for transfer-aware utterance payloads
+- local asset loading for VAD worklet, ONNX runtime wasm, and Silero model files

--- a/docs/plans/issue-440-groq-browser-vad-execution-plan.md
+++ b/docs/plans/issue-440-groq-browser-vad-execution-plan.md
@@ -1,0 +1,452 @@
+<!--
+Where: docs/plans/issue-440-groq-browser-vad-execution-plan.md
+What: Ticketed execution plan for moving Groq rolling-upload from the current RMS chunker to a browser-VAD utterance architecture.
+Why: Freeze the implementation sequence before coding so each PR is scoped, reviewable, and aligned with the approved design.
+-->
+
+# Issue 440 Execution Plan: Groq Browser VAD Utterance Chunking
+
+Date: 2026-03-09  
+Status: Pre-implementation plan. No production code changes have started from this plan.
+
+## Inputs Reviewed
+
+- Design:
+  - [2026-03-09-groq-browser-vad-utterance-chunking-design.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md)
+- Decision:
+  - [2026-03-09-groq-browser-vad-utterance-architecture-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-09-groq-browser-vad-utterance-architecture-decision.md)
+- Prior research:
+  - [2026-03-09-how-streaming-chunking-works-research.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-how-streaming-chunking-works-research.md)
+  - [2026-03-09-issue-440-deep-debug-hypotheses.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-issue-440-deep-debug-hypotheses.md)
+  - [2026-03-07-epicenter-whispering-vad-chunked-parallel-stt-architecture-research.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-07-epicenter-whispering-vad-chunked-parallel-stt-architecture-research.md)
+- Current runtime files:
+  - [native-recording.ts](/workspace/.worktrees/fix/issue-440/src/renderer/native-recording.ts)
+  - [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+  - [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+  - [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+  - [register-handlers.ts](/workspace/.worktrees/fix/issue-440/src/main/ipc/register-handlers.ts)
+  - [streaming-session-controller.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-session-controller.ts)
+  - [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+  - [ipc.ts](/workspace/.worktrees/fix/issue-440/src/shared/ipc.ts)
+  - [domain.ts](/workspace/.worktrees/fix/issue-440/src/shared/domain.ts)
+- External references:
+  - `@ricky0123/vad-web` API docs
+  - `@ricky0123/vad-web` algorithm docs
+  - Whispering reference code in `resources/references/epicenter-main.zip`
+
+## Planning Constraints
+
+- `1 ticket = 1 PR`.
+- Tickets are sorted by priority and dependency.
+- This workstream is for the Groq rolling-upload path only.
+- `whisper.cpp` must remain on the current continuous frame-stream path.
+- Each ticket must include docs and tests.
+- No ticket should silently widen scope into generic streaming refactors unless explicitly called out.
+
+## Priority Summary
+
+| Priority | Ticket | PR | Outcome | Depends On | Feasibility | Main Risk |
+|---|---|---|---|---|---|---|
+| P0 | T440-01 Contract Freeze | PR-1 | Freeze spec, settings, IPC, payload, and provider-specific capture contracts | None | High | Contract drift before implementation |
+| P1 | T440-02 Renderer Browser VAD Capture | PR-2 | Add Groq-only browser VAD capture and asset boot path behind provider-aware capture factory | PR-1 | Medium | Asset/runtime startup failures in Electron |
+| P2 | T440-03 Transfer-Aware Utterance IPC | PR-3 | Add utterance IPC path, preload bridge, ownership validation, and session-controller ingestion split | PR-1 | Medium | Incorrect transport semantics or renderer/main copy pressure |
+| P3 | T440-04 Groq Ordered Utterance Adapter | PR-4 | Refactor Groq adapter to upload ordered utterances instead of frame accumulation | PR-2, PR-3 | Medium | Sequence, backpressure, dedupe regressions |
+| P4 | T440-05 Stop, Backpressure, and QA Hardening | PR-5 | Finalize stop race handling, backpressure UX, diagnostics, and manual/automated QA gates | PR-4 | Medium | Tail-loss or pause-regression escaping into release |
+
+Priority rationale:
+
+- PR-1 must freeze the contract first because payload shape, settings shape, and provider-specific capture split are architecture seams.
+- PR-2 and PR-3 are split because browser VAD runtime/asset loading and renderer-main transport are different risk domains.
+- PR-4 stays Groq-only so the adapter rewrite does not accidentally drag `whisper.cpp` into the same abstraction.
+- PR-5 is reserved for hardening because stop, backpressure, and slow-network behavior are where this design can still fail after the happy path works.
+
+## Ticket T440-01 (P0): Contract Freeze -> PR-1
+
+### Goal
+
+Freeze the normative contract for Groq browser-VAD utterance chunking before any runtime code changes start.
+
+### Approach
+
+- Update shared spec and planning docs to make the provider split explicit:
+  - Groq uses browser-VAD utterance chunks.
+  - `whisper.cpp` stays continuous frame-streaming.
+- Lock the Groq utterance payload contract:
+  - transfer-aware `ArrayBuffer`
+  - WAV PCM16
+  - mono
+  - `16000 Hz`
+- Lock the sequencing contract:
+  - `utteranceIndex` for utterance ordering
+  - `nextSequence` in main for final segment ordering
+
+### Scope Files
+
+- [spec.md](/workspace/.worktrees/fix/issue-440/specs/spec.md)
+- [issue-440-groq-browser-vad-execution-plan.md](/workspace/.worktrees/fix/issue-440/docs/plans/issue-440-groq-browser-vad-execution-plan.md)
+- [2026-03-09-groq-browser-vad-utterance-chunking-design.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md)
+- [2026-03-09-groq-browser-vad-utterance-architecture-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-09-groq-browser-vad-utterance-architecture-decision.md)
+- [ipc.ts](/workspace/.worktrees/fix/issue-440/src/shared/ipc.ts)
+- [domain.ts](/workspace/.worktrees/fix/issue-440/src/shared/domain.ts)
+
+### Trade-offs
+
+- Selected: provider-specific capture contract.
+  - Pro: matches transport reality and avoids forcing Groq and `whisper.cpp` through one fake streaming model.
+  - Con: less abstract than a single universal capture interface.
+- Rejected: keep the current frame-batch contract and reinterpret batches as utterances.
+  - Pro: less contract churn.
+  - Con: preserves the current conceptual bug and copy-pressure risk.
+
+### Checklist
+
+- [ ] Spec explicitly says Groq rolling-upload uses browser-VAD utterance chunks.
+- [ ] Spec explicitly says `whisper.cpp` remains on native continuous frame transport.
+- [ ] Payload shape is locked.
+- [ ] Sequence allocation is locked.
+- [ ] Settings additions are locked.
+- [ ] ADR and design doc are consistent with the plan.
+
+### Tasks
+
+1. Add a normative spec subsection for provider-specific streaming capture posture.
+2. Add normative payload requirements for Groq utterance IPC.
+3. Add normative sequence-ordering requirements.
+4. Add normative settings requirements for `streaming.groqVad`.
+5. Ensure the plan, ADR, and design doc all use the same contract terms.
+
+### Gates
+
+- No code path work starts until spec, plan, and design use the same payload/ordering/settings vocabulary.
+- Reviewers can answer these without ambiguity:
+  - what crosses IPC for Groq
+  - who assigns utterance order
+  - who assigns final segment order
+  - whether `whisper.cpp` changes here
+
+### Code Snippet
+
+```ts
+export interface StreamingAudioUtteranceChunk {
+  sessionId: string
+  utteranceIndex: number
+  wavBytes: ArrayBuffer
+  wavFormat: 'wav_pcm_s16le_mono_16000'
+  startedAtMs: number
+  endedAtMs: number
+  reason: 'speech_pause' | 'session_stop'
+  source: 'browser_vad'
+}
+```
+
+## Ticket T440-02 (P1): Renderer Browser VAD Capture -> PR-2
+
+### Goal
+
+Add a Groq-only browser VAD capture path in the renderer without disturbing the existing `whisper.cpp` live-frame path.
+
+### Approach
+
+- Introduce a provider-aware capture factory in the renderer.
+- Add `groq-browser-vad-capture.ts` for the Groq path.
+- Keep `streaming-live-capture.ts` for `whisper.cpp`.
+- Bootstrap `@ricky0123/vad-web` assets and VAD startup/teardown explicitly in Electron.
+
+### Scope Files
+
+- [native-recording.ts](/workspace/.worktrees/fix/issue-440/src/renderer/native-recording.ts)
+- [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+- new renderer files:
+  - `src/renderer/groq-browser-vad-capture.ts`
+  - `src/renderer/groq-browser-vad-config.ts`
+  - `src/renderer/groq-browser-vad-capture.test.ts`
+- possible build/runtime files:
+  - `vite.config.*`
+  - preload or asset path helpers if required
+
+### Trade-offs
+
+- Selected: add a second renderer capture path.
+  - Pro: isolates Groq-specific behavior cleanly.
+  - Con: more files and more startup branching.
+- Rejected: teach `streaming-live-capture.ts` to do both frame-streaming and VAD-utterance capture.
+  - Pro: fewer top-level files.
+  - Con: mixes two incompatible capture truths into one module.
+
+### Checklist
+
+- [ ] Renderer capture factory chooses Groq VAD vs `whisper.cpp` frame-streaming.
+- [ ] VAD startup has bounded timeout and fatal-error path.
+- [ ] Stop/cancel/fatal all destroy the VAD instance and release the microphone.
+- [ ] Groq path does not initialize the existing audio worklet capture path.
+- [ ] Browser-VAD asset locations are explicit and test-covered.
+
+### Tasks
+
+1. Add provider-aware capture factory in the renderer start path.
+2. Implement Groq VAD capture state machine.
+3. Implement explicit stop barrier and generation-token guard.
+4. Implement cold-start timeout and startup feedback wiring.
+5. Add tests for:
+   - startup success
+   - startup timeout
+   - natural `onSpeechEnd`
+   - stop during speech
+   - cancel/fatal cleanup
+
+### Gates
+
+- Groq path can start and stop without touching the old worklet frame capture.
+- `whisper.cpp` tests remain unchanged or only minimally rewired through the factory.
+- VAD asset paths are local-app controlled, not CDN-based.
+
+### Code Snippet
+
+```ts
+const capture = config.provider === 'groq_whisper_large_v3_turbo'
+  ? await startGroqBrowserVadCapture({ sink, vad: groqVadOptions, onFatalError })
+  : await startStreamingLiveCapture({ sink, onFatalError, ...frameStreamOptions })
+```
+
+## Ticket T440-03 (P2): Transfer-Aware Utterance IPC -> PR-3
+
+### Goal
+
+Add a dedicated renderer-main utterance transport for Groq that does not clone large typed arrays through the existing invoke path.
+
+### Approach
+
+- Add a new IPC channel and preload bridge for utterance chunks.
+- Require transfer-aware `ArrayBuffer` ownership handoff.
+- Validate session ownership and session state exactly as strictly as the existing frame-batch ingress.
+- Split controller/provider interfaces between frame-stream ingestion and utterance-chunk ingestion.
+
+### Scope Files
+
+- [ipc.ts](/workspace/.worktrees/fix/issue-440/src/shared/ipc.ts)
+- [index.ts](/workspace/.worktrees/fix/issue-440/src/preload/index.ts)
+- [register-handlers.ts](/workspace/.worktrees/fix/issue-440/src/main/ipc/register-handlers.ts)
+- [streaming-session-controller.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-session-controller.ts)
+- [types.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/types.ts)
+- new tests around IPC registration and session-controller routing
+
+### Trade-offs
+
+- Selected: separate utterance IPC contract.
+  - Pro: keeps Groq transport honest and avoids overloading the frame-batch API.
+  - Con: adds more IPC surface.
+- Rejected: multiplex utterances into `pushStreamingAudioFrameBatch`.
+  - Pro: smaller API diff.
+  - Con: destroys type clarity and makes ownership/transport rules muddy again.
+
+### Checklist
+
+- [ ] New utterance IPC channel exists in shared/preload/main.
+- [ ] Transfer-aware handoff is required by the contract.
+- [ ] Session ownership validation matches the current streaming ingress rules.
+- [ ] Controller/provider interfaces distinguish frame-stream and utterance ingestion.
+- [ ] Tests cover allowed and rejected ownership cases.
+
+### Tasks
+
+1. Add shared utterance types and IPC channel.
+2. Expose preload bridge for utterance send.
+3. Register main IPC handler with owner-window validation.
+4. Add controller/provider split for frame-stream vs utterance ingestion.
+5. Add tests for:
+   - owner-window allowed
+   - owner-window rejected
+   - inactive session rejected
+   - stopping/cancel state behavior
+
+### Gates
+
+- Groq utterance transport can be reasoned about without reading the frame-batch code.
+- No large Groq payload depends on structured-clone copying through the old invoke path.
+- Tests prove renderer ownership enforcement still holds.
+
+### Code Snippet
+
+```ts
+await window.speechToTextApi.pushStreamingAudioUtteranceChunk({
+  ...chunk,
+  sessionId
+}, [chunk.wavBytes])
+```
+
+## Ticket T440-04 (P3): Groq Ordered Utterance Adapter -> PR-4
+
+### Goal
+
+Replace Groq’s current frame-accumulation adapter with an ordered utterance uploader that accepts ready-to-upload WAV utterances.
+
+### Approach
+
+- Keep the adapter Groq-specific.
+- Upload one utterance at a time in V1.
+- Use `utteranceIndex` only for utterance ordering.
+- Use `nextSequence` in main for final segment numbering.
+- Preserve dedupe, but retune it for pure utterance boundaries instead of overlap-heavy frame windows.
+
+### Scope Files
+
+- [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+- [chunk-window-policy.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/chunk-window-policy.ts)
+- [streaming-session-controller.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-session-controller.ts)
+- tests:
+  - `src/main/services/streaming/groq-rolling-upload-adapter.test.ts`
+  - stop budget / integration tests
+
+### Trade-offs
+
+- Selected: serial upload in V1.
+  - Pro: removes a large amount of ordering ambiguity while the new path is stabilizing.
+  - Con: sacrifices some throughput under ideal networks.
+- Rejected: keep concurrent uploads immediately.
+  - Pro: better top-end throughput.
+  - Con: more sequence/backpressure/dedupe complexity during the riskiest migration step.
+
+### Checklist
+
+- [ ] Adapter accepts utterance WAV payloads, not frame batches.
+- [ ] Upload ordering is deterministic.
+- [ ] `nextSequence` is monotonic and gap-safe.
+- [ ] Backpressure state is explicit.
+- [ ] Dedupe behavior is covered for:
+  - repeated last word
+  - short repeated word
+  - back-to-back short utterances with small pauses
+
+### Tasks
+
+1. Introduce utterance-ingestion entrypoint in the Groq adapter.
+2. Remove frame accumulation from the Groq path.
+3. Replace chunk-stride sequencing with monotonic `nextSequence`.
+4. Reevaluate dedupe logic against utterance boundaries.
+5. Add tests for:
+   - one utterance -> many provider segments
+   - two utterances in order
+   - repeated word boundaries
+   - no-overlap normal utterances
+   - explicit stop utterance
+
+### Gates
+
+- No Groq code path depends on renderer frame accumulation after this PR.
+- Ordered emission still holds under slow uploads.
+- Dedupe is validated against utterance-style edges, not just overlap edges.
+
+### Code Snippet
+
+```ts
+for (const providerSegment of providerSegments) {
+  const sequence = this.nextSequence
+  this.nextSequence += 1
+  await this.callbacks.onFinalSegment({
+    sessionId: this.params.sessionId,
+    sequence,
+    text: providerSegment.text,
+    startedAt: providerSegment.startedAt,
+    endedAt: providerSegment.endedAt
+  })
+}
+```
+
+## Ticket T440-05 (P4): Stop, Backpressure, and QA Hardening -> PR-5
+
+### Goal
+
+Harden the Groq VAD path around stop races, slow-network backpressure, diagnostics, and release gates.
+
+### Approach
+
+- Add explicit instrumentation at the renderer and adapter boundaries.
+- Convert backpressure into a visible paused state before it becomes terminal.
+- Validate stop behavior across natural end, active speech, misfire boundary, and slow upload drain.
+- Add a manual QA checklist for real microphone behavior.
+
+### Scope Files
+
+- [groq-browser-vad-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/groq-browser-vad-capture.ts)
+- [native-recording.ts](/workspace/.worktrees/fix/issue-440/src/renderer/native-recording.ts)
+- [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+- [register-handlers.ts](/workspace/.worktrees/fix/issue-440/src/main/ipc/register-handlers.ts)
+- [streaming-raw-dictation-manual-checklist.md](/workspace/.worktrees/fix/issue-440/docs/qa/streaming-raw-dictation-manual-checklist.md)
+
+### Trade-offs
+
+- Selected: ship with explicit diagnostics.
+  - Pro: lets us debug real device/network behavior quickly.
+  - Con: more logging and slightly more code surface.
+- Rejected: ship without temporary or structured diagnostics.
+  - Pro: cleaner code diff.
+  - Con: boundary bugs will be much slower to localize.
+
+### Checklist
+
+- [ ] Stop race is covered by tests.
+- [ ] Slow-upload backpressure is visible and test-covered.
+- [ ] Manual QA checklist includes natural pause, long speech, stop-during-speech, and low-volume start cases.
+- [ ] Logs are high-signal and removable later.
+
+### Tasks
+
+1. Add structured diagnostics around:
+   - VAD startup
+   - natural utterance completion
+   - stop barrier resolution
+   - queue-full auto-pause
+   - upload begin/end
+2. Add tests for:
+   - stop during speech
+   - stop during misfire boundary
+   - queue-full auto-pause and resume
+   - startup timeout
+3. Update manual QA checklist.
+4. Remove or gate any low-value debug noise before merge.
+
+### Gates
+
+- One manual test pass exists for real microphone behavior.
+- Stop path is validated under at least one slow-upload scenario.
+- Backpressure does not silently drop utterances.
+
+### Code Snippet
+
+```ts
+logStructured({
+  level: 'info',
+  scope: 'renderer',
+  event: 'streaming.groq_vad.backpressure_pause',
+  message: 'Pausing Groq VAD capture until utterance queue drains.',
+  context: {
+    sessionId,
+    queuedUtterances,
+    maxQueuedUtterances
+  }
+})
+```
+
+## Cross-Ticket Risks
+
+- Electron transfer-aware IPC may require preload/protocol adjustments not obvious from the current code.
+- `vad-web` asset loading may fail in packaged builds even if dev works.
+- Approximate phase-1 timestamps may be good enough for diagnostics but not ideal for future analytics.
+- Long uninterrupted speech remains a deliberate V1 limitation for the Groq path.
+
+## Implementation Order
+
+1. PR-1: freeze contract and spec.
+2. PR-2: Groq renderer capture path and startup semantics.
+3. PR-3: utterance IPC and controller/runtime split.
+4. PR-4: Groq adapter rewrite to ordered utterance uploads.
+5. PR-5: hardening, QA, and diagnostics.
+
+## Definition of Ready
+
+The implementation can start only when:
+
+- this plan is reviewed and clean
+- the design doc and ADR stay consistent with the plan
+- the spec update is committed
+- Groq browser VAD remains explicitly scoped away from `whisper.cpp`

--- a/docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md
+++ b/docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md
@@ -1,0 +1,914 @@
+<!--
+Where: docs/research/2026-03-09-groq-browser-vad-utterance-chunking-design.md
+What: Detailed design for replacing the current Groq chunking heuristic with a Whispering-style browser VAD utterance pipeline.
+Why: The current Groq path is still pause-bounded and relies on coarse RMS thresholding. This document designs a better utterance detector without collapsing the whisper.cpp path into the same architecture.
+-->
+
+# Groq Browser VAD Utterance Chunking Design
+
+## Scope
+
+This is a design-only document.
+No code changes are proposed here.
+
+This design targets only:
+
+- `processing.streaming.provider = groq_whisper_large_v3_turbo`
+- `processing.streaming.transport = rolling_upload`
+
+This design explicitly does **not** change the fundamental model for:
+
+- `processing.streaming.provider = local_whispercpp_coreml`
+- `processing.streaming.transport = native_stream`
+
+## Problem statement
+
+The current Groq streaming path is not true continuous upstream streaming.
+It is pause-bounded rolling upload.
+
+That is acceptable as a transport model for Groq.
+The problem is that the current utterance boundary detector is too primitive.
+
+Today, the renderer uses:
+
+- fixed PCM frames from [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js)
+- a simple RMS threshold + silence timer in [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+
+That current approach has predictable failure modes:
+
+- quiet starts can be dropped
+- boundary timing is coarse
+- pause detection is acoustic but not robust
+- last words near pauses can be clipped
+- short utterances can be misclassified and discarded
+
+The user wants Groq chunking to work more like Whispering.
+
+## What Whispering actually does
+
+I checked the actual Whispering code in `resources/references/epicenter-main.zip`, especially:
+
+- `apps/whispering/src/lib/state/vad-recorder.svelte.ts`
+
+Whispering uses:
+
+- `@ricky0123/vad-web`
+- `MicVAD.new({ submitUserSpeechOnPause: true, model: 'v5' })`
+
+That means it does not implement its own RMS chunker.
+It uses a model-based browser VAD pipeline and receives complete utterance audio when speech ends.
+
+Whispering is therefore:
+
+- utterance-first
+- VAD-driven
+- pause-bounded
+- not true continuous token streaming
+
+For Groq, that is a much better fit than our current heuristic.
+
+## Real browser VAD behavior
+
+Sources:
+
+- Whispering reference code in `resources/references/epicenter-main.zip`
+- official docs for `@ricky0123/vad-web`: https://docs.vad.ricky0123.com/user-guide/api/
+- algorithm docs: https://docs.vad.ricky0123.com/user-guide/algorithm/
+- upstream package README: https://github.com/ricky0123/vad/tree/master/packages/web
+
+## Library surface
+
+The `MicVAD` API exposes:
+
+- `onSpeechStart`
+- `onSpeechRealStart`
+- `onSpeechEnd(audio: Float32Array)`
+- `onVADMisfire`
+- `onFrameProcessed(probabilities, frame)`
+- `submitUserSpeechOnPause`
+- `positiveSpeechThreshold`
+- `negativeSpeechThreshold`
+- `redemptionMs`
+- `preSpeechPadMs`
+- `minSpeechMs`
+- `getStream`
+- `pauseStream`
+- `resumeStream`
+
+Important behavioral facts from the docs:
+
+- `onSpeechEnd` returns audio as `Float32Array` at sample rate `16000`
+- the VAD algorithm runs on model-sized frames
+- for model `v5`, frame size is `512` samples
+- at `16 kHz`, that is `32 ms` per frame
+- speech state transitions are based on speech probability, not raw RMS energy
+- `preSpeechPadMs` prepends context before detected speech
+- `redemptionMs` controls how much speech-negative time is tolerated before closing the utterance
+- `submitUserSpeechOnPause: true` lets pause/end-of-session force emission of the current utterance
+- `MicVAD` does **not** expose a direct "emit the current utterance buffer now" API during active speech
+
+Verified-library constraint:
+
+- this design assumes a pinned `vad-web` release whose API includes `onSpeechRealStart`
+- if the pinned release lacks `onSpeechRealStart`, phase 1 must fall back to `onSpeechStart` plus local confirmed-speech sample counting
+- implementation must not proceed on an unpinned floating version of the VAD package
+
+Implementation constraint for this design:
+
+- phase 1 should **not** rely on `submitUserSpeechOnPause`
+- phase 1 should treat natural `onSpeechEnd` as the only VAD-owned utterance completion path
+- explicit stop should be handled by the renderer-owned live buffer instead of asking MicVAD to flush
+
+## Why this is materially better than the current chunker
+
+Our current chunker operates on about:
+
+- `2048`-sample worklet frames
+- about `128 ms` frame cadence at `16 kHz`
+
+The browser VAD model operates on:
+
+- `512`-sample frames for `v5`
+- about `32 ms` cadence at `16 kHz`
+
+That improves boundary precision by roughly `4x` before any tuning changes are considered.
+
+More importantly, the model is using speech probability rather than RMS only.
+That means the detector is less likely to confuse:
+
+- soft consonants
+- quiet syllables
+- background noise changes
+- breath and plosive boundaries
+
+## Design goals
+
+1. Improve Groq utterance boundaries significantly.
+2. Keep the existing streaming session control plane.
+3. Avoid rewriting the entire main process transport.
+4. Do not degrade or complicate `whisper.cpp` native streaming.
+5. Preserve the ability to stop, cancel, and fail sessions deterministically.
+6. Make boundary behavior observable and tunable.
+
+## Non-goals
+
+1. Do not convert Groq into true native token streaming.
+2. Do not replace `whisper.cpp` with browser VAD chunking.
+3. Do not unify Groq and `whisper.cpp` under one fake "streaming" abstraction.
+4. Do not add transformation-layer changes in this design.
+
+## Current architecture summary
+
+Current Groq path:
+
+1. worklet emits PCM frames
+2. ingress batches frames over IPC
+3. speech chunker decides `speech_pause`, `max_chunk`, or `discard_pending`
+4. main Groq adapter accumulates batches
+5. upload starts only when `flushReason !== null`
+6. overlap/dedupe manage repeated boundary text
+
+This means the renderer currently has two different responsibilities mixed together:
+
+- transport frame batching
+- utterance boundary detection
+
+That is the main thing the redesign should clean up.
+
+## Proposed target architecture
+
+## High-level model
+
+Split the renderer capture layer into two provider-specific modes:
+
+### Mode A: native continuous stream
+
+Used only for:
+
+- `local_whispercpp_coreml`
+
+Behavior:
+
+- keep the current frame-based live capture model
+- keep transport batching
+- remove semantic dependency on renderer chunk boundaries
+
+### Mode B: browser VAD utterance chunking
+
+Used only for:
+
+- `groq_whisper_large_v3_turbo`
+
+Behavior:
+
+- browser VAD owns utterance detection
+- renderer emits complete utterance audio units
+- main Groq adapter uploads those utterances
+- overlap/dedupe become simpler and narrower
+
+This design intentionally makes the renderer path provider-aware.
+That is correct here, because the providers have different transport truths.
+
+## Proposed renderer components
+
+### 1. `groq-browser-vad-capture.ts`
+
+New renderer module responsibility:
+
+- create and manage `MicVAD`
+- maintain a bounded renderer-owned PCM shadow buffer from `onFrameProcessed`
+- request microphone stream
+- emit utterance-level audio payloads
+- surface speech lifecycle signals
+- support graceful stop/cancel semantics
+
+Ownership rule:
+
+- `groq-browser-vad-capture.ts` owns the `MicVAD` instance lifecycle
+- microphone stream acquisition is supplied through the `MicVAD.new({ getStream })` option
+- stop, cancel, fatal error, and init failure must all converge on `MicVAD.destroy()` plus stream cleanup
+
+Suggested interface:
+
+```ts
+export interface GroqVadUtteranceCapture {
+  stop(reason?: StreamingSessionStopReason): Promise<void>
+  cancel(): Promise<void>
+}
+
+export interface GroqVadUtteranceCaptureOptions {
+  deviceConstraints: MediaTrackConstraints
+  sink: GroqUtteranceSink
+  onFatalError: (error: unknown) => void
+  vad: GroqBrowserVadOptions
+}
+```
+
+### 2. `groq-browser-vad-config.ts`
+
+New pure module responsibility:
+
+- own Groq VAD defaults
+- centralize tuning
+- prevent magic numbers from spreading into tests and wiring
+
+Suggested defaults:
+
+- `model = 'v5'`
+- `positiveSpeechThreshold = 0.3`
+- `negativeSpeechThreshold = 0.25`
+- `redemptionMs = 900-1400` search range for tuning, not a pre-validated default
+- `preSpeechPadMs = 300-800` range, default chosen by testing
+- `minSpeechMs = 160-250` range, default chosen by testing
+
+Important point:
+
+We should not blindly copy Whispering defaults.
+Whispering is optimized for hands-free dictation UX in its own app.
+Groq latency and boundary loss may benefit from smaller `preSpeechPadMs` and possibly smaller `redemptionMs`.
+
+## Proposed IPC contract changes
+
+The current IPC contract is frame-batch-centric:
+
+- `pushStreamingAudioFrameBatch(batch)`
+
+For Groq VAD utterances, we should not force utterance blobs through a frame-batch API that was designed for continuous transport.
+
+Recommended approach:
+
+- keep the existing frame-batch IPC for `whisper.cpp`
+- add a second IPC path for utterance chunks
+
+Suggested shared type:
+
+```ts
+export interface StreamingAudioUtteranceChunk {
+  sessionId: string
+  wavBytes: ArrayBuffer
+  wavFormat: 'wav_pcm_s16le_mono_16000'
+  startedAtMs: number
+  endedAtMs: number
+  source: 'browser_vad'
+  utteranceIndex: number
+  reason: 'speech_pause' | 'session_stop'
+}
+```
+
+Suggested renderer API:
+
+- `pushStreamingAudioUtteranceChunk(chunk)`
+
+Why separate IPC is better:
+
+1. It matches the transport truth for Groq.
+2. It avoids pretending utterance chunks are just another frame batch.
+3. It simplifies invariants in the main adapter.
+4. It keeps `whisper.cpp` fast-path unchanged.
+
+Why `ArrayBuffer`-backed WAV instead of `Float32Array`:
+
+1. It makes IPC payload size and representation explicit.
+2. It avoids silently relying on large structured-clone copies of `Float32Array`.
+3. It matches the Groq adapter's eventual WAV construction needs more closely.
+4. It makes transfer and ownership decisions easier to reason about.
+
+Refinement for the first implementation:
+
+- the renderer should emit `wavBytes`, not raw `pcm16le`
+- this keeps the Groq adapter simple because it uploads a ready-to-send WAV payload
+- timestamp metadata still travels alongside the WAV payload for ordering and diagnostics
+- the utterance IPC path must transfer the `ArrayBuffer` to main rather than clone it
+
+Locked payload contract:
+
+- RIFF/WAV container
+- PCM signed 16-bit little-endian payload
+- mono only
+- `16000 Hz` sample rate
+- one utterance per payload
+
+Transport requirement:
+
+- the new utterance IPC must use transfer-aware transport, not plain invoke-style structured-clone only IPC
+- if a transfer-aware preload bridge is not practical, the fallback should be a `MessagePort`-based bridge rather than large typed-array cloning
+- a new shared browser-safe WAV encoder module is required because the current helper in [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts) is main-process-specific
+- the shared encoder must operate on browser-compatible typed arrays rather than Node `Buffer`
+
+## Proposed main-side adapter changes
+
+## New adapter model for Groq
+
+Instead of accumulating `currentChunkFrames` from arbitrary frame batches, the Groq adapter should accept already-formed utterances.
+
+New responsibilities:
+
+- upload one utterance at a time
+- preserve output ordering
+- optionally add overlap only when needed
+- dedupe only where overlap or provider repetition requires it
+
+This changes the Groq adapter from:
+
+- "frame accumulator + upload scheduler"
+
+to:
+
+- "ordered utterance uploader"
+
+That is a cleaner and more honest architecture.
+
+Ordering policy for the first implementation:
+
+- uploads may remain concurrent
+- the existing main-side ordered-emission behavior should be preserved
+- `utteranceIndex` is required so out-of-order HTTP completions can still be reassembled deterministically before segment emission
+
+## Should overlap still exist?
+
+Yes, but in a narrower form.
+
+Today overlap is used for `max_chunk`.
+In the new design:
+
+- `speech_pause` utterances should usually not need overlap
+- phase 1 should not use overlap between naturally completed VAD utterances
+
+So overlap should become tied to:
+
+- forced mid-speech continuity splits
+
+not to:
+
+- normal VAD-completed utterances
+
+## What about long uninterrupted speech?
+
+This is the most important design question after adopting VAD.
+
+A pure "emit only on pause" strategy is not enough if the user speaks continuously for a long time.
+
+Recommended phase 1 policy:
+
+1. Primary boundary mechanism:
+   - browser VAD utterance completion on pause
+2. Explicit stop boundary:
+   - renderer-owned live buffer emits a final `session_stop` utterance
+3. Long uninterrupted speech:
+   - accepted as a known limitation of phase 1
+   - documented as a follow-up problem rather than forced into the first implementation
+   - guarded by a hard renderer-side maximum utterance byte budget that fails the session with an explicit provider-limit error before a likely 413 upload
+
+Why phase 1 deliberately excludes forced splits:
+
+- `MicVAD` has no direct API to flush the current utterance mid-speech
+- combining forced splits with later `onSpeechEnd` reconciliation creates a much more complex duplicate/loss problem
+- the pause-bounded model is already a substantial improvement over the current RMS chunker
+
+Future phase 2 option:
+
+- if long uninterrupted speech remains a real product problem, introduce a hybrid forced-split layer on top of the bounded shadow PCM buffer
+- that phase should be designed separately, because it changes dedupe, overlap, and stop behavior materially
+
+## Stop and cancel semantics in the VAD model
+
+## Stop (`user_stop`)
+
+Desired behavior:
+
+1. set renderer state to `flushing_stop`
+2. create a renderer-owned stop barrier promise
+3. synchronously set `ignoreVadSpeechEnd = true` and increment a stop generation token before the first `await`
+4. prevent any new utterance emission paths from arming
+5. pause or destroy VAD without relying on `submitUserSpeechOnPause`
+6. finalize the renderer-owned live utterance buffer
+7. emit at most one final utterance chunk with `reason = 'session_stop'`
+8. resolve the renderer stop barrier when one of these happens:
+   - the final utterance chunk is handed off successfully
+   - there is no valid buffered speech to submit
+   - a terminal timeout is hit
+9. only after the renderer stop barrier settles does main consume the remaining Groq stop budget for upload drain
+10. end session
+
+The renderer-owned live buffer is the source of truth for explicit stop.
+To avoid double emission races, phase 1 should configure `MicVAD` with:
+
+- `submitUserSpeechOnPause = false`
+
+Stop precedence rule:
+
+- once `flushing_stop` begins, stop becomes the sole terminal utterance emitter
+- any later `onSpeechEnd` callback is ignored if its captured generation token does not match the current live generation
+- this avoids trying to merge a VAD-completed utterance with a stop-time utterance in the same boundary window
+
+Budget ownership rule:
+
+- renderer owns `stop -> final utterance handoff or timeout`
+- main owns `post-handoff upload drain within adapter budget`
+
+## Cancel (`user_cancel`)
+
+Desired behavior:
+
+1. destroy/pause VAD immediately
+2. discard unsubmitted speech buffers
+3. abort in-flight uploads
+4. clear ordering state
+
+## Fatal error
+
+Desired behavior:
+
+1. terminate VAD
+2. stop renderer capture path
+3. notify main
+4. clear pending buffers
+5. abort uploads
+
+## Recommended state machine
+
+Groq renderer VAD state should be explicit.
+
+Suggested states:
+
+- `idle`
+- `initializing`
+- `listening`
+- `speech_detected`
+- `speech_confirmed`
+- `flushing_stop`
+- `stopped`
+- `failed`
+
+Why this matters:
+
+- `onSpeechStart` is not the same as durable speech
+- `onSpeechRealStart` indicates enough frames for a stronger "confirmed speech" signal
+- misfire handling should not be confused with real utterance completion
+
+Cold-start rule:
+
+- `initializing` has a bounded startup timeout
+- if VAD assets or microphone startup do not complete in time, the session fails before entering `listening`
+- user speech that happens before `listening` is not recoverable in V1 and must be surfaced as startup latency, not silently treated as captured audio
+
+Stop-race guardrails:
+
+- once `flushing_stop` begins, no new utterance may be started
+- exactly one terminal utterance emission is allowed during stop
+- late `onSpeechEnd` callbacks must be ignored unconditionally once `ignoreVadSpeechEnd = true`
+- cancel/fatal paths discard all pending renderer-owned utterance buffers immediately
+- the transition to `flushing_stop` must happen before any VAD pause/destroy call
+
+## Detailed callback mapping
+
+Map `MicVAD` callbacks to our app behavior like this.
+
+### `onSpeechStart`
+
+Purpose:
+
+- UI activity only
+- optional diagnostics
+
+Do not upload anything here.
+
+### `onSpeechRealStart`
+
+Purpose:
+
+- transition renderer state to confirmed speech
+- mark the utterance as legitimate
+- useful for diagnostics and eventual UI indicators
+
+### `onVADMisfire`
+
+Purpose:
+
+- log a dropped candidate utterance
+- increment diagnostics counters
+- do not upload
+
+This replaces our current `discard_pending` semantics with a library-native concept.
+Misfires must not consume `utteranceIndex`.
+
+Stop interaction rule:
+
+- during `flushing_stop`, `onVADMisfire` is a no-op for upload behavior
+- if stop lands after `onSpeechStart` but before the library would misfire or end speech, the renderer stop path decides whether the shadow buffer contains enough confirmed speech to emit `session_stop`
+- otherwise stop resolves with no final utterance
+
+### `onSpeechEnd(audio)`
+
+Purpose:
+
+- confirm a naturally completed utterance boundary
+- finalize the current natural utterance
+- clear the renderer-owned live buffer
+- send one utterance payload to main
+
+This becomes the primary Groq audio delivery event.
+
+## Timestamps and utterance metadata
+
+`MicVAD.onSpeechEnd` returns samples at `16000 Hz`, but we still need useful session-relative timing metadata for:
+
+- segment assembly
+- ordering
+- debugging
+- overlap calculations for forced splits
+
+Recommended utterance metadata:
+
+- `startedAtMs`
+- `endedAtMs`
+- `durationMs`
+- `reason`
+- `sessionId`
+- `utteranceIndex`
+
+`utteranceIndex` semantics:
+
+- contiguous and monotonic across emitted utterances only
+- misfires do not consume an index
+- ordering in the Groq adapter must wait only for emitted indices, never for misfire counters
+
+How to derive timing:
+
+- phase 1 must not assume `onFrameProcessed` is already in the final 16 kHz model domain unless runtime verification proves it
+- maintain a monotonically increasing renderer monotonic clock for session-relative diagnostics
+- derive `durationMs` from the emitted utterance WAV payload length at `16000 Hz`
+- derive `endedAtMs` from the renderer monotonic clock when the utterance is sealed
+- derive `startedAtMs = endedAtMs - durationMs`, clamped to `0`
+
+Important constraint:
+
+- `MicVAD.onSpeechEnd` does not itself provide sample-accurate timestamps
+- therefore phase-1 timestamps are approximate session-relative audio-window diagnostics, not canonical segment-ordering inputs
+- utterance ordering must rely on `utteranceIndex`, not timestamp precision
+
+Bounded shadow-buffer policy:
+
+- keep only the current live utterance buffer plus a rolling pre-speech ring sized to `preSpeechPadMs + safety`
+- do not retain the entire session PCM history
+- once an utterance is emitted, the live utterance buffer is cleared and the rolling pre-speech ring continues
+
+Pre-speech alignment rule:
+
+- the emitted WAV payload is sourced from `onSpeechEnd(audio)` for natural utterances and from the renderer shadow buffer only for explicit stop
+- timestamp metadata is derived to match the emitted payload length, not an independently reconstructed hypothetical window
+
+## Proposed settings design
+
+Current `StreamingSettingsSchema` has no provider-specific VAD config.
+
+That is a real gap.
+
+Recommended new nested settings:
+
+```ts
+streaming: {
+  ...
+  groqVad: {
+    model: 'v5'
+    positiveSpeechThreshold: number
+    negativeSpeechThreshold: number
+    redemptionMs: number
+    preSpeechPadMs: number
+    minSpeechMs: number
+  }
+}
+```
+
+Why settings-backed:
+
+1. Tunables must not be hard-coded across files.
+2. We will need empirical tuning.
+3. Tests should derive defaults from one place.
+
+Why there is no `enabled` flag:
+
+- for the Groq rolling-upload path, browser VAD is the intended capture architecture
+- a boolean flag would create an undesigned fallback to the legacy RMS chunker
+- if we ever need fallback behavior, it should be expressed as an explicit capture mode, not a hidden boolean escape hatch
+
+Suggested future-proof expression if rollback is needed:
+
+- `processing.streaming.groqCaptureMode = 'browser_vad' | 'legacy_rms'`
+
+That is intentionally not part of the first design because it would commit us to maintaining both paths indefinitely.
+
+## Recommended defaults
+
+Initial proposed defaults for Groq:
+
+- `model = 'v5'`
+- `positiveSpeechThreshold = 0.3`
+- `negativeSpeechThreshold = 0.25`
+- `redemptionMs = 900` as an initial hypothesis, not a validated production number
+- `preSpeechPadMs = 400`
+- `minSpeechMs = 160`
+
+Rationale:
+
+- lower `redemptionMs` than the package default reduces post-pause lag
+- `900 ms` is still slower than the current `550 ms` silence heuristic and is proposed only as a starting tradeoff for better VAD quality, not as a proven latency win over the current implementation
+- lower `preSpeechPadMs` than Whispering default reduces repeated lead-in context
+- `minSpeechMs = 160` avoids regressing short valid utterances relative to the current path
+
+These are starting points only.
+
+Settings migration requirement:
+
+- the settings repository must default-fill the new `streaming.groqVad` object for existing users
+- validation must treat the block as required when the provider is Groq streaming
+- migration/default-fill must happen during persisted-settings load, not only at UI write time
+
+## Detailed migration plan
+
+## Phase 1: Introduce provider-specific capture abstraction
+
+Create a small renderer capture factory:
+
+- `createStreamingCaptureForProvider(config, sink, ...)`
+
+Behavior:
+
+- `groq` -> VAD utterance capture
+- `whisper.cpp` -> existing live frame capture
+
+This is the architectural separation point.
+
+Explicit Groq-mode rule:
+
+- do not start [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js) in Groq VAD mode
+- MicVAD owns microphone capture for the Groq path
+
+## Phase 2: Add utterance IPC path
+
+Introduce:
+
+- `pushStreamingAudioUtteranceChunk`
+
+Keep:
+
+- `pushStreamingAudioFrameBatch`
+
+Main controller should route:
+
+- frame batches only to native-stream runtimes
+- utterance chunks only to rolling-upload runtimes
+
+Contract change requirement:
+
+- the shared IPC surface must add the new utterance channel
+- the preload bridge must explicitly expose it
+- main IPC registration must validate session ownership for utterance chunks the same way frame batches are validated today
+- the session controller/runtime interfaces must distinguish frame-stream ingestion from utterance-chunk ingestion instead of overloading one method ambiguously
+- the preload bridge must support transferred `ArrayBuffer` payloads for utterance WAV bytes
+- specifically, the runtime surface should expose separate contracts for:
+  - continuous frame ingestion used by native-stream providers
+  - utterance-chunk ingestion used by rolling-upload providers
+
+## Phase 3: Refactor Groq adapter
+
+Replace frame-accumulation semantics with utterance-acceptance semantics.
+
+The new Groq adapter should:
+
+- accept one utterance at a time
+- accept a ready-to-upload WAV payload plus timing metadata
+- use serial upload/drain in V1
+- preserve emission order
+- keep model-level dedupe even when there is no audio overlap
+- keep overlap-specific dedupe available for any later forced-split follow-up work
+- assign final segment `sequence` from a monotonic `nextSequence` counter rather than a stride formula
+- cap `maxInFlightUploads = 1` in V1
+- cap `maxQueuedUtterances = 2` in V1 and auto-pause VAD after the current utterance if the queue is full
+- surface a user-visible backpressure state while the queue drains
+- resume VAD only after queue capacity returns
+- fail the session only if backpressure cannot clear within a bounded watchdog window
+
+Ordering contract:
+
+- `utteranceIndex` is a zero-based, session-local counter assigned in the renderer
+- main owns one monotonic `nextSequence` counter for emitted final segments
+- each provider segment emitted from the current utterance consumes the next sequence number in order
+- `utteranceIndex` is for utterance ordering only, not final segment numbering
+
+## Phase 4: Instrumentation and tuning
+
+Before broad rollout, log:
+
+- speech start
+- speech real start
+- misfire
+- speech end
+- utterance duration
+- upload duration
+- segment dedupe
+
+That should happen before any UX claims about quality improvement.
+
+Explicit IPC payload policy:
+
+- phase 1 requires transfer-aware IPC for utterance `ArrayBuffer` payloads
+- plain structured-clone copying is not an acceptable implementation for utterance WAV payloads
+
+## Optional Phase 5: Long-speech hybrid follow-up
+
+Only if needed after phase 1 tuning:
+
+- add a separate design for long uninterrupted speech splitting
+- keep it explicitly distinct from the base VAD utterance design
+- require a reconciliation algorithm between renderer-emitted forced splits and any later VAD completion callbacks
+
+## Risks and tradeoffs
+
+## Risk 1: Browser VAD asset/runtime complexity
+
+`vad-web` requires:
+
+- model assets
+- ONNX runtime wasm assets
+- worklet support or fallback
+
+This is more operationally complex than our current local chunker.
+
+Mitigation:
+
+- scope it to Groq only
+- package assets explicitly
+- bundle and resolve the VAD worklet, Silero model, and ONNX runtime wasm from app-controlled local asset paths
+- validate Electron renderer/CSP compatibility for those local asset URLs before implementation starts
+- add startup validation and good fatal errors
+
+## Risk 2: Different browser/device behavior
+
+Microphone constraints, AGC, noise suppression, and echo cancellation can affect VAD quality.
+
+Mitigation:
+
+- provide custom `getStream`
+- log real audio constraints
+- tune on representative devices
+- request mono constraints explicitly, but tolerate browser fallback if mono is not honored
+- the capture module should own stream lifecycle explicitly through custom `getStream`, `pauseStream`, and teardown logic so microphone tracks are stopped exactly once
+
+## Risk 3: Forced split still needed
+
+Pure pause-based utterances can stall for uninterrupted speech.
+
+Mitigation:
+
+- accept this in phase 1 and measure it explicitly
+- only add a hybrid split layer in a follow-up design if the measured UX cost justifies the complexity
+- explicitly call out that long uninterrupted speech plus the existing Groq stop budget may still produce weak tail latency when the user stops after a very long utterance
+
+## Risk 4: Session stop semantics are still subtle
+
+Stop must coordinate:
+
+- VAD pause
+- final utterance submit
+- upload drain
+- session controller stop
+
+Mitigation:
+
+- treat stop as a first-class design path
+- test explicit stop during:
+  - silence
+  - active speech
+  - immediately after speech end
+  - concurrently with a natural `onSpeechEnd` callback
+
+## Risk 5: Not all benefits apply to whisper.cpp
+
+Trying to share the same capture architecture across Groq and `whisper.cpp` would reintroduce the current conceptual confusion.
+
+Mitigation:
+
+- keep provider-specific capture modes
+
+## Why not keep the current chunker and just tune thresholds?
+
+Because the current chunker is fundamentally based on:
+
+- coarse worklet frame windows
+- RMS thresholding
+- silence duration
+
+That can be tuned, but it will remain:
+
+- less precise
+- less robust
+- more error-prone on soft speech and boundary words
+
+The problem is not just the threshold values.
+It is the quality of the detector itself.
+
+## Why not use browser VAD for whisper.cpp too?
+
+Because that would downgrade the conceptual model for a provider that already supports a truer continuous stream.
+
+For `whisper.cpp`, the correct optimization targets are:
+
+- frame cadence
+- stop/drain correctness
+- child-process transport reliability
+
+For Groq, the correct optimization target is:
+
+- utterance quality
+
+These are different problems.
+
+## Recommended implementation direction
+
+The right architecture is:
+
+1. keep `whisper.cpp` on continuous frame streaming
+2. move Groq to browser-VAD utterance chunks
+3. introduce provider-specific renderer capture paths
+4. add a dedicated utterance IPC contract
+5. keep the first Groq implementation pause-bounded plus stop-safe
+6. preserve ordered emission and model-level dedupe in the Groq adapter
+7. defer any forced long-speech split layer to a separate follow-up design
+
+## Stop-time minimum-content rule
+
+For a stop-triggered utterance:
+
+- emit only if either:
+  - `onSpeechRealStart` has already fired, or
+  - the renderer has accumulated at least `minSpeechMs` worth of confirmed speech-domain samples
+- otherwise treat the stop-time buffer as a misfire and discard it
+
+Misfire reset rule:
+
+- `onVADMisfire` clears the current live utterance buffer
+- the rolling pre-speech ring continues
+- there is no overlap carryover state in phase 1 normal VAD utterances, so nothing else must be preserved across misfires
+
+## Proposed acceptance criteria
+
+This design is successful if Groq shows these improvements:
+
+1. quiet utterance starts are preserved better than today
+2. end-of-utterance clipping is reduced
+3. short valid utterances are dropped less often
+4. long uninterrupted speech behavior is measured and documented explicitly in V1
+5. stop during active speech reliably produces the final utterance
+6. repeated words at chunk boundaries are reduced, not increased
+7. back-to-back short utterances with pauses shorter than `preSpeechPadMs` do not regress dedupe quality
+
+## Final recommendation
+
+Adopt a Whispering-style browser VAD utterance pipeline for Groq only.
+
+Do not try to "improve streaming" by making every provider obey the same chunker.
+That is the mistake the current architecture is already too close to making.
+
+For Groq, chunking is the transport truth, so improve chunk quality with real VAD.
+For `whisper.cpp`, keep continuous streaming and treat chunking as secondary scaffolding only.

--- a/docs/research/2026-03-09-how-streaming-chunking-works-research.md
+++ b/docs/research/2026-03-09-how-streaming-chunking-works-research.md
@@ -1,0 +1,693 @@
+<!--
+Where: docs/research/2026-03-09-how-streaming-chunking-works-research.md
+What: Detailed research note on how streaming chunking currently works across renderer, main, and provider adapters.
+Why: Give a precise model for debugging chunk-boundary issues before changing the implementation.
+-->
+
+# Research: How Streaming Chunking Works In This Repo
+
+Date: 2026-03-09
+Status: code-backed research, no implementation changes
+
+## Executive Summary
+
+This repo has multiple different things that can all be called "chunking", and they are easy to confuse.
+
+There are really five layers:
+
+1. **Worklet frame chunking**
+   - fixed-size PCM frames emitted by the `AudioWorklet`
+2. **Renderer transport batching**
+   - several frames grouped into one renderer -> main IPC payload
+3. **Renderer speech chunk detection**
+   - pause / max-duration / short-blip logic that decides when a speech chunk boundary happened
+4. **Provider-side audio chunking**
+   - for Groq rolling upload, those boundaries become actual uploaded audio chunks
+   - for whisper.cpp native stream, they mostly do not
+5. **Final text segmentation**
+   - provider final segments committed into ordered output
+
+If a user says "chunking is wrong", the bug could live in any of those layers.
+
+The most important practical distinction is:
+
+- **Whisper.cpp path** is closer to real streaming. Renderer chunk boundaries do not define final STT output; they mostly shape transport and short-blip discard behavior.
+- **Groq rolling-upload path** is not true native streaming. It is deliberate **pause-bounded chunk upload**. In that path, chunk boundaries are first-class and directly affect what audio gets uploaded together.
+
+## Key Terms
+
+### Frame
+
+A small PCM block emitted by the renderer worklet.
+
+Current default:
+
+- `processorBufferSize = 2048` samples in [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+- at `16000 Hz`, one full frame is about `128 ms`
+
+Source:
+
+- [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js)
+
+### Batch
+
+A transport unit sent over IPC from renderer to main.
+
+Current default:
+
+- `maxFramesPerBatch = 6` in [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+- at `16000 Hz` and `2048`-sample frames, one full transport batch is about `768 ms` of audio
+
+### Chunk
+
+An audio window bounded by speech logic, not just transport limits.
+
+Chunk boundaries come from:
+
+- `speech_pause`
+- `max_chunk`
+- `session_stop`
+- `discard_pending`
+
+These reasons are carried as `flushReason`.
+
+### Segment
+
+A finalized text unit emitted by the provider runtime and committed by main.
+
+Source:
+
+- [segment-assembler.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/segment-assembler.ts)
+- [streaming-segment-router.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-segment-router.ts)
+
+## End-To-End Flow
+
+## 1. AudioWorklet produces fixed-size PCM frames
+
+Source:
+
+- [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js)
+
+The worklet reads microphone samples from `inputs[0][0]`.
+
+It accumulates samples into `pendingSamples` until it reaches `frameSize`.
+
+When full, it posts:
+
+- `type: 'audio_frame'`
+- `samples: Float32Array`
+- `timestampMs`
+
+On stop, the renderer sends a `flush` control message. The worklet then:
+
+1. posts one final partial `audio_frame` if samples are buffered
+2. posts `flush_complete`
+
+Important property:
+
+- this layer is **not speech aware**
+- it only knows about sample counts and stop flush
+
+## 2. Renderer receives frames and feeds both ingress and chunker
+
+Source:
+
+- [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+
+Every `audio_frame` is turned into:
+
+- `samples`
+- `timestampMs`
+
+Then two subsystems see it:
+
+1. `StreamingAudioIngress.pushFrame(frame)`
+2. `StreamingSpeechChunker.observeFrame(frame, sampleRateHz)`
+
+That split is important:
+
+- ingress is about **transport**
+- chunker is about **speech boundaries**
+
+## 3. Renderer transport batching
+
+Source:
+
+- [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+- decision: [2026-03-07-streaming-audio-frame-batching-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-07-streaming-audio-frame-batching-decision.md)
+
+Ingress keeps:
+
+- `pendingFrames`
+- `queuedBatches`
+- one shared `activeDrain`
+
+Behavior:
+
+- each incoming frame is copied into `pendingFrames`
+- once `pendingFrames.length >= maxFramesPerBatch`, ingress enqueues a batch with `flushReason: null`
+- a chunker-triggered flush enqueues a batch with a non-null `flushReason`
+- `discard_pending` enqueues a control batch with `frames: []`
+- `stop()` turns remaining pending audio into a `session_stop` batch
+
+Current defaults:
+
+- `maxFramesPerBatch = 6`
+- `maxQueuedBatches = 3`
+
+If queue pressure exceeds the bound, ingress throws instead of silently dropping audio.
+
+Why this exists:
+
+- one IPC call per frame would be too chatty
+- batching lowers IPC overhead
+- batching is transport-level, not semantic STT segmentation
+
+## 4. Renderer speech chunk detection
+
+Source:
+
+- [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+- tests: [streaming-speech-chunker.test.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.test.ts)
+- decision: [2026-03-08-streaming-chunker-short-blip-reset.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-08-streaming-chunker-short-blip-reset.md)
+
+The chunker is a simple RMS + time policy.
+
+Defaults:
+
+- `speechRmsThreshold = 0.015`
+- `trailingSilenceMs = 550`
+- `minSpeechMs = 160`
+- `maxChunkMs = 12000`
+
+The chunker tracks:
+
+- `chunkStartedAtMs`
+- `lastSpeechAtMs`
+- `hasSpeech`
+
+For each frame:
+
+1. compute frame RMS
+2. decide whether the frame counts as speech
+3. update current chunk timing state
+4. possibly emit one of three outcomes:
+
+- no action
+- `shouldFlush = true`
+- `shouldDiscardPending = true`
+
+### `speech_pause`
+
+If the chunk has enough speech and silence lasts at least `trailingSilenceMs`, the chunker flushes with `reason = 'speech_pause'`.
+
+Meaning:
+
+- "the speaker probably finished an utterance"
+
+### `max_chunk`
+
+If total chunk lifetime reaches `maxChunkMs`, the chunker flushes with `reason = 'max_chunk'`.
+
+Meaning:
+
+- "force a chunk boundary even without silence"
+
+This is the continuity safety valve for long uninterrupted speech.
+
+### `discard_pending`
+
+If the chunk was armed by a short blip but total spoken time stays below `minSpeechMs`, the chunker resets and tells ingress to drop buffered audio.
+
+Meaning:
+
+- "this looked like speech briefly, but not enough to keep"
+
+This is the anti-noise / anti-clipped-start guard.
+
+## 5. How renderer chunk decisions affect transport
+
+The live capture loop reacts to chunker observations like this:
+
+- `shouldDiscardPending` -> `ingress.discardPendingChunk()`
+- `shouldFlush` -> `ingress.flush(reason)`
+
+So chunking is not performed by the worklet itself.
+It is imposed later, in the renderer main-thread capture logic.
+
+That means:
+
+- worklet frame size changes transport cadence
+- chunker thresholds change semantic chunk boundaries
+- ingress batching changes IPC shape
+
+All three interact.
+
+## 6. Main-process meaning of those batches depends on provider
+
+Source:
+
+- [streaming-session-controller.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-session-controller.ts)
+- [types.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/types.ts)
+
+Main accepts `StreamingAudioFrameBatch` and forwards them into the active provider runtime.
+
+But the provider runtime decides what those boundaries mean.
+
+## 7. Whisper.cpp path: batches are transport, not semantic chunks
+
+Source:
+
+- [whispercpp-streaming-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/whispercpp-streaming-adapter.ts)
+
+For whisper.cpp:
+
+- each accepted batch is serialized to JSONL and sent to the child process
+- `discard_pending` is ignored
+- other `flushReason` values are effectively ignored at the adapter boundary
+
+This means:
+
+- renderer speech chunk boundaries do **not** directly define final transcript segmentation
+- whisper.cpp itself owns the eventual final-segment timing and chunking internally
+
+So if you are debugging "bad chunking" on whisper.cpp, you must ask:
+
+- is the bug actually in renderer pause detection?
+- or is it the provider runtime's own segmentation logic?
+
+The answer is often the second one.
+
+## 8. Groq path: chunking is the actual upload model
+
+Source:
+
+- [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+- [chunk-window-policy.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/chunk-window-policy.ts)
+- decision: [2026-03-07-groq-rolling-upload-boundary-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-07-groq-rolling-upload-boundary-decision.md)
+- research: [2026-03-07-groq-rolling-upload-dedupe-research.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-07-groq-rolling-upload-dedupe-research.md)
+
+Groq is not using a native realtime stream here.
+It uses **rolling uploaded audio chunks**.
+
+Adapter behavior:
+
+- accumulate incoming frames into `currentChunkFrames`
+- when `flushReason !== null`, package those frames into one chunk upload
+- upload the chunk as a WAV file
+- hold completed chunk results until all earlier chunk indices are ready
+- emit final text in chunk order
+
+This is real chunking, not just transport batching.
+
+### Overlap behavior
+
+Only `max_chunk` creates carryover overlap.
+
+Policy:
+
+- `continuationOverlapMs = 800`
+- overlap only for `max_chunk`
+- no overlap for `speech_pause`
+- no overlap for `session_stop`
+- no overlap for `discard_pending`
+
+Why:
+
+- `speech_pause` is treated as a clean utterance boundary
+- `max_chunk` is an artificial split inside continuous speech, so continuity overlap is needed
+
+### Dedupe behavior
+
+If a chunk had overlap:
+
+- prefer timestamp-based dedupe using `verbose_json` segment timings
+- fall back to text-prefix trimming if only plain text is available
+
+This is why Groq chunking has more moving pieces than whisper.cpp.
+
+## 9. Final text segmentation is another layer again
+
+Source:
+
+- [segment-assembler.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/segment-assembler.ts)
+- [streaming-segment-router.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-segment-router.ts)
+
+Providers emit final segments with:
+
+- `sequence`
+- `text`
+- `startedAt`
+- `endedAt`
+
+Those become canonical app-owned segments, then get committed in order.
+
+This is not audio chunking.
+It is output segmentation.
+
+For `stream_transformed`, these finalized text segments also feed:
+
+- `ContextManager`
+- rolling summary refresh
+- transformation worker pool
+
+So bad audio chunking upstream can ripple into transformation context quality downstream.
+
+## 10. Stop semantics interact with chunking
+
+Relevant docs:
+
+- [2026-03-08-streaming-user-stop-drain-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-08-streaming-user-stop-drain-decision.md)
+- [2026-03-08-streaming-renderer-ingress-drain-contract.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-08-streaming-renderer-ingress-drain-contract.md)
+- [2026-03-08-streaming-command-contract-and-ack-decision.md](/workspace/.worktrees/fix/issue-440/docs/decisions/2026-03-08-streaming-command-contract-and-ack-decision.md)
+
+### `user_stop`
+
+Goal:
+
+- preserve final legitimate tail audio
+- let late final text drain safely
+
+Renderer:
+
+- asks the worklet to flush
+- pushes remaining audio with `session_stop`
+- waits for ingress drain
+
+Main:
+
+- blocks fresh audio ingress once stop begins
+- still accepts late final text segments for `user_stop`
+
+### `user_cancel`
+
+Goal:
+
+- destructive stop
+- do not preserve tail
+
+Renderer:
+
+- cancels ingress
+
+Main:
+
+- does not drain late final segments
+
+### `fatal_error`
+
+Also destructive.
+
+So if you are debugging "it lost the end of what I said", always ask whether the observed stop path was:
+
+- `user_stop`
+- `user_cancel`
+- `fatal_error`
+
+Those are intentionally different.
+
+## 11. Why the same user symptom can come from very different causes
+
+Example user complaint:
+
+"It split my sentence badly."
+
+Possible real causes:
+
+- worklet frame cadence too coarse for the observed timing
+- `speechRmsThreshold` too sensitive or not sensitive enough
+- `trailingSilenceMs` too short
+- `minSpeechMs` too high, causing discard of short utterances
+- `maxChunkMs` too low, forcing continuation splits
+- Groq overlap/dedupe issue after a `max_chunk` boundary
+- whisper.cpp provider-side segmentation, not renderer chunking
+- stop flush timing loss near `session_stop`
+
+These are not the same bug.
+
+## 12. Practical Debug Strategy
+
+If you still get "the same issue", debug in layers.
+
+## 12.1 First isolate the provider path
+
+Ask:
+
+- is this happening on `local_whispercpp_coreml`?
+- or on `groq_whisper_large_v3_turbo`?
+
+If it is whisper.cpp:
+
+- renderer chunk boundaries are not the final text segmentation authority
+- provider runtime behavior matters more
+
+If it is Groq:
+
+- chunk boundaries are the upload model
+- renderer pause logic matters directly
+
+## 12.2 Log `flushReason` transitions
+
+Add temporary logs around:
+
+- `StreamingSpeechChunker.observeFrame(...)`
+- `StreamingAudioIngress.flush(...)`
+- `StreamingAudioIngress.discardPendingChunk(...)`
+- `GroqRollingUploadAdapter.scheduleChunkUpload(...)`
+
+Useful fields:
+
+- frame `timestampMs`
+- frame duration
+- computed RMS
+- current `spokenMs`
+- `trailingSilenceMs`
+- chosen `flushReason`
+- current chunk frame count
+
+If the flush reason itself is surprising, the bug is probably renderer-side.
+
+## 12.3 Measure actual frame and batch durations
+
+At `16000 Hz`:
+
+- `2048` samples ~= `128 ms`
+- `6` frames ~= `768 ms`
+
+If someone expects sub-100 ms response, current defaults are already too coarse for that expectation.
+
+So log:
+
+- `frame.samples.length`
+- `batch.frames.length`
+- effective audio duration per batch
+
+This often explains "laggy chunking" reports immediately.
+
+## 12.4 Verify whether the problem is pause detection or max-chunk rollover
+
+If boundaries appear during silence:
+
+- inspect `speech_pause`
+
+If boundaries happen mid-sentence:
+
+- inspect `max_chunk`
+
+If short utterances vanish:
+
+- inspect `minSpeechMs`
+- inspect `discard_pending`
+
+That triage tells you which threshold family is actually involved.
+
+## 12.5 For Groq, inspect overlap and dedupe explicitly
+
+Log per upload:
+
+- `chunkIndex`
+- `flushReason`
+- `chunkStartMs`
+- `chunkEndMs`
+- whether carryover existed
+- overlap frame timestamps
+
+If duplicate text only appears after long continuous speech, the likely culprit is:
+
+- `max_chunk` split
+- overlap carryover
+- dedupe logic
+
+Not plain pause chunking.
+
+## 12.6 Compare audio chunk boundaries to committed text segments
+
+The right debug view is a timeline table:
+
+- frame timestamp
+- flush reason
+- provider chunk index
+- provider final segment start/end
+- committed output text
+
+Without this, it is too easy to blame the wrong layer.
+
+## 12.7 Use the existing tests as probes
+
+Good places to start:
+
+- [streaming-speech-chunker.test.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.test.ts)
+- [streaming-live-capture.test.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.test.ts)
+- [groq-rolling-upload-adapter.test.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.test.ts)
+- [chunk-window-policy.test.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/chunk-window-policy.test.ts)
+
+If the issue is reproducible, write the reproduction first as:
+
+- a chunker unit test
+- then an ingress/live-capture test
+- then a provider-adapter test
+
+in that order.
+
+## 12.8 Reproduce with controlled input, not live speech first
+
+Use deterministic audio:
+
+- short blip
+- long silence
+- uninterrupted speech-length tone
+- tone-silence-tone pattern
+
+This is much better than trying to debug from microphone variability first.
+
+The repo already has streaming and mic fixture assets in `e2e/fixtures/` and `src/main/test-support/`.
+
+## 13. Is the chunk approach actually the right approach?
+
+Short answer:
+
+- **For Groq rolling-upload: yes, mostly**
+- **For whisper.cpp native stream: only partially**
+- **For true realtime partial-token UX: not by itself**
+
+## 13.1 Where chunking is the right approach
+
+Chunking is the right approach when the provider surface is fundamentally file-based or pause-bounded.
+
+That is exactly the Groq rolling-upload case.
+
+Why it is right there:
+
+- the upstream API is upload-oriented, not session-stream oriented
+- pause chunks are honest to the provider contract
+- max-chunk overlap gives continuity during long speech
+- ordered emission + dedupe solves the biggest chunking failure modes
+
+For that provider, chunking is not a workaround. It is the architecture.
+
+## 13.2 Where chunking is only transport help
+
+For whisper.cpp native stream:
+
+- transport batching is useful
+- short-blip discard is useful
+- but speech chunk boundaries are not the main segmentation authority
+
+So if the product goal is "continuous local streaming dictation with provider-native segmentation", the current chunker is not the whole answer.
+
+## 13.3 Where chunking is the wrong mental model
+
+If the product goal is:
+
+- low-latency partial text updates
+- token-level or near-token-level continuity
+- minimal sentence-boundary lag
+- provider-native streaming semantics
+
+then pause-bounded chunking alone is not enough.
+
+You need a true session-oriented streaming model where:
+
+- audio flows continuously
+- provider runtime owns segmentation or partial hypotheses
+- chunking becomes secondary or provider-specific
+
+This repo already implicitly acknowledges that split:
+
+- `native_stream` for whisper.cpp
+- `rolling_upload` for Groq
+
+That is the right abstraction boundary.
+
+## 13.4 My conclusion
+
+The current architecture is directionally correct **if you keep the two modes conceptually separate**:
+
+1. **Transport batching** is always reasonable.
+2. **Pause-bounded chunking** is right for rolling-upload providers.
+3. **Provider-native streaming** should not be forced into the same mental model.
+
+So the answer is not "chunking is wrong".
+The answer is:
+
+- chunking is right for some transports
+- chunking is only part of the story for native streams
+- debugging must identify which layer is actually misbehaving
+
+## 14. Most Likely Places To Look If The User Still Sees The Same Issue
+
+In priority order:
+
+1. [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+   - wrong silence / min-speech / max-chunk threshold behavior
+2. [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+   - wrong interaction between frame arrival, chunker observation, and ingress flush/discard
+3. [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+   - overlap or dedupe error after `max_chunk`
+4. [whispercpp-streaming-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/whispercpp-streaming-adapter.ts)
+   - provider-side segmentation expectations mismatch
+5. stop-path timing around `session_stop`
+   - especially if the complaint is "the very end gets lost"
+
+## 15. Recommended Next Debug Session
+
+Before implementing anything, the cleanest next debug pass would be:
+
+1. Reproduce on one provider only.
+2. Add temporary logs for:
+   - frame timestamp
+   - RMS
+   - `spokenMs`
+   - `trailingSilenceMs`
+   - `flushReason`
+   - batch frame count
+   - Groq chunk index / overlap
+3. Capture one failing trace.
+4. Build a timeline:
+   - input audio
+   - renderer chunk decisions
+   - provider chunk uploads or stream pushes
+   - final committed segments
+5. Only then decide whether the fix belongs in:
+   - threshold tuning
+   - transport batching
+   - Groq overlap/dedupe
+   - stop flush behavior
+   - provider-native segmentation expectations
+
+## Bottom Line
+
+Chunking in this repo is not one mechanism.
+
+It is a stack:
+
+- fixed worklet frames
+- IPC transport batches
+- renderer speech chunk boundaries
+- provider-specific audio chunk semantics
+- final text segment commits
+
+If you debug "chunking" as one thing, you will usually fix the wrong layer.
+
+For Groq, chunking is the real delivery model.
+For whisper.cpp, chunking is mostly scaffolding around a truer streaming runtime.

--- a/docs/research/2026-03-09-issue-440-deep-debug-hypotheses.md
+++ b/docs/research/2026-03-09-issue-440-deep-debug-hypotheses.md
@@ -1,0 +1,505 @@
+<!--
+Where: docs/research/2026-03-09-issue-440-deep-debug-hypotheses.md
+What: Deep follow-up research note for issue 440, focused on remaining chunking-related failure modes and debugging strategy.
+Why: The first issue-440 fix hardened session ownership and stop semantics, but the user still reproduces the symptom. This document separates likely remaining defects from architecture-driven behavior.
+-->
+
+# Issue 440 Deep Debug Hypotheses
+
+## Scope
+
+This note is a follow-up to:
+
+- [2026-03-09-how-streaming-chunking-works-research.md](/workspace/.worktrees/fix/issue-440/docs/research/2026-03-09-how-streaming-chunking-works-research.md)
+- [issue-440-streaming-capture-bug-audit.md](/workspace/.worktrees/fix/issue-440/docs/research/issue-440-streaming-capture-bug-audit.md)
+
+The first document explains the chunking pipeline.
+The second documents bugs that were already fixed.
+
+This document answers a narrower question:
+
+> If the user still sees issue 440 after the stop/session fix, what are the most plausible remaining causes?
+
+## Executive conclusion
+
+The most important remaining fact is this:
+
+1. The renderer always captures continuously.
+2. The renderer always sends IPC batches continuously.
+3. But the Groq adapter does **not** upload continuously.
+4. It uploads only when a batch arrives with a non-null `flushReason`.
+
+That means the Groq path is still fundamentally **pause-bounded chunk upload**, not true continuous upstream streaming.
+
+So if the user-visible symptom is one of these:
+
+- "it only transcribes after I pause"
+- "it still waits too long before text appears"
+- "the last word before a pause is sometimes clipped"
+- "the end of the utterance still disappears or arrives late"
+
+then the remaining problem may be:
+
+- a real chunk-boundary bug, or
+- the current architecture behaving as designed but not matching the expected UX
+
+Both are plausible.
+
+## What the code is actually doing now
+
+### 1. Worklet framing
+
+File:
+
+- [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js)
+
+The worklet emits fixed-size PCM frames.
+
+Default frame size:
+
+- `2048` samples
+
+At `16000 Hz`, one frame is about:
+
+- `2048 / 16000 = 0.128 s`
+- about `128 ms`
+
+This matters because all chunk observations are quantized by that frame size.
+The system cannot react at sub-frame precision.
+
+### 2. Renderer transport batching
+
+File:
+
+- [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+
+Default ingress limits:
+
+- `maxFramesPerBatch = 6`
+- `maxQueuedBatches = 3`
+
+At `128 ms` per frame, a full auto batch is about:
+
+- `6 * 128 ms = 768 ms`
+
+For whisper.cpp, those batches go straight to the runtime.
+For Groq, those batches do **not** automatically trigger upload.
+
+### 3. Speech chunking
+
+File:
+
+- [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+
+Defaults:
+
+- `speechRmsThreshold = 0.015`
+- `trailingSilenceMs = 550`
+- `minSpeechMs = 160`
+- `maxChunkMs = 12000`
+
+The chunker emits only these semantic decisions:
+
+- `speech_pause`
+- `max_chunk`
+- `discard_pending`
+
+`session_stop` comes from ingress stop, not from the chunker.
+
+### 4. Live capture wiring
+
+File:
+
+- [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+
+Each worklet frame is sent to two places:
+
+- ingress, for transport batching
+- chunker, for semantic boundary decisions
+
+When chunker says flush, `streaming-live-capture.ts` calls:
+
+- `ingress.flush('speech_pause')`, or
+- `ingress.flush('max_chunk')`
+
+When chunker says discard, `streaming-live-capture.ts` calls:
+
+- `ingress.discardPendingChunk()`
+
+### 5. Provider meaning diverges here
+
+Files:
+
+- [whispercpp-streaming-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/whispercpp-streaming-adapter.ts)
+- [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+
+#### whisper.cpp path
+
+Whisper.cpp receives every non-discard batch immediately.
+
+Meaning:
+
+- transport batching matters
+- semantic chunking matters much less
+- final transcription boundaries are mostly decided by the provider runtime
+
+#### Groq path
+
+Groq accumulates `currentChunkFrames` on every incoming batch.
+It schedules a network upload **only when** `batch.flushReason !== null`.
+
+Meaning:
+
+- plain auto batches with `flushReason = null` do not create near-realtime server work
+- `speech_pause` and `session_stop` are actual upload boundaries
+- `max_chunk` is a forced upload boundary for long uninterrupted speech
+
+This is the single most important architectural fact behind issue 440.
+
+## Most plausible remaining causes
+
+## Hypothesis 1: The user is observing architecture, not a regression
+
+If the provider is Groq, the app is not true streaming.
+It is chunked rolling upload.
+
+That means the earliest upload usually happens at one of these points:
+
+- enough trailing silence to trigger `speech_pause`
+- `maxChunkMs` during uninterrupted speech
+- explicit stop
+
+So if the complaint is "I still do not get continuous live transcription while speaking", that is consistent with the current design.
+
+This is not fixed by the earlier session/stop patch, because that patch made stop and session ownership safer. It did not convert Groq into a true streaming transport.
+
+## Hypothesis 2: `speech_pause` is too coarse because the worklet frame is large
+
+The chunker sees one RMS value per frame.
+With `2048` samples at `16 kHz`, boundary decisions happen in about `128 ms` chunks.
+
+That creates several effects:
+
+- speech start can be detected late by up to almost one frame
+- trailing silence can be recognized late by up to almost one frame
+- short soft consonants near a boundary can be swallowed into silence
+- stop-time flush can feel late even when it is technically correct
+
+A `550 ms` trailing silence threshold plus `128 ms` frame granularity means actual flush timing can effectively be closer to:
+
+- about `550-678 ms`, depending on frame alignment
+
+That is before IPC scheduling, upload, inference, and output commit.
+
+## Hypothesis 3: `discard_pending` can still hide quiet starts or short phrases
+
+Files:
+
+- [streaming-speech-chunker.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-speech-chunker.ts)
+- [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+
+If speech energy stays below threshold, or total speech duration stays below `minSpeechMs`, the renderer can send:
+
+- `discard_pending`
+
+That causes:
+
+- pending ingress audio to be cleared
+- Groq `currentChunkFrames` to be cleared
+- Groq `carryoverFrames` to be cleared
+- whisper.cpp to ignore the control batch
+
+If the user symptom is "quiet first syllables disappear" or "short utterances vanish", this is a prime suspect.
+
+## Hypothesis 4: Groq boundary overlap is missing on pause boundaries
+
+File:
+
+- [chunk-window-policy.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/chunk-window-policy.ts)
+
+Current rule:
+
+- overlap only for `max_chunk`
+- overlap is `0` for `speech_pause`
+- overlap is `0` for `session_stop`
+
+That policy is coherent if pause boundaries are truly clean.
+But in reality, pause detection is based on frame RMS and a silence timer, not on linguistic boundaries.
+
+So the last phoneme or word near a pause can straddle the boundary.
+
+If the user symptom is:
+
+- "the last word before a pause gets clipped"
+- "the first word after a pause is repeated or missing"
+
+then the current no-overlap-on-`speech_pause` rule is a strong suspect.
+
+This is especially plausible because the boundary detector is intentionally coarse and acoustic, not transcript-aware.
+
+## Hypothesis 5: The remaining issue is downstream from chunking
+
+Files:
+
+- [segment-assembler.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/segment-assembler.ts)
+- [streaming-segment-router.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-segment-router.ts)
+
+The user may describe the symptom as chunking, but the actual failure may be later:
+
+- provider final segments may be correct
+- router ordering may delay visible emission
+- transformation fallback may alter output
+- dedupe may trim too aggressively
+
+This matters most on the Groq path, where overlap and dedupe intentionally manipulate output around chunk boundaries.
+
+## Hypothesis 6: Stop is now safer, but still not equivalent to "flush everything instantly"
+
+The prior fix made explicit stop surface errors instead of silently succeeding.
+That removed one major blind spot.
+
+But even with that fix:
+
+- worklet flush happens first
+- ingress drain happens second
+- provider stop drain happens third
+
+On Groq, `user_stop` still has a budgeted drain.
+If uploads are slow, stop can still behave like "best effort within the budget" rather than "guaranteed final result no matter how long it takes."
+
+If the symptom appears specifically at the end of dictation, stop-path instrumentation is still required.
+
+## Likely root-cause ranking
+
+If the provider is `groq`:
+
+1. The current architecture is still pause-bounded, so "still not really streaming" is expected.
+2. `speech_pause` boundary timing is too coarse because of `2048`-sample frames.
+3. No overlap on `speech_pause` can clip or gap words near pause boundaries.
+4. `discard_pending` can drop quiet starts and short utterances.
+5. Stop drain timing can still make the tail feel unreliable under slow network conditions.
+
+If the provider is `local_whispercpp_coreml`:
+
+1. Chunking is probably not the main culprit.
+2. The most likely issue is capture cadence, worklet frame size, or child-process runtime behavior.
+3. `discard_pending` still matters for quiet starts or short utterances.
+4. Stop-path timing remains worth checking, but provider segmentation owns more of the result here.
+
+## Easiest ways to debug locally
+
+These are the cheapest checks that do not require architecture changes.
+
+## 1. First isolate the provider
+
+Do not debug Groq and whisper.cpp together.
+
+Run the same utterance on:
+
+- `local_whispercpp_coreml`
+- `groq`
+
+If only Groq reproduces, the issue is probably not renderer capture alone.
+It is likely pause-bounded upload semantics, overlap, or dedupe.
+
+If both reproduce the same way, the issue is more likely in:
+
+- worklet frame sizing
+- chunker thresholds
+- ingress stop/drain timing
+
+## 2. Use one deterministic utterance pattern
+
+Use the same spoken script every time, for example:
+
+1. "alpha bravo charlie"
+2. pause for about `700 ms`
+3. "delta echo"
+4. stop immediately after `echo`
+
+This single script exercises:
+
+- `speech_pause`
+- post-pause restart
+- final stop flush
+
+If you test random speech, boundary failures are much harder to localize.
+
+## 3. Correlate one timeline, not just one transcript
+
+For the same utterance, capture these moments:
+
+1. first frame arrives
+2. first frame above RMS threshold
+3. `speech_pause` or `max_chunk` decision
+4. ingress batch sent
+5. provider upload begins
+6. provider result arrives
+7. final segment is emitted to UI
+
+Without one joined timeline, chunking bugs and routing bugs look identical.
+
+## 4. Distinguish these failure shapes
+
+Ask which of these you see:
+
+- text appears only after pauses
+- tail words disappear on stop
+- quiet beginnings disappear
+- repeated words appear near boundaries
+- long uninterrupted speech stalls until `max_chunk`
+
+Each one points to a different layer.
+
+## 5. Measure actual frame and batch durations
+
+Do not assume the actual input sample rate equals the requested sample rate.
+
+Check:
+
+- actual `audioContext.sampleRate`
+- actual `frame.samples.length`
+- time delta between consecutive worklet frames
+- time delta between ingress batches
+
+If the browser is running at a different real sample rate than expected, timing assumptions can drift.
+
+## If you want temporary logging code, these are the best probe points
+
+If local debugging without code changes is not enough, these are the highest-value temporary logs to add.
+
+## Probe A: Renderer frame/chunker log
+
+File:
+
+- [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+
+Log for each frame:
+
+- `sessionId`
+- `timestampMs`
+- `samples.length`
+- computed RMS
+- chunker decision
+- whether `discardPendingChunk()` was called
+- whether `flush()` was called and with what reason
+
+This tells us whether the bug starts before IPC.
+
+## Probe B: Ingress queue log
+
+File:
+
+- [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+
+Log:
+
+- pending frame count before enqueue
+- queued batch count
+- flush reason
+- frame timestamps in the batch
+- total samples per batch
+
+This proves whether frames were captured but never drained.
+
+## Probe C: Worklet stop log
+
+File:
+
+- [streaming-audio-capture-worklet.js](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-capture-worklet.js)
+
+Log:
+
+- when `flush` message is received
+- pending sample count at that moment
+- timestamp of the final partial frame
+- when `flush_complete` is posted
+
+This isolates the stop-tail path.
+
+## Probe D: Groq upload boundary log
+
+File:
+
+- [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+
+Log per upload:
+
+- `chunkIndex`
+- `flushReason`
+- live frame count
+- carryover frame count
+- chunk start/end ms
+- overlap ms
+- request start/end time
+- emitted segments after dedupe
+
+This is the most important probe if the issue happens only on Groq.
+
+## Probe E: Final segment routing log
+
+Files:
+
+- [streaming-session-controller.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-session-controller.ts)
+- [streaming-segment-router.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/streaming-segment-router.ts)
+
+Log:
+
+- accepted final segment sequence
+- canonicalized text
+- commit order
+- transform fallback versus transformed output
+
+This tells us whether the transcript was correct before routing changed it.
+
+## Is chunking really the right approach?
+
+## For Groq
+
+Mostly yes, because the provider surface is chunk-upload oriented rather than true session streaming.
+
+But one clarification matters:
+
+- chunking is the correct **transport architecture**
+- it is not enough by itself to deliver a true token-by-token live streaming UX
+
+So if the product expectation is "continuous live text while the user is still speaking", then this approach is only an approximation.
+
+## For whisper.cpp
+
+Only partly.
+
+For whisper.cpp, transport batching is sensible.
+But pause-bounded chunking is not the core model.
+The provider runtime is already closer to native streaming, so renderer chunk boundaries should not be treated as the semantic source of truth.
+
+## Bottom line
+
+The chunk approach is the right way to go when:
+
+- the provider only supports chunk/file transcription
+- you are willing to trade exact realtime behavior for simpler bounded uploads
+
+The chunk approach is not the full answer when:
+
+- the expected UX is continuous live text with minimal latency
+- boundary clipping near pauses is unacceptable
+- the provider already has a truer streaming model
+
+## Recommended next debugging step
+
+Before changing architecture, add temporary logs only at these three places:
+
+1. [streaming-live-capture.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-live-capture.ts)
+2. [streaming-audio-ingress.ts](/workspace/.worktrees/fix/issue-440/src/renderer/streaming-audio-ingress.ts)
+3. [groq-rolling-upload-adapter.ts](/workspace/.worktrees/fix/issue-440/src/main/services/streaming/groq-rolling-upload-adapter.ts)
+
+That is the smallest useful logging set.
+
+If the timeline shows:
+
+- frames captured correctly
+- chunker flushes correctly
+- Groq uploads only on pause/stop
+
+then the remaining "issue 440" is probably architecture or tuning, not another hidden stop-session bug.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -857,6 +857,22 @@ Transport rules:
 - Groq `whisper-large-v3-turbo` **MUST** be modeled as `rolling_upload` unless official provider documentation later proves a native realtime session contract that has been separately reviewed
 - rolling-upload providers **MUST NOT** be described in code, UI, or tests as native realtime streaming
 
+Provider-specific capture rules:
+- provider-specific renderer capture behavior **MUST** be allowed when transport realities differ.
+- `local_whispercpp_coreml` **MUST** remain on continuous frame-stream ingestion.
+- Groq rolling-upload **MUST** use utterance-style browser VAD capture rather than the native-stream frame ingestion contract.
+- Groq utterance capture **MUST** emit one utterance payload per finalized utterance boundary or explicit session stop.
+- Groq utterance payloads **MUST** cross renderer-main transport as transfer-aware WAV buffers, not as large structured-cloned float sample arrays.
+- Groq utterance payload format **MUST** be:
+  - RIFF/WAV container
+  - PCM signed 16-bit little-endian
+  - mono
+  - `16000 Hz`
+- Groq utterance ordering **MUST** use:
+  - `utteranceIndex` for utterance-order coordination
+  - a main-owned monotonic `sequence` allocator for final segment emission
+- `whisper.cpp` **MUST NOT** be refactored to depend on Groq browser-VAD utterance capture semantics.
+
 Required adapter outputs:
 - ordered stream events with monotonic `sequence`.
 - event `kind` (`partial`, `final`, `error`, `end`).


### PR DESCRIPTION
## Summary
- add a detailed issue-440 execution plan that breaks the Groq browser-VAD work into one-ticket/one-PR steps
- add the supporting Groq browser-VAD design and ADR docs
- update the normative spec so Groq rolling-upload and whisper.cpp streaming have distinct capture postures

## Notes
- planning/spec only; no implementation has started from this plan
- no tests were run because this PR only changes docs/spec artifacts