### PR TITLE
feat: add groq utterance streaming ipc

### DIFF
--- a/docs/decisions/2026-03-09-groq-utterance-message-port-ipc-decision.md
+++ b/docs/decisions/2026-03-09-groq-utterance-message-port-ipc-decision.md
@@ -1,0 +1,52 @@
+<!--
+Where: docs/decisions/2026-03-09-groq-utterance-message-port-ipc-decision.md
+What: Decision note for the Groq utterance IPC transport introduced in T440-03.
+Why: The Groq renderer capture path now ships WAV utterances to main, and this
+     records why the implementation uses one-shot message ports instead of the
+     existing invoke-based IPC or a long-lived background port.
+-->
+
+# Decision: Groq Utterance IPC Uses One-Shot Message Ports
+
+## Status
+
+Accepted on March 9, 2026.
+
+## Context
+
+Ticket `T440-03` requires a dedicated Groq utterance transport that does not depend on
+the old invoke-based structured-clone path for large audio payloads.
+
+Electron `ipcRenderer.invoke()` is request/response friendly, but it does not give us
+a transfer-aware `ArrayBuffer` handoff for the WAV payload.
+
+Electron `ipcRenderer.postMessage()` can transfer `MessagePort`s to main. A `MessagePort`
+message can then transfer the utterance `ArrayBuffer`.
+
+## Decision
+
+The preload bridge creates a fresh `MessageChannel` per Groq utterance send:
+
+1. transfer one port to main with `ipcRenderer.postMessage(...)`
+2. send the utterance payload over the paired renderer port with `[chunk.wavBytes]`
+3. wait for an acknowledgement or error reply from main
+4. close the ports after the one-shot exchange completes
+
+## Why This Is Acceptable
+
+- It satisfies the transfer-aware handoff requirement for `wavBytes`.
+- It keeps the public renderer API promise-based.
+- It avoids introducing a long-lived background port lifecycle in the same ticket.
+- It preserves the existing owner-window enforcement in main before the chunk reaches the controller.
+
+## Trade-offs
+
+- Pro: small surface area and explicit request/ack semantics.
+- Pro: easy to fail one utterance cleanly without poisoning later sends.
+- Con: more per-send setup than a long-lived port.
+- Con: more IPC plumbing than a simple `invoke()` handler.
+
+## Follow-up
+
+If Groq utterance throughput later makes one-shot ports too expensive, a future ticket can
+upgrade this to a long-lived port while preserving the same shared utterance contract.

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -71,6 +71,28 @@ const getRegisteredHandle = (channel: string) => {
   return match?.[1]
 }
 
