### PR TITLE
fix: harden groq vad stop backpressure flow

### DIFF
--- a/docs/decisions/2026-03-09-groq-stop-backpressure-hardening-decision.md
+++ b/docs/decisions/2026-03-09-groq-stop-backpressure-hardening-decision.md
@@ -1,0 +1,52 @@
+<!--
+Where: docs/decisions/2026-03-09-groq-stop-backpressure-hardening-decision.md
+What: Decision note for the T440-05 stop and backpressure hardening pass.
+Why: The Groq utterance-native path needs explicit rules for bounded upload drain,
+     renderer-visible backpressure, and in-flight utterance stop behavior.
+-->
+
+# Decision: Groq Stop Budget Applies To Upload Drain, Not Downstream Commit
+
+## Status
+
+Accepted on March 9, 2026.
+
+## Context
+
+After the utterance-native adapter landed, review found that the Groq queue pump
+was still awaiting `onFinalSegment(...)` before starting the next upload. That
+incorrectly coupled upload progress and stop timeout behavior to downstream
+transform/output latency.
+
+The renderer also had no visible signal when Groq utterance delivery was blocked
+behind upload backlog, and `stop()` only waited for `max_chunk` flushes instead
+of any in-flight utterance send.
+
+## Decision
+
+For the Groq browser-VAD path:
+
+1. the adapter serializes uploads, not downstream segment commit
+2. already-uploaded utterances continue committing even if the upload stop budget expires
+3. the upload queue is bounded and blocks new utterances when capacity is full
+4. renderer capture surfaces pause/resume activity when an utterance send stays blocked past a threshold
+5. renderer `stop()` waits for any active utterance send before teardown
+
+## Why This Is Acceptable
+
+- It restores the intended “upload serial, output independent” behavior.
+- It prevents slow transform/output work from consuming the Groq upload stop budget.
+- It turns queue pressure into an observable paused state instead of a silent stall.
+- It keeps the shared session-state contract unchanged in the final hardening ticket.
+
+## Trade-offs
+
+- Pro: better stop correctness and better debugging signal under slow networks.
+- Pro: bounded queue pressure now produces deterministic backpressure.
+- Con: renderer-visible pause/resume is inferred from blocked utterance delivery, not a dedicated main-process status channel.
+- Con: structured logs are noisier in focused tests unless explicitly silenced.
+
+## Follow-up
+
+If backlog state needs richer UI treatment later, a future ticket can promote this
+from inferred pause/resume activity into an explicit streaming runtime event.

--- a/docs/qa/streaming-raw-dictation-manual-checklist.md
+++ b/docs/qa/streaming-raw-dictation-manual-checklist.md
@@ -61,3 +61,7 @@
   - verify pause-bounded chunks continue during one long recording session
   - verify a Groq auth/network failure appears as a streaming error toast and activity entry
   - verify the UX never claims Groq is a native realtime session API
+  - verify stopping during active speech still commits the last utterance before the session ends
+  - simulate a slow network and verify backlog pause/resume activity appears instead of silent stalling
+  - verify backlog recovery resumes live dictation without dropping later utterances
+  - verify a quiet/short utterance near a misfire boundary does not leak a ghost stop chunk

--- a/src/main/services/streaming/chunk-window-policy.test.ts
+++ b/src/main/services/streaming/chunk-window-policy.test.ts
@@ -12,7 +12,8 @@ describe('chunk-window-policy', () => {
   it('keeps Groq retry defaults small and explicit', () => {
     expect(DEFAULT_GROQ_CHUNK_WINDOW_POLICY).toEqual({
       maxRetryCount: 1,
-      retryBackoffMs: 250
+      retryBackoffMs: 250,
+      maxQueuedUtterances: 2
     })
   })
 })

--- a/src/main/services/streaming/chunk-window-policy.ts
+++ b/src/main/services/streaming/chunk-window-policy.ts
@@ -1,16 +1,18 @@
 /**
  * Where: src/main/services/streaming/chunk-window-policy.ts
- * What:  Central retry policy defaults for Groq utterance uploads.
- * Why:   Once Groq becomes utterance-only, the remaining shared tunables are
- *        retry count and retry backoff rather than frame overlap or strides.
+ * What:  Central retry and queue policy defaults for Groq utterance uploads.
+ * Why:   The utterance-native Groq path still needs explicit retry and bounded
+ *        queue tunables so upload backpressure remains predictable and testable.
  */
 
 export interface ChunkWindowPolicy {
   maxRetryCount: number
   retryBackoffMs: number
+  maxQueuedUtterances: number
 }
 
 export const DEFAULT_GROQ_CHUNK_WINDOW_POLICY: ChunkWindowPolicy = {
   maxRetryCount: 1,
-  retryBackoffMs: 250
+  retryBackoffMs: 250,
+  maxQueuedUtterances: 2
 }

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -175,6 +175,65 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1])
   })
 
