### PR TITLE
refactor: make groq adapter utterance-native

### DIFF
--- a/docs/decisions/2026-03-09-groq-ordered-utterance-upload-decision.md
+++ b/docs/decisions/2026-03-09-groq-ordered-utterance-upload-decision.md
@@ -1,0 +1,51 @@
+<!--
+Where: docs/decisions/2026-03-09-groq-ordered-utterance-upload-decision.md
+What: Decision note for the T440-04 Groq adapter rewrite.
+Why: The adapter no longer accumulates renderer frames, and this records why the
+     first utterance-native version uses serial uploads and monotonic sequences.
+-->
+
+# Decision: Groq Adapter Is Utterance-Only And Serial In V1
+
+## Status
+
+Accepted on March 9, 2026.
+
+## Context
+
+Ticket `T440-03` introduced a dedicated Groq utterance IPC path and blocked Groq
+frame batches at the controller boundary.
+
+That left one remaining mismatch inside main: the Groq adapter still kept its old
+frame-accumulation, overlap, and chunk-stride logic even though the renderer now
+produces ready-to-upload WAV utterances.
+
+## Decision
+
+For `groq_whisper_large_v3_turbo`, the adapter now:
+
+1. rejects `pushAudioFrameBatch(...)`
+2. accepts only browser-VAD utterance chunks
+3. enforces contiguous `utteranceIndex` ordering at ingress
+4. uploads utterances one at a time in queue order
+5. assigns final segment sequences with a simple monotonic `nextSequence++`
+
+## Why This Is Acceptable
+
+- It removes the last Groq dependency on renderer frame accumulation.
+- Serial upload eliminates the old out-of-order completion and chunk-stride complexity.
+- `utteranceIndex` stays responsible only for utterance ordering.
+- Final segment numbering becomes gap-safe under normal drain because sequences are
+  assigned only as segments are actually emitted.
+
+## Trade-offs
+
+- Pro: simpler ordering and easier reasoning during the migration.
+- Pro: no overlap or stride policy is needed for ordinary utterances.
+- Con: lower throughput than concurrent uploads on ideal networks.
+- Con: queued utterances can build up behind one slow Groq request until later hardening.
+
+## Follow-up
+
+Ticket `T440-05` should add backpressure diagnostics and manual QA around slow
+uploads, stop timing, and real microphone behavior.

--- a/src/main/services/streaming/chunk-window-policy.test.ts
+++ b/src/main/services/streaming/chunk-window-policy.test.ts
@@ -1,31 +1,18 @@
 /**
  * Where: src/main/services/streaming/chunk-window-policy.test.ts
- * What:  Tests chunk overlap policy helpers for rolling-upload providers.
- * Why:   PR-7 depends on explicit max-chunk continuation overlap without
- *        smearing that behavior across normal speech-pause chunk boundaries.
+ * What:  Tests Groq upload retry policy defaults.
+ * Why:   T440-04 removes overlap/stride helpers from the adapter, so the
+ *        remaining shared policy surface should stay explicit and stable.
  */
 
 import { describe, expect, it } from 'vitest'