+const getRegisteredOn = (channel: string) => {
+  const match = mocks.ipcOn.mock.calls.find(([registeredChannel]) => registeredChannel === channel)
+  return match?.[1]
+}
+
+const createFakeMessagePort = () => {
+  let onMessage: ((event: { data: unknown }) => void | Promise<void>) | null = null
+  return {
+    on: vi.fn((event: string, listener: (event: { data: unknown }) => void | Promise<void>) => {
+      if (event === 'message') {
+        onMessage = listener
+      }
+    }),
+    start: vi.fn(),
+    postMessage: vi.fn(),
+    close: vi.fn(),
+    emitMessage: async (data: unknown) => {
+      await onMessage?.({ data })
+    }
+  }
+}
+
 describe('registerIpcHandlers', () => {
   beforeEach(() => {
     resetMainServicesForTest()
@@ -147,6 +169,7 @@ describe('registerIpcHandlers', () => {
     expect(getRegisteredHandle(IPC_CHANNELS.getStreamingSessionSnapshot)).toBeTypeOf('function')
     expect(getRegisteredHandle(IPC_CHANNELS.ackStreamingRendererStop)).toBeTypeOf('function')
     expect(getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioFrameBatch)).toBeTypeOf('function')
+    expect(getRegisteredOn(IPC_CHANNELS.pushStreamingAudioUtteranceChunk)).toBeTypeOf('function')
 
     await getRegisteredHandle(IPC_CHANNELS.startStreamingSession)?.({}, undefined)
     expect(getRegisteredHandle(IPC_CHANNELS.getStreamingSessionSnapshot)?.({}, undefined)).toEqual(
@@ -185,6 +208,101 @@ describe('registerIpcHandlers', () => {
     expect(
       mocks.windowSend.mock.calls.filter(([channel]) => channel === IPC_CHANNELS.onStreamingSessionState)
     ).toHaveLength(2)
+  })
+
+  it('routes accepted utterance chunks through the owner renderer and rejects non-owned chunks', async () => {
+    const pushAudioUtteranceChunk = vi.fn(async () => {})
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi.fn().mockResolvedValue({
+        kind: 'streaming_start',
+        sessionId: 'session-utterance',
+        preferredDeviceId: 'mic-1'
+      }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession: vi.fn()
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: {
+        onSessionState: vi.fn(),
+        onSegment: vi.fn(),
+        onError: vi.fn(),
+        pushAudioFrameBatch: vi.fn(),
+        pushAudioUtteranceChunk
+      } as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    await getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
+    const utteranceHandler = getRegisteredOn(IPC_CHANNELS.pushStreamingAudioUtteranceChunk)
+    expect(utteranceHandler).toBeTypeOf('function')
+
+    const ownerPort = createFakeMessagePort()
+    await utteranceHandler?.({ sender: mocks.windows[0]?.webContents, ports: [ownerPort] }, undefined)
+    await ownerPort.emitMessage({
+      sessionId: 'session-utterance',
+      sampleRateHz: 16000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 0,
+      endedAtMs: 500,
+      hadCarryover: false,
+      reason: 'speech_pause',
+      source: 'browser_vad'
+    })
+
+    expect(pushAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-utterance',
+      utteranceIndex: 0
+    }))
+    expect(ownerPort.postMessage).toHaveBeenCalledWith({ ok: true })
+
+    const nonOwnerPort = createFakeMessagePort()
+    await utteranceHandler?.({ sender: mocks.windows[1]?.webContents, ports: [nonOwnerPort] }, undefined)
+    await nonOwnerPort.emitMessage({
+      sessionId: 'session-utterance',
+      sampleRateHz: 16000,
+      channels: 1,
+      utteranceIndex: 1,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 600,
+      endedAtMs: 900,
+      hadCarryover: false,
+      reason: 'speech_pause',
+      source: 'browser_vad'
+    })
+
+    expect(nonOwnerPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      message: expect.stringContaining('does not own session')
+    }))
   })
 
   it('logs and returns when recording command dispatch finds no renderer windows', async () => {

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -17,9 +17,10 @@ import {
   type RendererInitiatedStreamingStopReason,
   type SoundEvent,
   type StopStreamingSessionRequest,
-  type StreamingRendererStopAck,
   type StreamingAudioFrameBatch,
+  type StreamingAudioUtteranceChunk,
   type StreamingErrorEvent,
+  type StreamingRendererStopAck,
   type StreamingSegmentEvent,
   type StreamingSessionStateSnapshot
 } from '../../shared/ipc'
@@ -191,6 +192,24 @@ const assertStreamingAudioBatchAllowed = (
   const pendingStopAck = pendingStreamingRendererStopAcks.get(batch.sessionId)
   if (pendingStopAck && pendingStopAck.reason !== 'user_stop') {
     throw new Error(`Streaming audio frame batch rejected: session ${batch.sessionId} is cancelling.`)
+  }
+}
+
+const assertStreamingAudioUtteranceChunkAllowed = (
+  chunk: StreamingAudioUtteranceChunk,
+  senderWindowId: number | null
+): void => {
+  const ownerWindowId = streamingSessionOwnerWindowIds.get(chunk.sessionId)
+  if (ownerWindowId === undefined || ownerWindowId === null) {
+    throw new Error(`Streaming audio utterance chunk rejected: no owner renderer is registered for session ${chunk.sessionId}.`)
+  }
+  if (senderWindowId !== ownerWindowId) {
+    throw new Error(`Streaming audio utterance chunk rejected: renderer ${senderWindowId ?? 'unknown'} does not own session ${chunk.sessionId}.`)
+  }
+
+  const pendingStopAck = pendingStreamingRendererStopAcks.get(chunk.sessionId)
+  if (pendingStopAck && pendingStopAck.reason !== 'user_stop') {
+    throw new Error(`Streaming audio utterance chunk rejected: session ${chunk.sessionId} is cancelling.`)
   }
 }
 
@@ -640,6 +659,30 @@ const bindIpcHandlers = (svc: MainServices): void => {
   ipcMain.handle(IPC_CHANNELS.pushStreamingAudioFrameBatch, (event, batch: StreamingAudioFrameBatch) => {
     assertStreamingAudioBatchAllowed(batch, resolveRendererWindowIdFromSender(event.sender))
     return svc.streamingSessionController.pushAudioFrameBatch(batch)
+  })
+  ipcMain.on(IPC_CHANNELS.pushStreamingAudioUtteranceChunk, (event) => {
+    const senderWindowId = resolveRendererWindowIdFromSender(event.sender)
+    const replyPort = event.ports[0]
+    if (!replyPort) {
+      return
+    }
+
+    replyPort.on('message', async (messageEvent) => {
+      try {
+        const chunk = messageEvent.data as StreamingAudioUtteranceChunk
+        assertStreamingAudioUtteranceChunkAllowed(chunk, senderWindowId)
+        await svc.streamingSessionController.pushAudioUtteranceChunk(chunk)
+        replyPort.postMessage({ ok: true })
+      } catch (error) {
+        replyPort.postMessage({
+          ok: false,
+          message: error instanceof Error ? error.message : String(error)
+        })
+      } finally {
+        replyPort.close()
+      }
+    })
+    replyPort.start()
   })
   ipcMain.handle(IPC_CHANNELS.runPickTransformationFromClipboard, async () => svc.hotkeyService.runPickAndRunTransform())
 }

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -82,6 +82,49 @@ describe('GroqRollingUploadAdapter', () => {
     }))
   })
 
+  it('accepts browser-VAD utterance chunks directly', async () => {
+    const onFinalSegment = vi.fn()
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      text: 'utterance path'
+    }), { status: 200 }))
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk({
+      sessionId: 'session-1',
+      sampleRateHz: 16000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 2_000,
+      endedAtMs: 2_500,
+      hadCarryover: true,
+      reason: 'speech_pause',
+      source: 'browser_vad'
+    })
+    await adapter.stop('user_stop')
+
+    expect(fetchFn).toHaveBeenCalledOnce()
+    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      sequence: 0,
+      text: 'utterance path',
+      startedAt: '1970-01-01T00:00:02.000Z',
+      endedAt: '1970-01-01T00:00:02.500Z'
+    }))
+  })
+
   it('releases chunk results in chunk order even when later uploads finish first', async () => {
     const resolvers: Array<(response: Response) => void> = []
     const fetchFn = vi.fn(() => new Promise<Response>((resolve) => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -27,6 +27,7 @@ import type {
   StreamingProviderRuntimeCallbacks,
   StreamingSessionStartConfig
 } from './types'
+import type { StreamingAudioUtteranceChunk } from '../../../shared/ipc'
 
 interface GroqRollingUploadAdapterParams {
   sessionId: string
@@ -55,10 +56,10 @@ interface GroqVerboseResponse {
 interface PendingChunkUpload {
   chunkIndex: number
   flushReason: StreamingAudioChunkFlushReason
-  sampleRateHz: number
-  channels: number
-  liveFrames: StreamingAudioFrame[]
-  carryoverFrames: StreamingAudioFrame[]
+  body: Blob
+  hadCarryover: boolean
+  chunkStartMs: number
+  chunkEndMs: number
 }
 
 interface CompletedChunkUpload {
@@ -178,25 +179,55 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     }
   }
 
+  async pushAudioUtteranceChunk(chunk: StreamingAudioUtteranceChunk): Promise<void> {
+    if (this.stopped) {
+      throw new Error('Groq rolling upload runtime is already stopped.')
+    }
+    if (chunk.channels !== 1) {
+      throw new Error(`Groq rolling upload currently requires mono audio. Received channels=${chunk.channels}.`)
+    }
+    if (chunk.wavFormat !== 'wav_pcm_s16le_mono_16000') {
+      throw new Error(`Groq rolling upload requires wav_pcm_s16le_mono_16000 utterances. Received ${chunk.wavFormat}.`)
+    }
+
+    const pendingChunk: PendingChunkUpload = {
+      chunkIndex: this.nextChunkIndex,
+      flushReason: chunk.reason,
+      body: new Blob([Buffer.from(chunk.wavBytes)], { type: 'audio/wav' }),
+      hadCarryover: chunk.hadCarryover,
+      chunkStartMs: chunk.startedAtMs,
+      chunkEndMs: chunk.endedAtMs
+    }
+    this.nextChunkIndex += 1
+
+    this.schedulePendingChunkUpload(pendingChunk)
+  }
+
   private scheduleChunkUpload(flushReason: StreamingAudioChunkFlushReason): void {
     if (this.currentChunkFrames.length === 0) {
       return
     }
 
-    const chunk: PendingChunkUpload = {
+    const liveFrames = this.currentChunkFrames.splice(0, this.currentChunkFrames.length)
+    const carryoverFrames = this.carryoverFrames.map(cloneFrame)
+    const pendingChunk: PendingChunkUpload = {
       chunkIndex: this.nextChunkIndex,
       flushReason,
-      sampleRateHz: this.currentSampleRateHz,
-      channels: this.currentChannels,
-      liveFrames: this.currentChunkFrames.splice(0, this.currentChunkFrames.length),
-      carryoverFrames: this.carryoverFrames.map(cloneFrame)
+      body: createWavBlob([...carryoverFrames, ...liveFrames], this.currentSampleRateHz, this.currentChannels),
+      hadCarryover: carryoverFrames.length > 0,
+      chunkStartMs: liveFrames[0]?.timestampMs ?? 0,
+      chunkEndMs: resolveChunkEndMs(liveFrames, this.currentSampleRateHz)
     }
     this.nextChunkIndex += 1
 
     const overlapMs = resolveOverlapMsForFlushReason(flushReason, this.chunkWindowPolicy)
     this.carryoverFrames =
-      overlapMs > 0 ? tailFramesForOverlap(chunk.liveFrames, chunk.sampleRateHz, overlapMs) : []
+      overlapMs > 0 ? tailFramesForOverlap(liveFrames, this.currentSampleRateHz, overlapMs) : []
 
+    this.schedulePendingChunkUpload(pendingChunk)
+  }
+
+  private schedulePendingChunkUpload(chunk: PendingChunkUpload): void {
     const uploadPromise = this.uploadChunk(chunk)
       .catch(async (error) => {
         if (isAbortError(error) && this.stopped) {
@@ -216,10 +247,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private async uploadChunk(chunk: PendingChunkUpload): Promise<void> {
-    const frames = [...chunk.carryoverFrames, ...chunk.liveFrames]
-    const chunkStartMs = frames[0]?.timestampMs ?? 0
-    const chunkEndMs = resolveChunkEndMs(frames, chunk.sampleRateHz)
-    const body = createWavBlob(frames, chunk.sampleRateHz, chunk.channels)
     const endpoint = resolveProviderEndpoint(
       GROQ_DEFAULT_BASE,
       GROQ_STT_PATH,
@@ -234,7 +261,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       attempt += 1
       const formData = new FormData()
       formData.append('model', this.params.config.model)
-      formData.append('file', body, `streaming-chunk-${chunk.chunkIndex}.wav`)
+      formData.append('file', chunk.body, `streaming-chunk-${chunk.chunkIndex}.wav`)
       formData.append('response_format', 'verbose_json')
       formData.append('timestamp_granularities[]', 'segment')
 
@@ -268,9 +295,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       this.completedChunks.set(chunk.chunkIndex, {
         chunkIndex: chunk.chunkIndex,
         flushReason: chunk.flushReason,
-        hadCarryover: chunk.carryoverFrames.length > 0,
-        chunkStartMs,
-        chunkEndMs,
+        hadCarryover: chunk.hadCarryover,
+        chunkStartMs: chunk.chunkStartMs,
+        chunkEndMs: chunk.chunkEndMs,
         response: data
       })
       await this.drainCompletedChunks()

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -34,6 +34,20 @@ const TRANSFORMED_STREAMING_CONFIG = {
   }
 }
 
+const GROQ_STREAMING_CONFIG = {
+  provider: 'groq_whisper_large_v3_turbo' as const,
+  transport: 'rolling_upload' as const,
+  model: 'whisper-large-v3-turbo',
+  outputMode: 'stream_raw_dictation' as const,
+  maxInFlightTransforms: 2,
+  apiKeyRef: 'groq' as const,
+  delimiterPolicy: {
+    mode: 'space' as const,
+    value: null
+  },
+  transformationProfile: null
+}
+
 describe('InMemoryStreamingSessionController', () => {
   it('transitions start -> active -> stopping -> ended deterministically', async () => {
     const controller = new InMemoryStreamingSessionController({
@@ -233,6 +247,92 @@ describe('InMemoryStreamingSessionController', () => {
       flushReason: null,
       frames: [{ samples: new Float32Array([0, 0.1]), timestampMs: 1 }]
     })
+  })
+
+  it('rejects frame batches for active Groq sessions', async () => {
+    const pushAudioFrameBatch = vi.fn(async () => {})
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      createProviderRuntime: () => ({
+        start: async () => {},
+        stop: async () => {},
+        pushAudioFrameBatch,
+        pushAudioUtteranceChunk: async () => {}
+      })
+    })
+
+    await controller.start(GROQ_STREAMING_CONFIG)
+
+    await expect(
+      controller.pushAudioFrameBatch({
+        sessionId: 'session-1',
+        sampleRateHz: 16000,
+        channels: 1,
+        flushReason: null,
+        frames: [{ samples: new Float32Array([0, 0.1]), timestampMs: 1 }]
+      })
+    ).rejects.toThrow('not supported for Groq sessions')
+    expect(pushAudioFrameBatch).not.toHaveBeenCalled()
+  })
+
+  it('rejects pushed audio utterance chunks when no session is active', async () => {
+    const controller = new InMemoryStreamingSessionController()
+
+    await expect(
+      controller.pushAudioUtteranceChunk({
+        sessionId: 'session-1',
+        sampleRateHz: 16000,
+        channels: 1,
+        utteranceIndex: 0,
+        wavBytes: new ArrayBuffer(4),
+        wavFormat: 'wav_pcm_s16le_mono_16000',
+        startedAtMs: 0,
+        endedAtMs: 100,
+        hadCarryover: false,
+        reason: 'speech_pause',
+        source: 'browser_vad'
+      })
+    ).rejects.toThrow('active session')
+  })
+
+  it('forwards accepted utterance chunks into the active provider runtime', async () => {
+    const pushAudioUtteranceChunk = vi.fn(async () => {})
+    const controller = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-1',
+      createProviderRuntime: () => ({
+        start: async () => {},
+        stop: async () => {},
+        pushAudioFrameBatch: async () => {},
+        pushAudioUtteranceChunk
+      })
+    })
+
+    await controller.start({
+      ...LOCAL_STREAMING_CONFIG,
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo'
+    })
+    await controller.pushAudioUtteranceChunk({
+      sessionId: 'session-1',
+      sampleRateHz: 16000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 0,
+      endedAtMs: 100,
+      hadCarryover: true,
+      reason: 'max_chunk',
+      source: 'browser_vad'
+    })
+
+    expect(pushAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      utteranceIndex: 0,
+      hadCarryover: true,
+      reason: 'max_chunk'
+    }))
   })
 
   it('fails the session when the provider runtime reports a fatal error', async () => {

--- a/src/main/services/streaming/streaming-session-controller.ts
+++ b/src/main/services/streaming/streaming-session-controller.ts
@@ -7,6 +7,7 @@
 
 import type {
   StreamingAudioFrameBatch,
+  StreamingAudioUtteranceChunk,
   StreamingErrorEvent,
   StreamingSegmentEvent,
   StreamingSessionState,
@@ -39,6 +40,7 @@ export interface StreamingSessionController {
   start(config: StreamingSessionStartConfig): Promise<void>
   stop(reason?: StreamingSessionStopReason): Promise<void>
   pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void>
+  pushAudioUtteranceChunk(chunk: StreamingAudioUtteranceChunk): Promise<void>
   commitFinalSegment(segment: ProviderFinalSegmentInput): Promise<OutputApplyResult | null>
   getState(): StreamingSessionState
   getSnapshot(): Readonly<StreamingSessionRuntimeSnapshot>
@@ -207,8 +209,25 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
     if (batch.sessionId !== this.snapshot.sessionId) {
       throw new Error(`Streaming audio frame batch session mismatch. Expected ${this.snapshot.sessionId}.`)
     }
+    if (this.currentConfig?.provider === 'groq_whisper_large_v3_turbo') {
+      throw new Error('Streaming audio frame batches are not supported for Groq sessions.')
+    }
 
     await this.currentProviderRuntime?.pushAudioFrameBatch(batch)
+  }
+
+  async pushAudioUtteranceChunk(chunk: StreamingAudioUtteranceChunk): Promise<void> {
+    if (this.snapshot.state !== 'active') {
+      throw new Error('Streaming audio utterance chunks require an active session.')
+    }
+    if (chunk.sessionId !== this.snapshot.sessionId) {
+      throw new Error(`Streaming audio utterance chunk session mismatch. Expected ${this.snapshot.sessionId}.`)
+    }
+    if (!this.currentProviderRuntime?.pushAudioUtteranceChunk) {
+      throw new Error('Streaming audio utterance chunks are not supported by the active provider runtime.')
+    }
+
+    await this.currentProviderRuntime.pushAudioUtteranceChunk(chunk)
   }
 
   async commitFinalSegment(segment: ProviderFinalSegmentInput): Promise<OutputApplyResult | null> {

--- a/src/main/services/streaming/types.ts
+++ b/src/main/services/streaming/types.ts
@@ -7,6 +7,7 @@
 
 import type {
   StreamingAudioFrameBatch,
+  StreamingAudioUtteranceChunk,
   StreamingErrorEvent,
   StreamingSegmentEvent,
   StreamingSessionState,
@@ -62,6 +63,7 @@ export interface StreamingProviderRuntime {
   start: () => Promise<void>
   stop: (reason: StreamingSessionStopReason) => Promise<void>
   pushAudioFrameBatch: (batch: StreamingAudioFrameBatch) => Promise<void>
+  pushAudioUtteranceChunk?: (chunk: StreamingAudioUtteranceChunk) => Promise<void>
 }
 
 export type CreateStreamingProviderRuntime = (params: {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -1,0 +1,119 @@
+/*
+Where: src/preload/index.test.ts
+What: Focused preload bridge tests for the one-shot streaming utterance transport.
+Why: Prevent hangs in the renderer when the MessagePort handshake fails or never acks.
+*/
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const exposeInMainWorld = vi.fn()
+const postMessage = vi.fn()
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld
+  },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    postMessage
+  }
+}))
+
+class FakeMessagePort {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onmessageerror: ((event: MessageEvent) => void) | null = null
+  closed = false
+  peer: FakeMessagePort | null = null
+
+  postMessage(data: unknown): void {
+    this.peer?.onmessage?.({ data } as MessageEvent)
+  }
+
+  start(): void {}
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+class FakeMessageChannel {
+  readonly port1 = new FakeMessagePort()
+  readonly port2 = new FakeMessagePort()
+
+  constructor() {
+    this.port1.peer = this.port2
+    this.port2.peer = this.port1
+  }
+}
+
+describe('preload speechToTextApi', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.useRealTimers()
+    exposeInMainWorld.mockReset()
+    postMessage.mockReset()
+    vi.stubGlobal('MessageChannel', FakeMessageChannel as unknown as typeof MessageChannel)
+    await import('./index')
+  })
+
+  it('sends utterance chunks over a one-shot message port and resolves on ack', async () => {
+    const api = exposeInMainWorld.mock.calls.find(([name]) => name === 'speechToTextApi')?.[1]
+    const chunk = {
+      sessionId: 'session-1',
+      sampleRateHz: 16_000,
+      channels: 1,
+      utteranceIndex: 3,
+      wavBytes: new ArrayBuffer(8),
+      wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+      startedAtMs: 100,
+      endedAtMs: 240,
+      hadCarryover: false,
+      reason: 'speech_pause' as const,
+      source: 'browser_vad' as const
+    }
+
+    postMessage.mockImplementation((_channel, _message, ports: FakeMessagePort[]) => {
+      const replyPort = ports[0]
+      replyPort.onmessage = async (event) => {
+        expect(event.data).toMatchObject({
+          sessionId: 'session-1',
+          utteranceIndex: 3,
+          reason: 'speech_pause'
+        })
+        replyPort.postMessage({ ok: true })
+      }
+    })
+
+    await expect(api.pushStreamingAudioUtteranceChunk(chunk)).resolves.toBeUndefined()
+  })
+
+  it('rejects when the utterance ack never arrives', async () => {
+    vi.useFakeTimers()
+    const api = exposeInMainWorld.mock.calls.find(([name]) => name === 'speechToTextApi')?.[1]
+    const chunk = {
+      sessionId: 'session-1',
+      sampleRateHz: 16_000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+      startedAtMs: 0,
+      endedAtMs: 32,
+      hadCarryover: false,
+      reason: 'session_stop' as const,
+      source: 'browser_vad' as const
+    }
+
+    postMessage.mockImplementation(() => {})
+
+    const pending = expect(api.pushStreamingAudioUtteranceChunk(chunk)).rejects.toThrow(
+      'Streaming audio utterance chunk acknowledgement timed out.'
+    )
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    await pending
+  })
+})

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,8 @@ import {
 } from '../shared/ipc'
 import type { Settings } from '../shared/domain'
 
+const STREAMING_AUDIO_UTTERANCE_ACK_TIMEOUT_MS = 5_000
+
 const api: IpcApi = {
   ping: async (): Promise<string> => ipcRenderer.invoke(IPC_CHANNELS.ping),
   getSettings: async () => ipcRenderer.invoke(IPC_CHANNELS.getSettings),
@@ -40,6 +42,46 @@ const api: IpcApi = {
   ackStreamingRendererStop: async (ack: StreamingRendererStopAck) =>
     ipcRenderer.invoke(IPC_CHANNELS.ackStreamingRendererStop, ack),
   pushStreamingAudioFrameBatch: async (batch) => ipcRenderer.invoke(IPC_CHANNELS.pushStreamingAudioFrameBatch, batch),
+  pushStreamingAudioUtteranceChunk: async (chunk) => await new Promise<void>((resolve, reject) => {
+    const channel = new MessageChannel()
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      cleanup()
+      reject(new Error('Streaming audio utterance chunk acknowledgement timed out.'))
+    }, STREAMING_AUDIO_UTTERANCE_ACK_TIMEOUT_MS)
+
+    const cleanup = (): void => {
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle)
+        timeoutHandle = null
+      }
+      channel.port1.onmessage = null
+      channel.port1.onmessageerror = null
+      channel.port1.close()
+    }
+
+    channel.port1.onmessage = (event) => {
+      cleanup()
+      const payload = event.data as { ok?: boolean; message?: string } | null
+      if (payload?.ok) {
+        resolve()
+        return
+      }
+      reject(new Error(payload?.message ?? 'Streaming audio utterance chunk failed.'))
+    }
+    channel.port1.onmessageerror = () => {
+      cleanup()
+      reject(new Error('Streaming audio utterance chunk acknowledgement failed.'))
+    }
+    channel.port1.start()
+
+    try {
+      ipcRenderer.postMessage(IPC_CHANNELS.pushStreamingAudioUtteranceChunk, null, [channel.port2])
+      channel.port1.postMessage(chunk, [chunk.wavBytes])
+    } catch (error) {
+      cleanup()
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+  }),
   onRecordingCommand: (listener: (dispatch: RecordingCommandDispatch) => void) => {
     const handler = (_event: unknown, dispatch: RecordingCommandDispatch) => listener(dispatch)
     ipcRenderer.on(IPC_CHANNELS.onRecordingCommand, handler)

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -6,29 +6,15 @@ Why: Isolate Groq's browser-VAD lifecycle from the existing whisper.cpp frame-st
 */
 
 import { MicVAD, utils, type RealTimeVADOptions } from '@ricky0123/vad-web'
-import type { StreamingSessionStopReason } from '../shared/ipc'
+import type { StreamingAudioUtteranceChunk, StreamingSessionStopReason } from '../shared/ipc'
 import {
   GROQ_BROWSER_VAD_ASSET_PATHS,
   GROQ_BROWSER_VAD_DEFAULTS,
   type GroqBrowserVadConfig
 } from './groq-browser-vad-config'
 
-export interface GroqBrowserVadUtteranceChunk {
-  sampleRateHz: 16_000
-  channels: 1
-  utteranceIndex: number
-  // Transitional renderer-local PCM bridge used until dedicated utterance IPC lands.
-  pcmSamples: Float32Array
-  wavBytes: ArrayBuffer
-  wavFormat: 'wav_pcm_s16le_mono_16000'
-  startedAtMs: number
-  endedAtMs: number
-  reason: 'speech_pause' | 'max_chunk' | 'session_stop'
-  source: 'browser_vad'
-}
-
 export interface GroqBrowserVadSink {
-  pushStreamingAudioUtteranceChunk: (chunk: GroqBrowserVadUtteranceChunk) => Promise<void>
+  pushStreamingAudioUtteranceChunk: (chunk: Omit<StreamingAudioUtteranceChunk, 'sessionId'>) => Promise<void>
 }
 
 export interface GroqBrowserVadCapture {
@@ -112,6 +98,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private preSpeechSamples = 0
   private continuationFlushInFlight = false
   private continuationFlushPromise: Promise<void> | null = null
+  private nextUtteranceHadCarryover = false
 
   constructor(
     params: {
@@ -233,6 +220,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.confirmedSpeechSamples = 0
     this.liveFrames = this.preSpeechFrames.map(cloneFrame)
     this.liveSamples = this.preSpeechSamples
+    this.nextUtteranceHadCarryover = false
   }
 
   private handleFrameProcessed(probabilities: SpeechFrameProbabilities, frame: Float32Array): void {
@@ -277,10 +265,11 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     }
 
     const audio = concatFrames(this.liveFrames)
+    const hadCarryover = this.nextUtteranceHadCarryover
     this.resetSpeechWindow()
 
     try {
-      await this.pushUtterance(audio, 'speech_pause')
+      await this.pushUtterance(audio, 'speech_pause', hadCarryover)
     } catch (error) {
       this.reportFatalError(error)
     }
@@ -307,7 +296,8 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     }
 
     const audio = concatFrames(this.liveFrames)
-    await this.pushUtterance(audio, 'session_stop')
+    const hadCarryover = this.nextUtteranceHadCarryover
+    await this.pushUtterance(audio, 'session_stop', hadCarryover)
     this.resetSpeechWindow()
   }
 
@@ -320,15 +310,17 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     }
 
     this.continuationFlushInFlight = true
+    const hadCarryover = this.nextUtteranceHadCarryover
     const audio = concatFrames(this.liveFrames)
     this.liveFrames = this.preSpeechFrames.map(cloneFrame)
     this.liveSamples = this.preSpeechSamples
     this.speechRealStarted = false
     this.confirmedSpeechSamples = 0
+    this.nextUtteranceHadCarryover = this.preSpeechFrames.length > 0
 
     this.continuationFlushPromise = (async () => {
       try {
-        await this.pushUtterance(audio, 'max_chunk')
+        await this.pushUtterance(audio, 'max_chunk', hadCarryover)
       } catch (error) {
         this.reportFatalError(error)
       } finally {
@@ -338,7 +330,11 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     })()
   }
 
-  private async pushUtterance(audio: Float32Array, reason: GroqBrowserVadUtteranceChunk['reason']): Promise<void> {
+  private async pushUtterance(
+    audio: Float32Array,
+    reason: Omit<StreamingAudioUtteranceChunk, 'sessionId'>['reason'],
+    hadCarryover: boolean
+  ): Promise<void> {
     if (audio.length === 0) {
       return
     }
@@ -353,11 +349,11 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       sampleRateHz: STREAM_SAMPLE_RATE_HZ,
       channels: 1,
       utteranceIndex,
-      pcmSamples: audio.slice(),
       wavBytes: this.encodeWav(audio),
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtMs,
       endedAtMs,
+      hadCarryover,
       reason,
       source: 'browser_vad'
     })
@@ -370,6 +366,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.liveFrames = []
     this.liveSamples = 0
     this.continuationFlushInFlight = false
+    this.nextUtteranceHadCarryover = false
   }
 
   private hasValidSpeechWindow(): boolean {

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -130,6 +130,7 @@ describe('handleRecordingCommandDispatch', () => {
       getHistory: vi.fn(),
       submitRecordedAudio: vi.fn(),
       pushStreamingAudioFrameBatch: vi.fn(),
+      pushStreamingAudioUtteranceChunk: vi.fn(),
       stopStreamingSession: vi.fn(async (_request) => {}),
       ackStreamingRendererStop: vi.fn(async (_ack) => {})
     }
@@ -320,7 +321,7 @@ describe('handleRecordingCommandDispatch', () => {
     expect(state.hasCommandError).toBe(false)
   })
 
-  it('bridges Groq browser-VAD utterances into frame-batch IPC with the session id and flush reason', async () => {
+  it('bridges Groq browser-VAD utterances into dedicated utterance IPC with the session id', async () => {
     const { deps, state } = createDeps()
     state.settings = structuredClone(DEFAULT_SETTINGS)
     state.settings.processing.mode = 'streaming'
@@ -348,34 +349,33 @@ describe('handleRecordingCommandDispatch', () => {
       throw new Error('Expected Groq capture options to be passed to the browser VAD starter.')
     }
 
-    const samples = new Float32Array([0.1, 0.2, 0.3])
+    const wavBytes = new Uint8Array([1, 2, 3, 4]).buffer
     await groqCaptureOptions.sink.pushStreamingAudioUtteranceChunk({
       sampleRateHz: 16_000,
       channels: 1,
       utteranceIndex: 0,
-      pcmSamples: samples,
-      wavBytes: new ArrayBuffer(0),
+      wavBytes,
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtMs: 1_500,
       endedAtMs: 1_800,
+      hadCarryover: true,
       reason: 'max_chunk',
       source: 'browser_vad'
     })
 
-    expect(window.speechToTextApi.pushStreamingAudioFrameBatch).toHaveBeenCalledWith({
+    expect(window.speechToTextApi.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith({
       sessionId: 'session-groq-bridge',
       sampleRateHz: 16_000,
       channels: 1,
-      frames: [{
-        samples,
-        timestampMs: 1_500
-      }],
-      flushReason: 'max_chunk'
+      utteranceIndex: 0,
+      wavBytes,
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 1_500,
+      endedAtMs: 1_800,
+      hadCarryover: true,
+      reason: 'max_chunk',
+      source: 'browser_vad'
     })
-    const pushStreamingAudioFrameBatchMock = window.speechToTextApi.pushStreamingAudioFrameBatch as ReturnType<typeof vi.fn>
-    const forwardedSamples = pushStreamingAudioFrameBatchMock.mock.calls[0]?.[0].frames[0].samples as Float32Array
-    expect(forwardedSamples).not.toBe(samples)
-    expect([...forwardedSamples]).toEqual([...samples])
   })
 
   it('stops live streaming capture and acknowledges explicit streaming stop requests', async () => {

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -12,8 +12,8 @@ import type {
   AudioInputSource,
   RecordingCommandDispatch,
   RendererInitiatedStreamingStopReason,
-  StreamingAudioChunkFlushReason,
   StreamingAudioFrameBatch,
+  StreamingAudioUtteranceChunk,
   StreamingSessionStateSnapshot
 } from '../shared/ipc'
 import { SYSTEM_DEFAULT_AUDIO_SOURCE } from './app-shell-react'
@@ -24,8 +24,7 @@ import { resolveRecordingDeviceFallbackWarning, resolveRecordingDeviceId } from 
 import type { HistoryRecordSnapshot } from '../shared/ipc'
 import {
   startGroqBrowserVadCapture,
-  type GroqBrowserVadSink,
-  type GroqBrowserVadUtteranceChunk
+  type GroqBrowserVadSink
 } from './groq-browser-vad-capture'
 import { startStreamingLiveCapture, type StreamingLiveCapture } from './streaming-live-capture'
 
@@ -148,21 +147,14 @@ const createStreamingAudioSink = (sessionId: string) => ({
 })
 
 const createGroqBrowserVadSink = (sessionId: string): GroqBrowserVadSink => ({
-  pushStreamingAudioUtteranceChunk: async (chunk: GroqBrowserVadUtteranceChunk): Promise<void> => {
+  pushStreamingAudioUtteranceChunk: async (chunk: Omit<StreamingAudioUtteranceChunk, 'sessionId'>): Promise<void> => {
     const api = window.speechToTextApi
     if (!api) {
       throw new Error('speechToTextApi bridge is not available.')
     }
-    const flushReason: StreamingAudioChunkFlushReason = chunk.reason
-    await api.pushStreamingAudioFrameBatch({
-      sessionId,
-      sampleRateHz: chunk.sampleRateHz,
-      channels: chunk.channels,
-      frames: [{
-        samples: chunk.pcmSamples.slice(),
-        timestampMs: chunk.startedAtMs
-      }],
-      flushReason
+    await api.pushStreamingAudioUtteranceChunk({
+      ...chunk,
+      sessionId
     })
   }
 })

--- a/src/renderer/renderer-app.test.ts
+++ b/src/renderer/renderer-app.test.ts
@@ -156,6 +156,7 @@ const buildIpcHarness = (initialSettings?: typeof DEFAULT_SETTINGS): IpcHarness 
     stopStreamingSession: async (_request) => {},
     ackStreamingRendererStop: async (_ack) => {},
     pushStreamingAudioFrameBatch: async () => {},
+    pushStreamingAudioUtteranceChunk: async () => {},
     onRecordingCommand: onRecordingCommandSpy,
     onStreamingSessionState: onStreamingSessionStateSpy,
     onStreamingSegment: onStreamingSegmentSpy,

--- a/src/renderer/streaming-ui-state.integration.test.tsx
+++ b/src/renderer/streaming-ui-state.integration.test.tsx
@@ -81,6 +81,7 @@ const buildHarness = (): {
     stopStreamingSession: async (_request) => {},
     ackStreamingRendererStop: async (_ack) => {},
     pushStreamingAudioFrameBatch: async () => {},
+    pushStreamingAudioUtteranceChunk: async () => {},
     onRecordingCommand: (_listener: (dispatch: RecordingCommandDispatch) => void) => () => {},
     onStreamingSessionState: (listener: (state: StreamingSessionStateSnapshot) => void) => {
       onStreamingSessionStateListener = listener

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -102,6 +102,7 @@ export interface StreamingAudioFrame {
 }
 
 export type StreamingAudioChunkFlushReason = 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
+export type StreamingAudioUtteranceChunkFlushReason = Exclude<StreamingAudioChunkFlushReason, 'discard_pending'>
 
 export interface StreamingAudioFrameBatch {
   sessionId: string
@@ -109,6 +110,20 @@ export interface StreamingAudioFrameBatch {
   channels: number
   frames: StreamingAudioFrame[]
   flushReason: StreamingAudioChunkFlushReason | null
+}
+
+export interface StreamingAudioUtteranceChunk {
+  sessionId: string
+  sampleRateHz: number
+  channels: number
+  utteranceIndex: number
+  wavBytes: ArrayBuffer
+  wavFormat: 'wav_pcm_s16le_mono_16000'
+  startedAtMs: number
+  endedAtMs: number
+  hadCarryover: boolean
+  reason: StreamingAudioUtteranceChunkFlushReason
+  source: 'browser_vad'
 }
 
 export interface StreamingErrorEvent {
@@ -142,6 +157,7 @@ export interface IpcApi {
   stopStreamingSession: (request: StopStreamingSessionRequest) => Promise<void>
   ackStreamingRendererStop: (ack: StreamingRendererStopAck) => Promise<void>
   pushStreamingAudioFrameBatch: (batch: StreamingAudioFrameBatch) => Promise<void>
+  pushStreamingAudioUtteranceChunk: (chunk: StreamingAudioUtteranceChunk) => Promise<void>
   onRecordingCommand: (listener: (dispatch: RecordingCommandDispatch) => void) => () => void
   onStreamingSessionState: (listener: (state: StreamingSessionStateSnapshot) => void) => () => void
   onStreamingSegment: (listener: (segment: StreamingSegmentEvent) => void) => () => void
@@ -171,6 +187,7 @@ export const IPC_CHANNELS = {
   stopStreamingSession: 'streaming:stop-session',
   ackStreamingRendererStop: 'streaming:ack-renderer-stop',
   pushStreamingAudioFrameBatch: 'streaming:push-audio-frame-batch',
+  pushStreamingAudioUtteranceChunk: 'streaming:push-audio-utterance-chunk',
   onRecordingCommand: 'recording:on-command',
   onStreamingSessionState: 'streaming:on-session-state',
   onStreamingSegment: 'streaming:on-segment',


### PR DESCRIPTION
## Summary
- add a dedicated Groq utterance-chunk IPC contract and one-shot MessagePort transport
- route Groq browser VAD capture through utterance IPC while keeping whisper.cpp on frame batches
- reject legacy frame-batch ingress for Groq sessions and cover the preload handshake with tests

## Verification
- pnpm vitest run src/preload/index.test.ts src/renderer/native-recording.test.ts src/renderer/groq-browser-vad-capture.test.ts src/main/ipc/register-handlers.test.ts src/main/services/streaming/streaming-session-controller.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Review
- sub-agent review: clean after fixing the deprecated Groq frame-batch ingress and preload hang path
- Claude CLI review: attempted via headless CLI in this environment, but it did not return usable output before termination