+  it('blocks new utterances when the Groq upload queue reaches capacity', async () => {
+    let releaseFirstUpload = (): void => {
+      throw new Error('First upload resolver was not captured.')
+    }
+    const fetchFn = vi
+      .fn()
+      .mockImplementationOnce(async () => await new Promise<Response>((resolve) => {
+        releaseFirstUpload = () => resolve(new Response(JSON.stringify({ text: 'first' }), { status: 200 }))
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'second' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'third' }), { status: 200 }))
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn,
+      chunkWindowPolicy: {
+        maxRetryCount: 1,
+        retryBackoffMs: 0,
+        maxQueuedUtterances: 2
+      }
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    const secondPush = adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 600,
+      endMs: 1100,
+      reason: 'speech_pause'
+    }))
+    await secondPush
+
+    const thirdPush = adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 2,
+      startMs: 1200,
+      endMs: 1700,
+      reason: 'speech_pause'
+    }))
+    await Promise.resolve()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    releaseFirstUpload()
+    await thirdPush
+    await adapter.stop('user_stop')
+
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+
   it('rejects legacy frame-batch ingress for Groq', async () => {
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
@@ -496,12 +555,10 @@ describe('GroqRollingUploadAdapter', () => {
     expect(seenSignals[0]?.aborted).toBe(true)
   })
 
-  it('cuts off the remaining drain tail when user_stop budget expires mid-drain', async () => {
+  it('lets already-uploaded segments finish committing even when final-segment processing is slow', async () => {
     let releaseFirstSegment: (() => void) | null = null
-    let releaseStopBudget: (() => void) | null = null
     const onFinalSegment = vi.fn(async (segment: { text: string }) => {
       if (segment.text === 'hello') {
-        releaseStopBudget?.()
         await new Promise<void>((resolve) => {
           releaseFirstSegment = resolve
         })
@@ -522,10 +579,7 @@ describe('GroqRollingUploadAdapter', () => {
           { start: 0, end: 0.5, text: 'hello' },
           { start: 0.5, end: 1.0, text: 'world' }
         ]
-      }), { status: 200 })),
-      stopBudgetDelayMs: vi.fn(() => new Promise<void>((resolve) => {
-        releaseStopBudget = resolve
-      }))
+      }), { status: 200 }))
     })
 
     await adapter.start()
@@ -535,13 +589,77 @@ describe('GroqRollingUploadAdapter', () => {
       endMs: 2000,
       reason: 'speech_pause'
     }))
-    await adapter.stop('user_stop')
+    const stopPromise = adapter.stop('user_stop')
+    await vi.waitFor(() => {
+      expect(onFinalSegment).toHaveBeenCalledTimes(1)
+    })
 
-    expect(onFinalSegment).toHaveBeenCalledTimes(1)
     expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
       text: 'hello'
     }))
     ;(releaseFirstSegment as (() => void) | null)?.()