-import { resolveOverlapMsForFlushReason, tailFramesForOverlap } from './chunk-window-policy'
+import { DEFAULT_GROQ_CHUNK_WINDOW_POLICY } from './chunk-window-policy'
 
 describe('chunk-window-policy', () => {
-  it('uses overlap only for max_chunk continuation uploads', () => {
-    expect(resolveOverlapMsForFlushReason('speech_pause')).toBe(0)
-    expect(resolveOverlapMsForFlushReason('session_stop')).toBe(0)
-    expect(resolveOverlapMsForFlushReason('discard_pending')).toBe(0)
-    expect(resolveOverlapMsForFlushReason('max_chunk')).toBeGreaterThan(0)
-  })
-
-  it('selects the tail frames needed for continuation overlap', () => {
-    const frames = [
-      { timestampMs: 0, samples: new Float32Array(4000) },
-      { timestampMs: 250, samples: new Float32Array(4000) },
-      { timestampMs: 500, samples: new Float32Array(4000) },
-      { timestampMs: 750, samples: new Float32Array(4000) }
-    ]
-
-    const overlap = tailFramesForOverlap(frames, 16000, 400)
-
-    expect(overlap.map((frame) => frame.timestampMs)).toEqual([500, 750])
+  it('keeps Groq retry defaults small and explicit', () => {
+    expect(DEFAULT_GROQ_CHUNK_WINDOW_POLICY).toEqual({
+      maxRetryCount: 1,
+      retryBackoffMs: 250
+    })
   })
 })

--- a/src/main/services/streaming/chunk-window-policy.ts
+++ b/src/main/services/streaming/chunk-window-policy.ts
@@ -1,55 +1,16 @@
 /**
  * Where: src/main/services/streaming/chunk-window-policy.ts
- * What:  Central policy helpers for rolling-upload chunk overlap and retry defaults.
- * Why:   Groq is near-realtime chunk upload rather than native session streaming,
- *        so chunk carryover and retry behavior must stay explicit and testable.
+ * What:  Central retry policy defaults for Groq utterance uploads.
+ * Why:   Once Groq becomes utterance-only, the remaining shared tunables are
+ *        retry count and retry backoff rather than frame overlap or strides.
  */
 
-import type { StreamingAudioChunkFlushReason, StreamingAudioFrame } from '../../../shared/ipc'
-
 export interface ChunkWindowPolicy {
-  continuationOverlapMs: number
   maxRetryCount: number
   retryBackoffMs: number
-  sequenceStride: number
 }
 
 export const DEFAULT_GROQ_CHUNK_WINDOW_POLICY: ChunkWindowPolicy = {
-  continuationOverlapMs: 800,
   maxRetryCount: 1,
-  retryBackoffMs: 250,
-  sequenceStride: 1000
-}
-
-export const resolveOverlapMsForFlushReason = (
-  reason: StreamingAudioChunkFlushReason,
-  policy: ChunkWindowPolicy = DEFAULT_GROQ_CHUNK_WINDOW_POLICY
-): number => (reason === 'max_chunk' ? policy.continuationOverlapMs : 0)
-
-export const tailFramesForOverlap = (
-  frames: readonly StreamingAudioFrame[],
-  sampleRateHz: number,
-  overlapMs: number
-): StreamingAudioFrame[] => {
-  if (frames.length === 0 || sampleRateHz <= 0 || overlapMs <= 0) {
-    return []
-  }
-
-  const requiredSamples = Math.ceil((overlapMs / 1000) * sampleRateHz)
-  let collectedSamples = 0
-  const selected: StreamingAudioFrame[] = []
-
-  for (let index = frames.length - 1; index >= 0; index -= 1) {
-    const frame = frames[index]
-    selected.unshift({
-      samples: frame.samples.slice(),
-      timestampMs: frame.timestampMs
-    })
-    collectedSamples += frame.samples.length
-    if (collectedSamples >= requiredSamples) {
-      break
-    }
-  }
-
-  return selected
+  retryBackoffMs: 250
 }

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -1,8 +1,8 @@
 /**
  * Where: src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- * What:  Tests the Groq rolling-upload runtime around ordering, retries, and dedupe.
- * Why:   PR-7 must prove that near-realtime chunk uploads do not emit duplicate
- *        text or reorder commits when uploads finish out of order.
+ * What:  Tests the Groq utterance-upload runtime around ordering, retries, and dedupe.
+ * Why:   T440-04 removes frame accumulation from the Groq adapter, so the
+ *        remaining behavior must be validated strictly at utterance boundaries.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -23,25 +23,29 @@ const LOCAL_CONFIG = {
   transformationProfile: null
 }
 
-const makeBatch = (params: {
+const makeUtterance = (params: {
+  utteranceIndex: number
   startMs: number
-  flushReason: 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
-  values?: number[]
+  endMs: number
+  reason: 'speech_pause' | 'max_chunk' | 'session_stop'
+  hadCarryover?: boolean
+  wavBytes?: number[]
 }) => ({
   sessionId: 'session-1',
   sampleRateHz: 16000,
   channels: 1,
-  flushReason: params.flushReason,
-  frames: [
-    {
-      samples: new Float32Array(params.values ?? [0.2, 0.2, 0.2, 0.2]),
-      timestampMs: params.startMs
-    }
-  ]
+  utteranceIndex: params.utteranceIndex,
+  wavBytes: new Uint8Array(params.wavBytes ?? [82, 73, 70, 70]).buffer,
+  wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+  startedAtMs: params.startMs,
+  endedAtMs: params.endMs,
+  hadCarryover: params.hadCarryover ?? false,
+  reason: params.reason,
+  source: 'browser_vad' as const
 })
 
 describe('GroqRollingUploadAdapter', () => {
-  it('emits timestamped final segments for a pause-bounded Groq chunk', async () => {
+  it('emits timestamped final segments for a pause-bounded Groq utterance', async () => {
     const onFinalSegment = vi.fn()
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
@@ -62,9 +66,11 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
       startMs: 1000,
-      flushReason: 'speech_pause'
+      endMs: 2000,
+      reason: 'speech_pause'
     }))
     await adapter.stop('user_stop')
 
@@ -100,19 +106,13 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioUtteranceChunk({
-      sessionId: 'session-1',
-      sampleRateHz: 16000,
-      channels: 1,
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
       utteranceIndex: 0,
-      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
-      wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 2_000,
-      endedAtMs: 2_500,
+      startMs: 2_000,
+      endMs: 2_500,
       hadCarryover: true,
-      reason: 'speech_pause',
-      source: 'browser_vad'
-    })
+      reason: 'speech_pause'
+    }))
     await adapter.stop('user_stop')
 
     expect(fetchFn).toHaveBeenCalledOnce()
@@ -125,7 +125,7 @@ describe('GroqRollingUploadAdapter', () => {
     }))
   })
 
-  it('releases chunk results in chunk order even when later uploads finish first', async () => {
+  it('releases utterance results in utterance order even when later sends are queued quickly', async () => {
     const resolvers: Array<(response: Response) => void> = []
     const fetchFn = vi.fn(() => new Promise<Response>((resolve) => {
       resolvers.push(resolve)
@@ -144,70 +144,86 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 1000, flushReason: 'speech_pause' }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 1000,
+      endMs: 1500,
+      reason: 'speech_pause'
+    }))
 
-    if (resolvers[1]) {
-      resolvers[1](new Response(JSON.stringify({ text: 'second chunk' }), { status: 200 }))
-    }
     await Promise.resolve()
     expect(onFinalSegment).not.toHaveBeenCalled()
 
     if (resolvers[0]) {
-      resolvers[0](new Response(JSON.stringify({ text: 'first chunk' }), { status: 200 }))
+      resolvers[0](new Response(JSON.stringify({ text: 'first utterance' }), { status: 200 }))
+    }
+    await vi.waitFor(() => {
+      expect(resolvers).toHaveLength(2)
+    })
+    if (resolvers[1]) {
+      resolvers[1](new Response(JSON.stringify({ text: 'second utterance' }), { status: 200 }))
     }
     await adapter.stop('user_stop')
 
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first chunk', 'second chunk'])
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1000])
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first utterance', 'second utterance'])
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1])
   })
 
-  it('clears buffered audio when discard_pending is received before the next pause flush', async () => {
-    const onFinalSegment = vi.fn()
+  it('rejects legacy frame-batch ingress for Groq', async () => {
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
       config: LOCAL_CONFIG,
       callbacks: {
-        onFinalSegment,
+        onFinalSegment: vi.fn(),
         onFailure: vi.fn()
       }
     }, {
       secretStore: { getApiKey: vi.fn(() => 'test-key') },
-      fetchFn: vi.fn(async () => new Response(JSON.stringify({
-        text: 'later',
-        segments: [
-          { start: 0, end: 0.5, text: 'later' }
-        ]
-      }), { status: 200 }))
+      fetchFn: vi.fn()
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch({
-      sessionId: 'session-1',
-      sampleRateHz: 16000,
-      channels: 1,
-      flushReason: null,
-      frames: [
-        {
-          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
-          timestampMs: 0
-        }
-      ]
-    })
-    await adapter.pushAudioFrameBatch({
-      sessionId: 'session-1',
-      sampleRateHz: 16000,
-      channels: 1,
-      flushReason: 'discard_pending',
-      frames: []
-    })
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 1000, flushReason: 'speech_pause' }))
-    await adapter.stop('user_stop')
 
-    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
-      text: 'later',
-      startedAt: '1970-01-01T00:00:01.000Z'
-    }))
+    await expect(
+      adapter.pushAudioFrameBatch({
+        sessionId: 'session-1',
+        sampleRateHz: 16000,
+        channels: 1,
+        flushReason: null,
+        frames: [{ samples: new Float32Array([0.2, 0.2]), timestampMs: 0 }]
+      })
+    ).rejects.toThrow('only accepts browser-VAD utterance chunks')
+  })
+
+  it('rejects out-of-order utterance indices', async () => {
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn()
+    })
+
+    await adapter.start()
+
+    await expect(
+      adapter.pushAudioUtteranceChunk(makeUtterance({
+        utteranceIndex: 1,
+        startMs: 0,
+        endMs: 500,
+        reason: 'speech_pause'
+      }))
+    ).rejects.toThrow('expected utteranceIndex=0')
   })
 
   it('retries one transient Groq failure without duplicating committed text', async () => {
@@ -230,7 +246,12 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
     await adapter.stop('user_stop')
 
     expect(fetchFn).toHaveBeenCalledTimes(2)
@@ -241,7 +262,7 @@ describe('GroqRollingUploadAdapter', () => {
     }))
   })
 
-  it('trims duplicated fallback text when a speech_pause chunk carries overlap from a prior max_chunk', async () => {
+  it('trims duplicated fallback text when a max_chunk continuation carries overlap into the next utterance', async () => {
     const fetchFn = vi
       .fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'hello world' }), { status: 200 }))
@@ -260,19 +281,58 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
       startMs: 0,
-      flushReason: 'max_chunk',
-      values: new Array(16000).fill(0.2)
+      endMs: 1000,
+      reason: 'max_chunk'
     }))
-    await adapter.pushAudioFrameBatch(makeBatch({
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
       startMs: 1000,
-      flushReason: 'speech_pause',
-      values: new Array(16000).fill(0.2)
+      endMs: 1800,
+      reason: 'speech_pause',
+      hadCarryover: true
     }))
     await adapter.stop('user_stop')
 
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['hello world', 'again'])
+  })
+
+  it('does not trim repeated words across normal pause-bounded utterances without carryover', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'hello' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'hello there' }), { status: 200 }))
+    const onFinalSegment = vi.fn()
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 900,
+      endMs: 1600,
+      reason: 'speech_pause'
+    }))
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['hello', 'hello there'])
   })
 
   it('fails startup when the Groq API key is missing', async () => {
@@ -313,7 +373,12 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
     await adapter.stop('user_cancel')
 
     expect(seenSignals).toHaveLength(1)
@@ -321,8 +386,15 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFinalSegment).not.toHaveBeenCalled()
   })
 
-  it('drops buffered audio on user_cancel even before any upload starts', async () => {
-    const fetchFn = vi.fn()
+  it('drops queued utterances on user_cancel after the active upload is aborted', async () => {
+    const seenSignals: AbortSignal[] = []
+    const fetchFn = vi.fn(async (_input, init) => {
+      if (init?.signal) {
+        seenSignals.push(init.signal)
+      }
+      await new Promise(() => {})
+      return new Response(JSON.stringify({ text: 'never' }), { status: 200 })
+    })
     const onFinalSegment = vi.fn()
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
@@ -337,16 +409,23 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch({
-      sessionId: 'session-1',
-      sampleRateHz: 16000,
-      channels: 1,
-      flushReason: null,
-      frames: [{ samples: new Float32Array([0.2, 0.2, 0.2, 0.2]), timestampMs: 0 }]
-    })
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 600,
+      endMs: 1100,
+      reason: 'session_stop'
+    }))
     await adapter.stop('user_cancel')
 
-    expect(fetchFn).not.toHaveBeenCalled()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(seenSignals).toHaveLength(1)
+    expect(seenSignals[0]?.aborted).toBe(true)
     expect(onFinalSegment).not.toHaveBeenCalled()
   })
 
@@ -370,7 +449,12 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
     await adapter.stop('user_stop')
 
     expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({
@@ -400,7 +484,12 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({ startMs: 0, flushReason: 'speech_pause' }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
     await adapter.stop('user_stop')
 
     expect(seenSignals).toHaveLength(1)
@@ -440,9 +529,11 @@ describe('GroqRollingUploadAdapter', () => {
     })
 
     await adapter.start()
-    await adapter.pushAudioFrameBatch(makeBatch({
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
       startMs: 1000,
-      flushReason: 'speech_pause'
+      endMs: 2000,
+      reason: 'speech_pause'
     }))
     await adapter.stop('user_stop')
 
@@ -451,5 +542,53 @@ describe('GroqRollingUploadAdapter', () => {
       text: 'hello'
     }))
     ;(releaseFirstSegment as (() => void) | null)?.()
+  })
+
+  it('uses monotonic final segment sequences across utterances with many provider segments', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        text: 'alpha bravo',
+        segments: [
+          { start: 0, end: 0.3, text: 'alpha' },
+          { start: 0.3, end: 0.6, text: 'bravo' }
+        ]
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        text: 'charlie',
+        segments: [
+          { start: 0, end: 0.4, text: 'charlie' }
+        ]
+      }), { status: 200 }))
+    const onFinalSegment = vi.fn()
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 600,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 1000,
+      endMs: 1400,
+      reason: 'session_stop'
+    }))
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1, 2])
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['alpha', 'bravo', 'charlie'])
   })
 })

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -9,25 +9,20 @@ import { Buffer } from 'node:buffer'
 import type { SecretStore } from '../secret-store'
 import { resolveProviderEndpoint } from '../endpoint-resolver'
 import type {
-  StreamingAudioChunkFlushReason,
-  StreamingAudioFrame,
   StreamingAudioFrameBatch,
+  StreamingAudioUtteranceChunk,
   StreamingSessionStopReason
 } from '../../../shared/ipc'
 import { resolveTranscriptionLanguageOverride } from '../transcription/types'
 import {
   DEFAULT_GROQ_CHUNK_WINDOW_POLICY,
-  resolveOverlapMsForFlushReason,
-  tailFramesForOverlap,
   type ChunkWindowPolicy
 } from './chunk-window-policy'
 import type {
-  ProviderFinalSegmentInput,
   StreamingProviderRuntime,
   StreamingProviderRuntimeCallbacks,
   StreamingSessionStartConfig
 } from './types'
-import type { StreamingAudioUtteranceChunk } from '../../../shared/ipc'
 
 interface GroqRollingUploadAdapterParams {
   sessionId: string
@@ -53,22 +48,13 @@ interface GroqVerboseResponse {
   }>
 }
 
-interface PendingChunkUpload {
-  chunkIndex: number
-  flushReason: StreamingAudioChunkFlushReason
+interface PendingUtteranceUpload {
+  utteranceIndex: number
+  reason: StreamingAudioUtteranceChunk['reason']
   body: Blob
   hadCarryover: boolean
-  chunkStartMs: number
-  chunkEndMs: number
-}
-
-interface CompletedChunkUpload {
-  chunkIndex: number
-  flushReason: StreamingAudioChunkFlushReason
-  hadCarryover: boolean
-  chunkStartMs: number
-  chunkEndMs: number
-  response: GroqVerboseResponse
+  startedAtMs: number
+  endedAtMs: number
 }
 
 const GROQ_DEFAULT_BASE = 'https://api.groq.com'
@@ -81,16 +67,11 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private readonly delayMs: (ms: number) => Promise<void>
   private readonly stopBudgetDelayMs: (ms: number) => Promise<void>
   private readonly chunkWindowPolicy: ChunkWindowPolicy
-  private readonly currentChunkFrames: StreamingAudioFrame[] = []
-  private currentSampleRateHz = 0
-  private currentChannels = 1
-  private carryoverFrames: StreamingAudioFrame[] = []
-  private nextChunkIndex = 0
-  private nextChunkIndexToEmit = 0
-  private readonly completedChunks = new Map<number, CompletedChunkUpload>()
-  private readonly inFlightChunkPromises = new Map<number, Promise<void>>()
-  private readonly abortControllers = new Map<number, AbortController>()
-  private drainingCompletedChunks = false
+  private readonly pendingUtterances: PendingUtteranceUpload[] = []
+  private nextExpectedUtteranceIndex = 0
+  private nextSequence = 0
+  private queuePumpPromise: Promise<void> | null = null
+  private activeAbortController: AbortController | null = null
   private stopDrainTimedOut = false
   private stopped = false
   private lastCommittedEndedAtMs = Number.NEGATIVE_INFINITY
@@ -128,10 +109,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       return
     }
 
-    if (this.currentChunkFrames.length > 0) {
-      this.scheduleChunkUpload('session_stop')
-    }
-
     const finishStopDrainPromise = this.finishStopDrain().catch((error) => {
       if (this.stopDrainTimedOut) {
         return
@@ -153,30 +130,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {
-    if (this.stopped) {
-      throw new Error('Groq rolling upload runtime is already stopped.')
-    }
-    if (batch.channels !== 1) {
-      throw new Error(`Groq rolling upload currently requires mono audio. Received channels=${batch.channels}.`)
-    }
-    if (batch.flushReason === 'discard_pending') {
-      this.currentChunkFrames.length = 0
-      this.carryoverFrames = []
-      return
-    }
-    if (batch.frames.length === 0) {
-      return
-    }
-
-    if (this.currentChunkFrames.length === 0) {
-      this.currentSampleRateHz = batch.sampleRateHz
-      this.currentChannels = batch.channels
-    }
-    this.currentChunkFrames.push(...batch.frames.map(cloneFrame))
-
-    if (batch.flushReason !== null) {
-      this.scheduleChunkUpload(batch.flushReason)
-    }
+    void batch
+    throw new Error('Groq rolling upload only accepts browser-VAD utterance chunks.')
   }
 
   async pushAudioUtteranceChunk(chunk: StreamingAudioUtteranceChunk): Promise<void> {
@@ -189,64 +144,61 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     if (chunk.wavFormat !== 'wav_pcm_s16le_mono_16000') {
       throw new Error(`Groq rolling upload requires wav_pcm_s16le_mono_16000 utterances. Received ${chunk.wavFormat}.`)
     }
+    if (chunk.utteranceIndex !== this.nextExpectedUtteranceIndex) {
+      throw new Error(`Groq rolling upload expected utteranceIndex=${this.nextExpectedUtteranceIndex}, received ${chunk.utteranceIndex}.`)
+    }
 
-    const pendingChunk: PendingChunkUpload = {
-      chunkIndex: this.nextChunkIndex,
-      flushReason: chunk.reason,
+    this.nextExpectedUtteranceIndex += 1
+    this.pendingUtterances.push({
+      utteranceIndex: chunk.utteranceIndex,
+      reason: chunk.reason,
       body: new Blob([Buffer.from(chunk.wavBytes)], { type: 'audio/wav' }),
       hadCarryover: chunk.hadCarryover,
-      chunkStartMs: chunk.startedAtMs,
-      chunkEndMs: chunk.endedAtMs
-    }
-    this.nextChunkIndex += 1
-
-    this.schedulePendingChunkUpload(pendingChunk)
+      startedAtMs: chunk.startedAtMs,
+      endedAtMs: chunk.endedAtMs
+    })
+    this.ensureQueuePump()
   }
 
-  private scheduleChunkUpload(flushReason: StreamingAudioChunkFlushReason): void {
-    if (this.currentChunkFrames.length === 0) {
+  private ensureQueuePump(): void {
+    if (this.queuePumpPromise) {
       return
     }
 
-    const liveFrames = this.currentChunkFrames.splice(0, this.currentChunkFrames.length)
-    const carryoverFrames = this.carryoverFrames.map(cloneFrame)
-    const pendingChunk: PendingChunkUpload = {
-      chunkIndex: this.nextChunkIndex,
-      flushReason,
-      body: createWavBlob([...carryoverFrames, ...liveFrames], this.currentSampleRateHz, this.currentChannels),
-      hadCarryover: carryoverFrames.length > 0,
-      chunkStartMs: liveFrames[0]?.timestampMs ?? 0,
-      chunkEndMs: resolveChunkEndMs(liveFrames, this.currentSampleRateHz)
-    }
-    this.nextChunkIndex += 1
-
-    const overlapMs = resolveOverlapMsForFlushReason(flushReason, this.chunkWindowPolicy)
-    this.carryoverFrames =
-      overlapMs > 0 ? tailFramesForOverlap(liveFrames, this.currentSampleRateHz, overlapMs) : []
-
-    this.schedulePendingChunkUpload(pendingChunk)
+    this.queuePumpPromise = this.pumpQueue()
+      .finally(() => {
+        this.queuePumpPromise = null
+      })
   }
 
-  private schedulePendingChunkUpload(chunk: PendingChunkUpload): void {
-    const uploadPromise = this.uploadChunk(chunk)
-      .catch(async (error) => {
+  private async pumpQueue(): Promise<void> {
+    while (!this.stopDrainTimedOut && this.pendingUtterances.length > 0) {
+      const utterance = this.pendingUtterances.shift()
+      if (!utterance) {
+        continue
+      }
+
+      try {
+        const response = await this.uploadUtterance(utterance)
+        if (this.stopDrainTimedOut) {
+          return
+        }
+        await this.emitCompletedUtterance(utterance, response)
+      } catch (error) {
         if (isAbortError(error) && this.stopped) {
           return
         }
+        this.pendingUtterances.length = 0
         await this.params.callbacks.onFailure({
           code: 'groq_chunk_upload_failed',
           message: error instanceof Error ? error.message : String(error)
         })
-      })
-      .finally(() => {
-        this.inFlightChunkPromises.delete(chunk.chunkIndex)
-        this.abortControllers.delete(chunk.chunkIndex)
-      })
-
-    this.inFlightChunkPromises.set(chunk.chunkIndex, uploadPromise)
+        return
+      }
+    }
   }
 
-  private async uploadChunk(chunk: PendingChunkUpload): Promise<void> {
+  private async uploadUtterance(utterance: PendingUtteranceUpload): Promise<GroqVerboseResponse> {
     const endpoint = resolveProviderEndpoint(
       GROQ_DEFAULT_BASE,
       GROQ_STT_PATH,
@@ -254,156 +206,122 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     )
     const apiKey = this.requireApiKey()
     const abortController = new AbortController()
-    this.abortControllers.set(chunk.chunkIndex, abortController)
+    this.activeAbortController = abortController
 
-    let attempt = 0
-    while (true) {
-      attempt += 1
-      const formData = new FormData()
-      formData.append('model', this.params.config.model)
-      formData.append('file', chunk.body, `streaming-chunk-${chunk.chunkIndex}.wav`)
-      formData.append('response_format', 'verbose_json')
-      formData.append('timestamp_granularities[]', 'segment')
-
-      const language = resolveTranscriptionLanguageOverride(this.params.config.language ?? 'auto')
-      if (language) {
-        formData.append('language', language)
-      }
-
-      const response = await this.fetchFn(endpoint, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`
-        },
-        body: formData,
-        signal: abortController.signal
-      })
-
-      if (!response.ok) {
-        const detail = await response.text()
-        if (shouldRetryResponse(response.status, attempt, this.chunkWindowPolicy.maxRetryCount)) {
-          await this.delayMs(this.chunkWindowPolicy.retryBackoffMs)
-          continue
-        }
-        throw new Error(`Groq rolling upload failed with status ${response.status}: ${detail}`)
-      }
-
-      const data = (await response.json()) as GroqVerboseResponse
-      if (this.stopDrainTimedOut) {
-        return
-      }
-      this.completedChunks.set(chunk.chunkIndex, {
-        chunkIndex: chunk.chunkIndex,
-        flushReason: chunk.flushReason,
-        hadCarryover: chunk.hadCarryover,
-        chunkStartMs: chunk.chunkStartMs,
-        chunkEndMs: chunk.chunkEndMs,
-        response: data
-      })
-      await this.drainCompletedChunks()
-      return
-    }
-  }
-
-  private async drainCompletedChunks(): Promise<void> {
-    if (this.drainingCompletedChunks) {
-      return
-    }
-
-    this.drainingCompletedChunks = true
-    let shouldDrainAgain = false
     try {
-      if (this.stopDrainTimedOut) {
-        this.completedChunks.clear()
-        return
-      }
-      while (this.completedChunks.has(this.nextChunkIndexToEmit)) {
-        if (this.stopDrainTimedOut) {
-          this.completedChunks.clear()
-          return
-        }
-        const completedChunk = this.completedChunks.get(this.nextChunkIndexToEmit)
-        this.completedChunks.delete(this.nextChunkIndexToEmit)
-        this.nextChunkIndexToEmit += 1
-        if (!completedChunk) {
-          continue
+      let attempt = 0
+      while (true) {
+        attempt += 1
+        const formData = new FormData()
+        formData.append('model', this.params.config.model)
+        formData.append('file', utterance.body, `streaming-utterance-${utterance.utteranceIndex}.wav`)
+        formData.append('response_format', 'verbose_json')
+        formData.append('timestamp_granularities[]', 'segment')
+
+        const language = resolveTranscriptionLanguageOverride(this.params.config.language ?? 'auto')
+        if (language) {
+          formData.append('language', language)
         }
 
-        const segments = this.buildFinalSegments(completedChunk)
-        for (const segment of segments) {
-          if (this.stopDrainTimedOut) {
-            return
+        const response = await this.fetchFn(endpoint, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`
+          },
+          body: formData,
+          signal: abortController.signal
+        })
+
+        if (!response.ok) {
+          const detail = await response.text()
+          if (shouldRetryResponse(response.status, attempt, this.chunkWindowPolicy.maxRetryCount)) {
+            await this.delayMs(this.chunkWindowPolicy.retryBackoffMs)
+            continue
           }
-          await this.params.callbacks.onFinalSegment(segment)
+          throw new Error(`Groq rolling upload failed with status ${response.status}: ${detail}`)
         }
-      }
-      shouldDrainAgain = this.completedChunks.has(this.nextChunkIndexToEmit)
-    } finally {
-      this.drainingCompletedChunks = false
-    }
 
-    if (shouldDrainAgain) {
-      await this.drainCompletedChunks()
+        return (await response.json()) as GroqVerboseResponse
+      }
+    } finally {
+      if (this.activeAbortController === abortController) {
+        this.activeAbortController = null
+      }
     }
   }
 
-  private buildFinalSegments(chunk: CompletedChunkUpload): ProviderFinalSegmentInput[] {
-    const sequenceBase = chunk.chunkIndex * this.chunkWindowPolicy.sequenceStride
-    const segments = chunk.response.segments ?? []
+  private async emitCompletedUtterance(
+    utterance: PendingUtteranceUpload,
+    response: GroqVerboseResponse
+  ): Promise<void> {
+    const segments = response.segments ?? []
     if (segments.length > 0) {
-      const finalizedSegments: ProviderFinalSegmentInput[] = []
-      let offset = 0
       for (const segment of segments) {
         if (typeof segment.start !== 'number' || typeof segment.end !== 'number' || typeof segment.text !== 'string') {
           continue
         }
 
-        const absoluteStartedAtMs = chunk.chunkStartMs + Math.round(segment.start * 1000)
-        const absoluteEndedAtMs = chunk.chunkStartMs + Math.round(segment.end * 1000)
+        const absoluteStartedAtMs = utterance.startedAtMs + Math.round(segment.start * 1000)
+        const absoluteEndedAtMs = utterance.startedAtMs + Math.round(segment.end * 1000)
         if (absoluteEndedAtMs <= this.lastCommittedEndedAtMs) {
           continue
         }
 
         let text = segment.text.trim()
-        if (absoluteStartedAtMs < this.lastCommittedEndedAtMs) {
+        if (absoluteStartedAtMs < this.lastCommittedEndedAtMs || utterance.hadCarryover) {
           text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
+        }
+        if (this.stopDrainTimedOut) {
+          return
         }
         if (text.length === 0) {
           continue
         }
 
-        finalizedSegments.push({
-          sessionId: this.params.sessionId,
-          sequence: sequenceBase + offset,
+        await this.emitFinalSegment({
           text,
-          startedAt: new Date(absoluteStartedAtMs).toISOString(),
-          endedAt: new Date(absoluteEndedAtMs).toISOString()
+          startedAtMs: absoluteStartedAtMs,
+          endedAtMs: absoluteEndedAtMs
         })
-        offset += 1
         this.rememberCommittedText(text, absoluteEndedAtMs)
       }
-
-      if (finalizedSegments.length > 0) {
-        return finalizedSegments
-      }
+      return
     }
 
-    let text = (chunk.response.text ?? '').trim()
-    if (chunk.hadCarryover) {
+    let text = (response.text ?? '').trim()
+    if (utterance.hadCarryover) {
       text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
     }
-    if (text.length === 0) {
-      return []
+    if (text.length === 0 || this.stopDrainTimedOut) {
+      return
     }
 
-    this.rememberCommittedText(text, chunk.chunkEndMs)
-    return [{
-      sessionId: this.params.sessionId,
-      sequence: sequenceBase,
+    await this.emitFinalSegment({
       text,
-      startedAt: new Date(chunk.chunkStartMs).toISOString(),
-      endedAt: new Date(chunk.chunkEndMs).toISOString()
-    }]
+      startedAtMs: utterance.startedAtMs,
+      endedAtMs: utterance.endedAtMs
+    })
+    this.rememberCommittedText(text, utterance.endedAtMs)
+  }
+
+  private async emitFinalSegment(params: {
+    text: string
+    startedAtMs: number
+    endedAtMs: number
+  }): Promise<void> {
+    if (this.stopDrainTimedOut) {
+      return
+    }
+
+    const sequence = this.nextSequence
+    this.nextSequence += 1
+    await this.params.callbacks.onFinalSegment({
+      sessionId: this.params.sessionId,
+      sequence,
+      text: params.text,
+      startedAt: new Date(params.startedAtMs).toISOString(),
+      endedAt: new Date(params.endedAtMs).toISOString()
+    })
   }
 
   private rememberCommittedText(text: string, endedAtMs: number): void {
@@ -413,11 +331,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private async finishStopDrain(): Promise<void> {
-    await Promise.allSettled(this.inFlightChunkPromises.values())
-    if (this.stopDrainTimedOut) {
-      return
-    }
-    await this.drainCompletedChunks()
+    await this.queuePumpPromise
   }
 
   private requireApiKey(): string {
@@ -429,65 +343,13 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private abortOutstandingUploads(): void {
-    for (const controller of this.abortControllers.values()) {
-      controller.abort()
-    }
-    this.abortControllers.clear()
-    this.inFlightChunkPromises.clear()
+    this.activeAbortController?.abort()
+    this.activeAbortController = null
   }
 
   private clearPendingStopBuffers(): void {
-    this.completedChunks.clear()
-    this.currentChunkFrames.length = 0
-    this.carryoverFrames = []
+    this.pendingUtterances.length = 0
   }
-}
-
-const cloneFrame = (frame: StreamingAudioFrame): StreamingAudioFrame => ({
-  samples: frame.samples.slice(),
-  timestampMs: frame.timestampMs
-})
-
-const resolveChunkEndMs = (frames: readonly StreamingAudioFrame[], sampleRateHz: number): number => {
-  const lastFrame = frames.at(-1)
-  if (!lastFrame || sampleRateHz <= 0) {
-    return frames[0]?.timestampMs ?? 0
-  }
-  const frameDurationMs = (lastFrame.samples.length / sampleRateHz) * 1000
-  return lastFrame.timestampMs + Math.round(frameDurationMs)
-}
-
-const createWavBlob = (frames: readonly StreamingAudioFrame[], sampleRateHz: number, channels: number): Blob => {
-  const pcmSamples = frames.reduce((total, frame) => total + frame.samples.length, 0)
-  const pcmBytes = Buffer.alloc(pcmSamples * 2)
-  let offset = 0
-
-  for (const frame of frames) {
-    for (const sample of frame.samples) {
-      const clamped = Math.max(-1, Math.min(1, sample))
-      const pcm = clamped < 0 ? Math.round(clamped * 0x8000) : Math.round(clamped * 0x7fff)
-      pcmBytes.writeInt16LE(pcm, offset)
-      offset += 2
-    }
-  }
-
-  const wavBuffer = Buffer.alloc(44 + pcmBytes.length)
-  wavBuffer.write('RIFF', 0)
-  wavBuffer.writeUInt32LE(36 + pcmBytes.length, 4)
-  wavBuffer.write('WAVE', 8)
-  wavBuffer.write('fmt ', 12)
-  wavBuffer.writeUInt32LE(16, 16)
-  wavBuffer.writeUInt16LE(1, 20)
-  wavBuffer.writeUInt16LE(channels, 22)
-  wavBuffer.writeUInt32LE(sampleRateHz, 24)
-  wavBuffer.writeUInt32LE(sampleRateHz * channels * 2, 28)
-  wavBuffer.writeUInt16LE(channels * 2, 32)
-  wavBuffer.writeUInt16LE(16, 34)
-  wavBuffer.write('data', 36)
-  wavBuffer.writeUInt32LE(pcmBytes.length, 40)
-  pcmBytes.copy(wavBuffer, 44)
-
-  return new Blob([wavBuffer], { type: 'audio/wav' })
 }
 
 const trimOverlappingPrefix = (text: string, previousTail: string): string => {


### PR DESCRIPTION
## Summary
- remove Groq frame accumulation, overlap helpers, and chunk-stride sequencing from the adapter
- make the adapter utterance-only with serial upload queueing and monotonic final segment numbering
- add coverage for utterance ordering, carryover dedupe, natural pause boundaries, and frame-batch rejection

## Verification
- pnpm vitest run src/main/services/streaming/chunk-window-policy.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm vitest run src/main/services/streaming/chunk-window-policy.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts src/main/services/streaming/streaming-session-controller.test.ts src/main/ipc/register-handlers.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Review
- manual review: no remaining findings in the adapter rewrite
- Claude CLI review: unavailable in this environment because the CLI hit its usage cap before returning output