+    await stopPromise
+    expect(onFinalSegment).toHaveBeenCalledTimes(2)
+    expect(onFinalSegment).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      text: 'world'
+    }))
+  })
+
+  it('does not let slow final-segment processing delay the next upload start', async () => {
+    let releaseFirstSegment = (): void => {
+      throw new Error('Segment release was not captured.')
+    }
+    const resolvers: Array<(response: Response) => void> = []
+    const onFinalSegment = vi.fn(async (segment: { text: string }) => {
+      if (segment.text === 'first') {
+        await new Promise<void>((resolve) => {
+          releaseFirstSegment = resolve
+        })
+      }
+    })
+    const fetchFn = vi.fn(() => new Promise<Response>((resolve) => {
+      resolvers.push(resolve)
+    }))
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 400,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 500,
+      endMs: 900,
+      reason: 'speech_pause'
+    }))
+
+    resolvers[0]?.(new Response(JSON.stringify({
+      text: 'first'
+    }), { status: 200 }))
+    await vi.waitFor(() => {
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    })
+
+    resolvers[1]?.(new Response(JSON.stringify({
+      text: 'second'
+    }), { status: 200 }))
+    releaseFirstSegment()
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first', 'second'])
   })
 
   it('uses monotonic final segment sequences across utterances with many provider segments', async () => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -1,8 +1,8 @@
 /**
  * Where: src/main/services/streaming/groq-rolling-upload-adapter.ts
- * What:  Rolling-upload streaming adapter for Groq audio transcriptions.
- * Why:   Groq's official surface is file-based transcription, so PR-7 models it
- *        honestly as pause-bounded chunk upload with ordered result emission.
+ * What:  Rolling-upload streaming adapter for Groq browser-VAD utterances.
+ * Why:   Groq is still file-style upload, but the utterance-native path now
+ *        separates upload backpressure from downstream output commit latency.
  */
 
 import { Buffer } from 'node:buffer'
@@ -18,6 +18,7 @@ import {
   DEFAULT_GROQ_CHUNK_WINDOW_POLICY,
   type ChunkWindowPolicy
 } from './chunk-window-policy'
+import { logStructured } from '../../../shared/error-logging'
 import type {
   StreamingProviderRuntime,
   StreamingProviderRuntimeCallbacks,
@@ -50,11 +51,18 @@ interface GroqVerboseResponse {
 
 interface PendingUtteranceUpload {
   utteranceIndex: number
-  reason: StreamingAudioUtteranceChunk['reason']
   body: Blob
   hadCarryover: boolean
   startedAtMs: number
   endedAtMs: number
+}
+
+interface CompletedUtteranceUpload {
+  utteranceIndex: number
+  hadCarryover: boolean
+  startedAtMs: number
+  endedAtMs: number
+  response: GroqVerboseResponse
 }
 
 const GROQ_DEFAULT_BASE = 'https://api.groq.com'
@@ -68,11 +76,14 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private readonly stopBudgetDelayMs: (ms: number) => Promise<void>
   private readonly chunkWindowPolicy: ChunkWindowPolicy
   private readonly pendingUtterances: PendingUtteranceUpload[] = []
+  private readonly completedUtterances: CompletedUtteranceUpload[] = []
+  private readonly queueCapacityWaiters = new Set<() => void>()
   private nextExpectedUtteranceIndex = 0
   private nextSequence = 0
   private queuePumpPromise: Promise<void> | null = null
+  private emitPumpPromise: Promise<void> | null = null
   private activeAbortController: AbortController | null = null
-  private stopDrainTimedOut = false
+  private stopUploadTimedOut = false
   private stopped = false
   private lastCommittedEndedAtMs = Number.NEGATIVE_INFINITY
   private lastCommittedTextTail = ''
@@ -101,7 +112,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
   async stop(reason: StreamingSessionStopReason): Promise<void> {
     this.stopped = true
-    this.stopDrainTimedOut = false
+    this.stopUploadTimedOut = false
 
     if (reason === 'user_cancel' || reason === 'fatal_error') {
       this.abortOutstandingUploads()
@@ -109,24 +120,32 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       return
     }
 
-    const finishStopDrainPromise = this.finishStopDrain().catch((error) => {
-      if (this.stopDrainTimedOut) {
-        return
-      }
-      throw error
-    })
+    const uploadDrainPromise = this.queuePumpPromise ?? Promise.resolve()
     const outcome = await Promise.race([
-      finishStopDrainPromise.then(() => 'completed' as const),
+      uploadDrainPromise.then(() => 'completed' as const),
       this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
     ])
     if (outcome === 'timed_out') {
-      this.stopDrainTimedOut = true
+      this.stopUploadTimedOut = true
+      logStructured({
+        level: 'warn',
+        scope: 'main',
+        event: 'streaming.groq_upload.stop_budget_timed_out',
+        message: 'Groq stop budget expired while waiting for upload drain.',
+        context: {
+          sessionId: this.params.sessionId,
+          timeoutMs: GROQ_USER_STOP_BUDGET_MS,
+          queuedUtterances: this.getQueuedUtteranceCount()
+        }
+      })
       this.abortOutstandingUploads()
-      this.clearPendingStopBuffers()
+      this.pendingUtterances.length = 0
+      this.notifyQueueCapacityAvailable()
+      await this.emitPumpPromise
       return
     }
 
-    await finishStopDrainPromise
+    await this.finishStopDrain()
   }
 
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {
@@ -147,11 +166,11 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     if (chunk.utteranceIndex !== this.nextExpectedUtteranceIndex) {
       throw new Error(`Groq rolling upload expected utteranceIndex=${this.nextExpectedUtteranceIndex}, received ${chunk.utteranceIndex}.`)
     }
+    await this.waitForQueueCapacity(chunk.utteranceIndex)
 
     this.nextExpectedUtteranceIndex += 1
     this.pendingUtterances.push({
       utteranceIndex: chunk.utteranceIndex,
-      reason: chunk.reason,
       body: new Blob([Buffer.from(chunk.wavBytes)], { type: 'audio/wav' }),
       hadCarryover: chunk.hadCarryover,
       startedAtMs: chunk.startedAtMs,
@@ -172,18 +191,47 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private async pumpQueue(): Promise<void> {
-    while (!this.stopDrainTimedOut && this.pendingUtterances.length > 0) {
+    while (!this.stopUploadTimedOut && this.pendingUtterances.length > 0) {
       const utterance = this.pendingUtterances.shift()
       if (!utterance) {
         continue
       }
+      this.notifyQueueCapacityAvailable()
 
       try {
+        logStructured({
+          level: 'info',
+          scope: 'main',
+          event: 'streaming.groq_upload.begin',
+          message: 'Starting Groq utterance upload.',
+          context: {
+            sessionId: this.params.sessionId,
+            utteranceIndex: utterance.utteranceIndex,
+            queuedUtterances: this.getQueuedUtteranceCount()
+          }
+        })
         const response = await this.uploadUtterance(utterance)
-        if (this.stopDrainTimedOut) {
+        if (this.stopUploadTimedOut) {
           return
         }
-        await this.emitCompletedUtterance(utterance, response)
+        logStructured({
+          level: 'info',
+          scope: 'main',
+          event: 'streaming.groq_upload.completed',
+          message: 'Completed Groq utterance upload.',
+          context: {
+            sessionId: this.params.sessionId,
+            utteranceIndex: utterance.utteranceIndex
+          }
+        })
+        this.completedUtterances.push({
+          utteranceIndex: utterance.utteranceIndex,
+          hadCarryover: utterance.hadCarryover,
+          startedAtMs: utterance.startedAtMs,
+          endedAtMs: utterance.endedAtMs,
+          response
+        })
+        this.ensureEmitPump()
       } catch (error) {
         if (isAbortError(error) && this.stopped) {
           return
@@ -195,6 +243,27 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
         })
         return
       }
+    }
+  }
+
+  private ensureEmitPump(): void {
+    if (this.emitPumpPromise) {
+      return
+    }
+
+    this.emitPumpPromise = this.drainCompletedUtterances()
+      .finally(() => {
+        this.emitPumpPromise = null
+      })
+  }
+
+  private async drainCompletedUtterances(): Promise<void> {
+    while (this.completedUtterances.length > 0) {
+      const utterance = this.completedUtterances.shift()
+      if (!utterance) {
+        continue
+      }
+      await this.emitCompletedUtterance(utterance)
     }
   }
 
@@ -247,14 +316,12 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       if (this.activeAbortController === abortController) {
         this.activeAbortController = null
       }
+      this.notifyQueueCapacityAvailable()
     }
   }
 
-  private async emitCompletedUtterance(
-    utterance: PendingUtteranceUpload,
-    response: GroqVerboseResponse
-  ): Promise<void> {
-    const segments = response.segments ?? []
+  private async emitCompletedUtterance(utterance: CompletedUtteranceUpload): Promise<void> {
+    const segments = utterance.response.segments ?? []
     if (segments.length > 0) {
       for (const segment of segments) {
         if (typeof segment.start !== 'number' || typeof segment.end !== 'number' || typeof segment.text !== 'string') {
@@ -271,9 +338,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
         if (absoluteStartedAtMs < this.lastCommittedEndedAtMs || utterance.hadCarryover) {
           text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
         }
-        if (this.stopDrainTimedOut) {
-          return
-        }
         if (text.length === 0) {
           continue
         }
@@ -288,11 +352,11 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       return
     }
 
-    let text = (response.text ?? '').trim()
+    let text = (utterance.response.text ?? '').trim()
     if (utterance.hadCarryover) {
       text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
     }
-    if (text.length === 0 || this.stopDrainTimedOut) {
+    if (text.length === 0) {
       return
     }
 
@@ -309,10 +373,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     startedAtMs: number
     endedAtMs: number
   }): Promise<void> {
-    if (this.stopDrainTimedOut) {
-      return
-    }
-
     const sequence = this.nextSequence
     this.nextSequence += 1
     await this.params.callbacks.onFinalSegment({
@@ -332,6 +392,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
   private async finishStopDrain(): Promise<void> {
     await this.queuePumpPromise
+    await this.emitPumpPromise
   }
 
   private requireApiKey(): string {
@@ -349,6 +410,70 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
   private clearPendingStopBuffers(): void {
     this.pendingUtterances.length = 0
+    this.completedUtterances.length = 0
+    this.notifyQueueCapacityAvailable()
+  }
+
+  private getQueuedUtteranceCount(): number {
+    return this.pendingUtterances.length + (this.activeAbortController ? 1 : 0)
+  }
+
+  private async waitForQueueCapacity(utteranceIndex: number): Promise<void> {
+    if (this.stopped) {
+      throw new Error('Groq rolling upload runtime is already stopped.')
+    }
+
+    let didLogWait = false
+    while (this.getQueuedUtteranceCount() >= this.chunkWindowPolicy.maxQueuedUtterances) {
+      if (!didLogWait) {
+        didLogWait = true
+        logStructured({
+          level: 'warn',
+          scope: 'main',
+          event: 'streaming.groq_upload.backpressure_wait_begin',
+          message: 'Groq upload queue is full; waiting before accepting another utterance.',
+          context: {
+            sessionId: this.params.sessionId,
+            utteranceIndex,
+            queuedUtterances: this.getQueuedUtteranceCount(),
+            maxQueuedUtterances: this.chunkWindowPolicy.maxQueuedUtterances
+          }
+        })
+      }
+
+      await new Promise<void>((resolve) => {
+        this.queueCapacityWaiters.add(resolve)
+      })
+
+      if (this.stopped) {
+        throw new Error('Groq rolling upload runtime is already stopped.')
+      }
+    }
+
+    if (didLogWait) {
+      logStructured({
+        level: 'info',
+        scope: 'main',
+        event: 'streaming.groq_upload.backpressure_wait_end',
+        message: 'Groq upload queue drained enough to accept another utterance.',
+        context: {
+          sessionId: this.params.sessionId,
+          utteranceIndex,
+          queuedUtterances: this.getQueuedUtteranceCount(),
+          maxQueuedUtterances: this.chunkWindowPolicy.maxQueuedUtterances
+        }
+      })
+    }
+  }
+
+  private notifyQueueCapacityAvailable(): void {
+    if (this.getQueuedUtteranceCount() >= this.chunkWindowPolicy.maxQueuedUtterances) {
+      return
+    }
+    for (const resolve of this.queueCapacityWaiters) {
+      resolve()
+    }
+    this.queueCapacityWaiters.clear()
   }
 }
 

--- a/src/main/test-support/streaming-groq-stop-budget.test.ts
+++ b/src/main/test-support/streaming-groq-stop-budget.test.ts
@@ -2,7 +2,7 @@
  * Where: src/main/test-support/streaming-groq-stop-budget.test.ts
  * What:  Integration coverage for the bounded Groq user_stop path.
  * Why:   SSTP-04 must prove that a hung Groq upload no longer blocks the full
- *        controller stop path forever.
+ *        controller stop path forever on the utterance-native Groq path.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -53,17 +53,18 @@ describe('streaming Groq stop budget integration', () => {
     controller.onSessionState(onSessionState)
 
     await controller.start(GROQ_STREAMING_CONFIG)
-    await controller.pushAudioFrameBatch({
+    await controller.pushAudioUtteranceChunk({
       sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
-      flushReason: 'speech_pause',
-      frames: [
-        {
-          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
-          timestampMs: 1000
-        }
-      ]
+      utteranceIndex: 0,
+      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 1000,
+      endedAtMs: 1500,
+      hadCarryover: false,
+      reason: 'speech_pause',
+      source: 'browser_vad'
     })
     await controller.stop('user_stop')
 

--- a/src/main/test-support/streaming-stop-integration.test.ts
+++ b/src/main/test-support/streaming-stop-integration.test.ts
@@ -3,7 +3,7 @@
  * What:  Integration coverage for the streaming stop path across the controller
  *        and the real Groq rolling-upload adapter.
  * Why:   SSTP-03 must prove that late stop-time provider output still commits
- *        before the session ends.
+ *        before the session ends on the utterance-native Groq path.
  */
 
 import { describe, expect, it, vi } from 'vitest'
@@ -62,17 +62,18 @@ describe('streaming stop integration', () => {
     controller.onSegment(onSegment)
 
     await controller.start(GROQ_STREAMING_CONFIG)
-    await controller.pushAudioFrameBatch({
+    await controller.pushAudioUtteranceChunk({
       sessionId: 'session-1',
       sampleRateHz: 16000,
       channels: 1,
-      flushReason: null,
-      frames: [
-        {
-          samples: new Float32Array([0.2, 0.2, 0.2, 0.2]),
-          timestampMs: 1000
-        }
-      ]
+      utteranceIndex: 0,
+      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 1000,
+      endedAtMs: 2000,
+      hadCarryover: false,
+      reason: 'session_stop',
+      source: 'browser_vad'
     })
     await controller.stop('user_stop')
 

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -79,9 +79,11 @@ describe('startGroqBrowserVadCapture', () => {
 
   const createCapture = async (overrides: {
     sink?: { pushStreamingAudioUtteranceChunk: ReturnType<typeof vi.fn> }
+    onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
     nowMs?: () => number
     startupTimeoutMs?: number
     maxUtteranceMs?: number
+    backpressureSignalMs?: number
     encodeWav?: (audio: Float32Array) => ArrayBuffer
     createVad?: typeof FakeMicVad.create
   } = {}): Promise<{
@@ -96,10 +98,12 @@ describe('startGroqBrowserVadCapture', () => {
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError: vi.fn(),
+      onBackpressureStateChange: overrides.onBackpressureStateChange,
       nowMs: overrides.nowMs ?? (() => 5_000),
       config: {
         startupTimeoutMs: overrides.startupTimeoutMs,
-        maxUtteranceMs: overrides.maxUtteranceMs
+        maxUtteranceMs: overrides.maxUtteranceMs,
+        backpressureSignalMs: overrides.backpressureSignalMs
       }
     }, {
       createVad: overrides.createVad ?? FakeMicVad.create,
@@ -245,12 +249,97 @@ describe('startGroqBrowserVadCapture', () => {
     }))
   })
 
+  it('waits for an in-flight speech_pause push before stop completes', async () => {
+    let releasePush: (() => void) | null = null
+    const sink = {
+      pushStreamingAudioUtteranceChunk: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          releasePush = resolve
+        })
+      })
+    }
+    const { capture, vad } = await createCapture({
+      sink
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(3_200).fill(0.2))
+    const speechEndPromise = vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
+    await vi.waitFor(() => {
+      expect(releasePush).not.toBeNull()
+    })
+    const stopPromise = capture.stop()
+    await Promise.resolve()
+
+    expect(vad.destroy).not.toHaveBeenCalled()
+    const release = releasePush as (() => void) | null
+    if (!release) {
+      throw new Error('Expected speech_pause push to be pending.')
+    }
+    release()
+    await speechEndPromise
+    await stopPromise
+
+    expect(vad.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('signals backpressure pause and resume when utterance delivery blocks past the threshold', async () => {
+    let resolvePush = (): void => {
+      throw new Error('Push resolver was not captured.')
+    }
+    const backpressureEvents: Array<{ paused: boolean; durationMs?: number }> = []
+    const sink = {
+      pushStreamingAudioUtteranceChunk: vi.fn(async () => await new Promise<void>((resolve) => {
+        resolvePush = resolve
+      }))
+    }
+    const { vad } = await createCapture({
+      sink,
+      nowMs: () => 8_000,
+      backpressureSignalMs: 100,
+      onBackpressureStateChange: (state) => {
+        backpressureEvents.push(state)
+      }
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    const speechEndPromise = vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(3_200).fill(0.2))
+      .then(async () => {
+        await vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
+      })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(backpressureEvents).toEqual([{ paused: true }])
+
+    resolvePush()
+    await speechEndPromise
+
+    expect(backpressureEvents).toEqual([
+      { paused: true },
+      { paused: false, durationMs: 0 }
+    ])
+  })
+
   it('does not emit a stop utterance when speech never becomes valid', async () => {
     const { capture, vad, sink } = await createCapture()
 
     await vad.emitSpeechStart()
     await vad.emitFrame({ isSpeech: 0.2, notSpeech: 0.8 }, new Float32Array(800).fill(0.05))
     await capture.stop()
+
+    expect(sink.pushStreamingAudioUtteranceChunk).not.toHaveBeenCalled()
+    expect(vad.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('stops cleanly when stop lands before a pending misfire callback', async () => {
+    const { capture, vad, sink } = await createCapture()
+
+    await vad.emitSpeechStart()
+    await vad.emitFrame({ isSpeech: 0.2, notSpeech: 0.8 }, new Float32Array(800).fill(0.05))
+    await capture.stop()
+    await vad.emitMisfire()
 
     expect(sink.pushStreamingAudioUtteranceChunk).not.toHaveBeenCalled()
     expect(vad.destroy).toHaveBeenCalledOnce()

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -7,6 +7,7 @@ Why: Isolate Groq's browser-VAD lifecycle from the existing whisper.cpp frame-st
 
 import { MicVAD, utils, type RealTimeVADOptions } from '@ricky0123/vad-web'
 import type { StreamingAudioUtteranceChunk, StreamingSessionStopReason } from '../shared/ipc'
+import { logStructured } from '../shared/error-logging'
 import {
   GROQ_BROWSER_VAD_ASSET_PATHS,
   GROQ_BROWSER_VAD_DEFAULTS,
@@ -26,6 +27,7 @@ export interface GroqBrowserVadCaptureOptions {
   deviceConstraints: MediaTrackConstraints
   sink: GroqBrowserVadSink
   onFatalError: (error: unknown) => void
+  onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
   nowMs?: () => number
   config?: Partial<GroqBrowserVadConfig>
 }
@@ -77,6 +79,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private readonly nowMs: () => number
   private readonly sink: GroqBrowserVadSink
   private readonly onFatalError: (error: unknown) => void
+  private readonly onBackpressureStateChange: ((state: { paused: boolean; durationMs?: number }) => void) | null
   private readonly encodeWav: (audio: Float32Array) => ArrayBuffer
   private readonly config: GroqBrowserVadConfig
   private readonly setTimeoutFn: typeof setTimeout
@@ -98,12 +101,16 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private preSpeechSamples = 0
   private continuationFlushInFlight = false
   private continuationFlushPromise: Promise<void> | null = null
+  private activeUtterancePushPromise: Promise<void> | null = null
   private nextUtteranceHadCarryover = false
+  private backpressureActive = false
+  private backpressureStartedAtMs: number | null = null
 
   constructor(
     params: {
       sink: GroqBrowserVadSink
       onFatalError: (error: unknown) => void
+      onBackpressureStateChange: ((state: { paused: boolean; durationMs?: number }) => void) | null
       nowMs: () => number
       encodeWav: (audio: Float32Array) => ArrayBuffer
       config: GroqBrowserVadConfig
@@ -113,6 +120,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   ) {
     this.sink = params.sink
     this.onFatalError = params.onFatalError
+    this.onBackpressureStateChange = params.onBackpressureStateChange
     this.nowMs = params.nowMs
     this.encodeWav = params.encodeWav
     this.config = params.config
@@ -175,8 +183,16 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.ignoreVadSpeechEnd = true
 
     try {
+      logStructured({
+        level: 'info',
+        scope: 'renderer',
+        event: 'streaming.groq_vad.stop_begin',
+        message: 'Stopping Groq browser VAD capture.',
+        context: { reason }
+      })
       await this.vad?.pause()
       await this.awaitContinuationFlush()
+      await this.awaitActiveUtterancePush()
       if (reason !== 'user_cancel' && reason !== 'fatal_error') {
         await this.flushStopUtterance()
       } else {
@@ -193,11 +209,19 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
         // Destroy is best-effort during teardown only.
       }
       this.vad = null
+      this.clearBackpressure()
     }
 
     if (stopError) {
       throw stopError
     }
+    logStructured({
+      level: 'info',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.stop_complete',
+      message: 'Stopped Groq browser VAD capture.',
+      context: { reason }
+    })
   }
 
   async cancel(): Promise<void> {
@@ -269,6 +293,18 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.resetSpeechWindow()
 
     try {
+      logStructured({
+        level: 'info',
+        scope: 'renderer',
+        event: 'streaming.groq_vad.utterance_ready',
+        message: 'Groq browser VAD sealed a speech_pause utterance.',
+        context: {
+          utteranceIndex: this.utteranceIndex,
+          reason: 'speech_pause',
+          hadCarryover,
+          samples: audio.length
+        }
+      })
       await this.pushUtterance(audio, 'speech_pause', hadCarryover)
     } catch (error) {
       this.reportFatalError(error)
@@ -297,6 +333,18 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
 
     const audio = concatFrames(this.liveFrames)
     const hadCarryover = this.nextUtteranceHadCarryover
+    logStructured({
+      level: 'info',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.utterance_ready',
+      message: 'Groq browser VAD sealed a session_stop utterance.',
+      context: {
+        utteranceIndex: this.utteranceIndex,
+        reason: 'session_stop',
+        hadCarryover,
+        samples: audio.length
+      }
+    })
     await this.pushUtterance(audio, 'session_stop', hadCarryover)
     this.resetSpeechWindow()
   }
@@ -320,6 +368,18 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
 
     this.continuationFlushPromise = (async () => {
       try {
+        logStructured({
+          level: 'info',
+          scope: 'renderer',
+          event: 'streaming.groq_vad.utterance_ready',
+          message: 'Groq browser VAD sealed a max_chunk continuation utterance.',
+          context: {
+            utteranceIndex: this.utteranceIndex,
+            reason: 'max_chunk',
+            hadCarryover,
+            samples: audio.length
+          }
+        })
         await this.pushUtterance(audio, 'max_chunk', hadCarryover)
       } catch (error) {
         this.reportFatalError(error)
@@ -345,7 +405,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     const utteranceIndex = this.utteranceIndex
     this.utteranceIndex += 1
 
-    await this.sink.pushStreamingAudioUtteranceChunk({
+    const pushPromise = this.sink.pushStreamingAudioUtteranceChunk({
       sampleRateHz: STREAM_SAMPLE_RATE_HZ,
       channels: 1,
       utteranceIndex,
@@ -357,6 +417,21 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       reason,
       source: 'browser_vad'
     })
+    this.activeUtterancePushPromise = pushPromise
+    let backpressureTimeout: ReturnType<typeof setTimeout> | null = this.setTimeoutFn(() => {
+      this.markBackpressureStarted()
+    }, this.config.backpressureSignalMs)
+
+    try {
+      await pushPromise
+    } finally {
+      this.activeUtterancePushPromise = null
+      if (backpressureTimeout) {
+        this.clearTimeoutFn(backpressureTimeout)
+        backpressureTimeout = null
+      }
+      this.markBackpressureResolved()
+    }
   }
 
   private resetSpeechWindow(): void {
@@ -375,6 +450,52 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
 
   private async awaitContinuationFlush(): Promise<void> {
     await this.continuationFlushPromise
+  }
+
+  private async awaitActiveUtterancePush(): Promise<void> {
+    await this.activeUtterancePushPromise
+  }
+
+  private markBackpressureStarted(): void {
+    if (this.backpressureActive) {
+      return
+    }
+    this.backpressureActive = true
+    this.backpressureStartedAtMs = this.nowMs()
+    logStructured({
+      level: 'warn',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.backpressure_pause',
+      message: 'Pausing Groq utterance delivery until the upload queue drains.',
+      context: {
+        backpressureSignalMs: this.config.backpressureSignalMs
+      }
+    })
+    this.onBackpressureStateChange?.({ paused: true })
+  }
+
+  private markBackpressureResolved(): void {
+    if (!this.backpressureActive) {
+      return
+    }
+    const durationMs = this.backpressureStartedAtMs === null ? undefined : Math.max(0, this.nowMs() - this.backpressureStartedAtMs)
+    this.backpressureActive = false
+    this.backpressureStartedAtMs = null
+    logStructured({
+      level: 'info',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.backpressure_resume',
+      message: 'Groq utterance delivery resumed after upload backpressure.',
+      context: {
+        durationMs
+      }
+    })
+    this.onBackpressureStateChange?.({ paused: false, durationMs })
+  }
+
+  private clearBackpressure(): void {
+    this.backpressureActive = false
+    this.backpressureStartedAtMs = null
   }
 
   private reportFatalError(error: unknown): void {
@@ -434,6 +555,7 @@ export const startGroqBrowserVadCapture = async (
   const capture = new BrowserGroqVadCapture({
     sink: options.sink,
     onFatalError: options.onFatalError,
+    onBackpressureStateChange: options.onBackpressureStateChange ?? null,
     nowMs: options.nowMs ?? (() => performance.now()),
     encodeWav,
     config,
@@ -453,6 +575,16 @@ export const startGroqBrowserVadCapture = async (
       startupExpired = true
     }
   )
+  logStructured({
+    level: 'info',
+    scope: 'renderer',
+    event: 'streaming.groq_vad.start_begin',
+    message: 'Starting Groq browser VAD capture.',
+    context: {
+      startupTimeoutMs: config.startupTimeoutMs,
+      maxUtteranceMs: config.maxUtteranceMs
+    }
+  })
   const pendingVad = createVad(capture.buildVadOptions(getUserMedia)).then(
     async (createdVad) => {
       if (startupExpired || startupClosed) {
@@ -487,8 +619,21 @@ export const startGroqBrowserVadCapture = async (
       vad.start(),
       startupTimeout.promise
     ])
+    logStructured({
+      level: 'info',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.start_complete',
+      message: 'Started Groq browser VAD capture.'
+    })
     return capture
   } catch (error) {
+    logStructured({
+      level: 'error',
+      scope: 'renderer',
+      event: 'streaming.groq_vad.start_failed',
+      message: 'Failed to start Groq browser VAD capture.',
+      error
+    })
     startupClosed = true
     try {
       await vad?.destroy()

--- a/src/renderer/groq-browser-vad-config.ts
+++ b/src/renderer/groq-browser-vad-config.ts
@@ -19,6 +19,7 @@ export interface GroqBrowserVadConfig {
   minSpeechMs: number
   maxUtteranceMs: number
   startupTimeoutMs: number
+  backpressureSignalMs: number
 }
 
 export const GROQ_BROWSER_VAD_DEFAULTS: GroqBrowserVadConfig = {
@@ -29,7 +30,8 @@ export const GROQ_BROWSER_VAD_DEFAULTS: GroqBrowserVadConfig = {
   preSpeechPadMs: 400,
   minSpeechMs: 160,
   maxUtteranceMs: 12_000,
-  startupTimeoutMs: 5_000
+  startupTimeoutMs: 5_000,
+  backpressureSignalMs: 300
 }
 
 export interface GroqBrowserVadAssetPaths {

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -378,6 +378,51 @@ describe('handleRecordingCommandDispatch', () => {
     })
   })
 
+  it('surfaces Groq upload backpressure pause and resume through renderer activity', async () => {
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'groq_whisper_large_v3_turbo'
+    state.settings.processing.streaming.transport = 'rolling_upload'
+    state.settings.processing.streaming.model = 'whisper-large-v3-turbo'
+    state.streamingSessionState = {
+      sessionId: 'session-groq-backpressure',
+      state: 'starting',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-groq-backpressure',
+      preferredDeviceId: 'mic-1'
+    })
+
+    const groqCaptureOptions = startGroqBrowserVadCaptureMock.mock.calls[0]?.[0]
+    if (!groqCaptureOptions?.onBackpressureStateChange) {
+      throw new Error('Expected Groq capture to receive an onBackpressureStateChange hook.')
+    }
+
+    groqCaptureOptions.onBackpressureStateChange({ paused: true })
+    groqCaptureOptions.onBackpressureStateChange({ paused: false, durationMs: 425 })
+
+    expect(deps.addToast).toHaveBeenCalledWith(
+      'Groq upload backlog detected. Live dictation is waiting for uploads.',
+      'info'
+    )
+    expect(deps.addActivity).toHaveBeenCalledWith(
+      'Groq upload backlog detected. Pausing utterance delivery until the queue drains.',
+      'info'
+    )
+    expect(deps.addActivity).toHaveBeenCalledWith(
+      'Groq upload backlog cleared after 425 ms.',
+      'info'
+    )
+  })
+
   it('stops live streaming capture and acknowledges explicit streaming stop requests', async () => {
     const { deps, state } = createDeps()
     state.settings = structuredClone(DEFAULT_SETTINGS)

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -448,7 +448,19 @@ export const startNativeRecording = async (
         ? await startGroqBrowserVadCapture({
             deviceConstraints: constraints.audio as MediaTrackConstraints,
             sink: createGroqBrowserVadSink(streamingSessionId),
-            onFatalError
+            onFatalError,
+            onBackpressureStateChange: ({ paused, durationMs }) => {
+              if (paused) {
+                deps.addActivity('Groq upload backlog detected. Pausing utterance delivery until the queue drains.', 'info')
+                deps.addToast('Groq upload backlog detected. Live dictation is waiting for uploads.', 'info')
+                return
+              }
+
+              deps.addActivity(
+                `Groq upload backlog cleared${typeof durationMs === 'number' ? ` after ${Math.round(durationMs)} ms` : ''}.`,
+                'info'
+              )
+            }
           })
         : await startStreamingLiveCapture({
             deviceConstraints: constraints.audio as MediaTrackConstraints,


### PR DESCRIPTION
## Summary
- harden Groq utterance stop drainage so stop budgets apply to uploads without dropping already-uploaded segment commits
- add bounded upload-queue backpressure with renderer-visible pause/resume diagnostics
- extend focused Groq VAD, adapter, and integration coverage and document the stop/backpressure decision

## Testing
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/renderer/native-recording.test.ts src/main/services/streaming/chunk-window-policy.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts src/main/test-support/streaming-stop-integration.test.ts src/main/test-support/streaming-groq-stop-budget.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Review
- manual review completed with no remaining findings
- Claude CLI review attempt blocked by usage cap in this environment: `You're out of extra usage · resets 10pm (UTC)`
