### PR TITLE
fix: harden groq stop backpressure handling

### DIFF
--- a/docs/decisions/2026-03-09-groq-stop-backpressure-hardening-decision.md
+++ b/docs/decisions/2026-03-09-groq-stop-backpressure-hardening-decision.md
@@ -5,7 +5,7 @@ Why: The Groq utterance-native path needs explicit rules for bounded upload drai
      renderer-visible backpressure, and in-flight utterance stop behavior.
 -->
 
-# Decision: Groq Stop Budget Applies To Upload Drain, Not Downstream Commit
+# Decision: Groq Stop Uses Pre-Ack Queue Relaxation And Bounded Commit Backlog
 
 ## Status
 
@@ -13,10 +13,16 @@ Accepted on March 9, 2026.
 
 ## Context
 
-After the utterance-native adapter landed, review found that the Groq queue pump
-was still awaiting `onFinalSegment(...)` before starting the next upload. That
-incorrectly coupled upload progress and stop timeout behavior to downstream
-transform/output latency.
+After the utterance-native adapter landed, review found several stop-path gaps:
+
+- the Groq queue pump had been decoupled from downstream commit latency, but
+  `user_stop` could still wedge if the renderer was blocked on queue capacity
+  while main waited for the renderer stop acknowledgement
+- downstream `onFinalSegment(...)` work could still hang `user_stop` forever if
+  commit never resolved
+- a completed-upload item could arrive in the narrow window where the emit pump
+  had drained its queue but had not yet cleared its promise, orphaning the new
+  completion until another emit happened later
 
 The renderer also had no visible signal when Groq utterance delivery was blocked
 behind upload backlog, and `stop()` only waited for `max_chunk` flushes instead
@@ -26,24 +32,31 @@ of any in-flight utterance send.
 
 For the Groq browser-VAD path:
 
-1. the adapter serializes uploads, not downstream segment commit
-2. already-uploaded utterances continue committing even if the upload stop budget expires
-3. the upload queue is bounded and blocks new utterances when capacity is full
-4. renderer capture surfaces pause/resume activity when an utterance send stays blocked past a threshold
-5. renderer `stop()` waits for any active utterance send before teardown
+1. main calls a Groq-only `prepareForRendererStop('user_stop')` hook before waiting for renderer ack
+2. that prepare hook relaxes queue-capacity waiting for already in-flight renderer sends, without stopping the session yet
+3. the adapter queue budget counts the full Groq backlog:
+   active upload, pending uploads, completed uploads waiting to emit, and one in-flight emit
+4. final-segment commits are still decoupled from upload start, but each commit is bounded by the same stop-budget timer and fails the session if it wedges
+5. both the upload pump and emit pump self-restart if new work lands during their promise teardown window
+6. renderer capture surfaces pause/resume activity when an utterance send stays blocked past a threshold
+7. renderer `stop()` waits for any active utterance send before teardown
 
 ## Why This Is Acceptable
 
-- It restores the intended “upload serial, output independent” behavior.
-- It prevents slow transform/output work from consuming the Groq upload stop budget.
+- It resolves the Groq-specific stop-ordering deadlock without changing the
+  `whisper.cpp` renderer-stop handshake.
+- It bounds both upload backlog and downstream commit backlog, so `user_stop`
+  cannot hang forever on a wedged output consumer.
+- It closes the emit-pump handoff race, so completed Groq utterances cannot get
+  stranded silently.
 - It turns queue pressure into an observable paused state instead of a silent stall.
-- It keeps the shared session-state contract unchanged in the final hardening ticket.
 
 ## Trade-offs
 
-- Pro: better stop correctness and better debugging signal under slow networks.
-- Pro: bounded queue pressure now produces deterministic backpressure.
-- Con: renderer-visible pause/resume is inferred from blocked utterance delivery, not a dedicated main-process status channel.
+- Pro: better stop correctness and better debugging signal under slow networks or slow output handling.
+- Pro: bounded queue pressure now reflects the full backlog, not just upload backlog.
+- Con: a permanently wedged downstream commit now fails the Groq streaming session instead of waiting indefinitely.
+- Con: renderer-visible pause/resume is still inferred from blocked utterance delivery, not a dedicated main-process status channel.
 - Con: structured logs are noisier in focused tests unless explicitly silenced.
 
 ## Follow-up

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -349,4 +349,79 @@ describe('registerIpcHandlers', () => {
       })
     )
   })
+
+  it('prepares Groq renderer stop before waiting for the renderer acknowledgement', async () => {
+    const prepareForRendererStop = vi.fn(async () => {})
+    const stopStreamingSession = vi.fn(async () => {})
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi.fn().mockResolvedValue({
+        kind: 'streaming_stop_requested',
+        sessionId: 'session-groq',
+        reason: 'user_stop'
+      }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: {
+        onSessionState: vi.fn(),
+        onSegment: vi.fn(),
+        onError: vi.fn(),
+        getSnapshot: vi.fn(() => ({
+          sessionId: 'session-groq',
+          state: 'active',
+          provider: 'groq_whisper_large_v3_turbo',
+          transport: 'rolling_upload',
+          model: 'whisper-large-v3-turbo',
+          reason: null
+        })),
+        prepareForRendererStop
+      } as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    const runPromise = getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.(
+      { sender: mocks.windows[0]?.webContents },
+      'toggleRecording'
+    )
+    await Promise.resolve()
+
+    expect(prepareForRendererStop).toHaveBeenCalledWith('user_stop')
+    expect(stopStreamingSession).not.toHaveBeenCalled()
+
+    await getRegisteredHandle(IPC_CHANNELS.ackStreamingRendererStop)?.(
+      { sender: mocks.windows[0]?.webContents },
+      { sessionId: 'session-groq', reason: 'user_stop' }
+    )
+    await runPromise
+
+    expect(stopStreamingSession).toHaveBeenCalledWith({
+      sessionId: 'session-groq',
+      reason: 'user_stop'
+    })
+  })
 })

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -315,7 +315,7 @@ const initializeServices = (): MainServices => {
     })
 
     const runRecordingCommand = async (command: RecordingCommand): Promise<void> =>
-      await runRecordingCommandThroughRouter(commandRouter, command)
+      await runRecordingCommandThroughRouter(commandRouter, streamingSessionController, command)
 
     const hotkeyService = new HotkeyService({
       globalShortcut,
@@ -542,6 +542,7 @@ const wireStreamingControllerEvents = (
 
 const executeRecordingCommandDispatch = async (
   commandRouter: RecordingCommandRoutingSurface,
+  streamingSessionController: Pick<StreamingSessionController, 'getSnapshot' | 'prepareForRendererStop'>,
   dispatch: RecordingCommandDispatch,
   initiatorWindowId: number | null = null
 ): Promise<void> => {
@@ -590,6 +591,18 @@ const executeRecordingCommandDispatch = async (
     return
   }
 
+  const snapshot =
+    typeof streamingSessionController.getSnapshot === 'function'
+      ? streamingSessionController.getSnapshot()
+      : null
+  if (
+    dispatch.reason === 'user_stop' &&
+    snapshot?.sessionId === dispatch.sessionId &&
+    snapshot.provider === 'groq_whisper_large_v3_turbo'
+  ) {
+    await streamingSessionController.prepareForRendererStop?.(dispatch.reason)
+  }
+
   await ackWait.promise
   await commandRouter.stopStreamingSession({
     sessionId: dispatch.sessionId,
@@ -600,12 +613,13 @@ const executeRecordingCommandDispatch = async (
 
 const runRecordingCommandThroughRouter = async (
   commandRouter: RecordingCommandRoutingSurface,
+  streamingSessionController: Pick<StreamingSessionController, 'getSnapshot' | 'prepareForRendererStop'>,
   command: RecordingCommand,
   initiatorWindowId: number | null = null
 ): Promise<void> => {
   const dispatch = await commandRouter.runRecordingCommand(command)
   if (dispatch) {
-    await executeRecordingCommandDispatch(commandRouter, dispatch, initiatorWindowId)
+    await executeRecordingCommandDispatch(commandRouter, streamingSessionController, dispatch, initiatorWindowId)
   }
 }
 
@@ -637,7 +651,12 @@ const bindIpcHandlers = (svc: MainServices): void => {
     svc.soundService.play(event)
   })
   ipcMain.handle(IPC_CHANNELS.runRecordingCommand, async (event, command: RecordingCommand) => {
-    await runRecordingCommandThroughRouter(svc.commandRouter, command, resolveRendererWindowIdFromSender(event.sender))
+    await runRecordingCommandThroughRouter(
+      svc.commandRouter,
+      svc.streamingSessionController,
+      command,
+      resolveRendererWindowIdFromSender(event.sender)
+    )
   })
   ipcMain.handle(
     IPC_CHANNELS.submitRecordedAudio,

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -234,6 +234,65 @@ describe('GroqRollingUploadAdapter', () => {
     expect(fetchFn).toHaveBeenCalledTimes(3)
   })
 
+  it('lets a renderer-stop prepare bypass queue-capacity waiting for an in-flight utterance', async () => {
+    let releaseFirstUpload = (): void => {
+      throw new Error('First upload resolver was not captured.')
+    }
+    const fetchFn = vi
+      .fn()
+      .mockImplementationOnce(async () => await new Promise<Response>((resolve) => {
+        releaseFirstUpload = () => resolve(new Response(JSON.stringify({ text: 'first' }), { status: 200 }))
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'second' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'third' }), { status: 200 }))
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn,
+      chunkWindowPolicy: {
+        maxRetryCount: 1,
+        retryBackoffMs: 0,
+        maxQueuedUtterances: 2
+      }
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 600,
+      endMs: 1100,
+      reason: 'speech_pause'
+    }))
+
+    const blockedPush = adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 2,
+      startMs: 1200,
+      endMs: 1700,
+      reason: 'session_stop'
+    }))
+    await Promise.resolve()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    await adapter.prepareForRendererStop?.('user_stop')
+    await expect(blockedPush).resolves.toBeUndefined()
+
+    releaseFirstUpload()
+    await adapter.stop('user_stop')
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+
   it('rejects legacy frame-batch ingress for Groq', async () => {
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
@@ -605,6 +664,73 @@ describe('GroqRollingUploadAdapter', () => {
     }))
   })
 
+  it('counts slow final-segment emission as queue backlog for later utterances', async () => {
+    let releaseFirstSegment = (): void => {
+      throw new Error('Segment release was not captured.')
+    }
+    const onFinalSegment = vi.fn(async (segment: { text: string }) => {
+      if (segment.text === 'first') {
+        await new Promise<void>((resolve) => {
+          releaseFirstSegment = resolve
+        })
+      }
+    })
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'first' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'second' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'third' }), { status: 200 }))
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn,
+      chunkWindowPolicy: {
+        maxRetryCount: 1,
+        retryBackoffMs: 0,
+        maxQueuedUtterances: 2
+      }
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 400,
+      reason: 'speech_pause'
+    }))
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 1,
+      startMs: 500,
+      endMs: 900,
+      reason: 'speech_pause'
+    }))
+    await vi.waitFor(() => {
+      expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({ text: 'first' }))
+    })
+
+    const blockedThirdPush = adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 2,
+      startMs: 1000,
+      endMs: 1400,
+      reason: 'session_stop'
+    }))
+    await Promise.resolve()
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+
+    releaseFirstSegment()
+    await blockedThirdPush
+    await adapter.stop('user_stop')
+
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first', 'second', 'third'])
+  })
+
   it('does not let slow final-segment processing delay the next upload start', async () => {
     let releaseFirstSegment = (): void => {
       throw new Error('Segment release was not captured.')
@@ -660,6 +786,42 @@ describe('GroqRollingUploadAdapter', () => {
     await adapter.stop('user_stop')
 
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first', 'second'])
+  })
+
+  it('fails the session when final-segment commit exceeds the stop budget', async () => {
+    const onFailure = vi.fn()
+    const stopBudgetDelayMs = vi
+      .fn()
+      .mockImplementationOnce(async () => await new Promise(() => {}))
+      .mockImplementationOnce(async () => {})
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(async () => {
+          await new Promise(() => {})
+        }),
+        onFailure
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({ text: 'hello' }), { status: 200 })),
+      stopBudgetDelayMs
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.stop('user_stop')
+
+    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'groq_final_segment_commit_failed',
+      message: expect.stringContaining('timed out')
+    }))
   })
 
   it('uses monotonic final segment sequences across utterances with many provider segments', async () => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -83,8 +83,10 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private queuePumpPromise: Promise<void> | null = null
   private emitPumpPromise: Promise<void> | null = null
   private activeAbortController: AbortController | null = null
+  private activeEmit = false
   private stopUploadTimedOut = false
   private stopped = false
+  private rendererStopPrepared = false
   private lastCommittedEndedAtMs = Number.NEGATIVE_INFINITY
   private lastCommittedTextTail = ''
 
@@ -148,6 +150,14 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     await this.finishStopDrain()
   }
 
+  async prepareForRendererStop(reason: StreamingSessionStopReason): Promise<void> {
+    if (reason !== 'user_stop' || this.stopped) {
+      return
+    }
+    this.rendererStopPrepared = true
+    this.notifyQueueCapacityAvailable()
+  }
+
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {
     void batch
     throw new Error('Groq rolling upload only accepts browser-VAD utterance chunks.')
@@ -187,6 +197,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.queuePumpPromise = this.pumpQueue()
       .finally(() => {
         this.queuePumpPromise = null
+        if (!this.stopUploadTimedOut && this.pendingUtterances.length > 0) {
+          this.ensureQueuePump()
+        }
       })
   }
 
@@ -254,6 +267,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.emitPumpPromise = this.drainCompletedUtterances()
       .finally(() => {
         this.emitPumpPromise = null
+        if (this.completedUtterances.length > 0) {
+          this.ensureEmitPump()
+        }
       })
   }
 
@@ -263,7 +279,24 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       if (!utterance) {
         continue
       }
-      await this.emitCompletedUtterance(utterance)
+      this.activeEmit = true
+      this.notifyQueueCapacityAvailable()
+
+      try {
+        await this.emitCompletedUtterance(utterance)
+      } catch (error) {
+        this.pendingUtterances.length = 0
+        this.completedUtterances.length = 0
+        this.notifyQueueCapacityAvailable()
+        await this.params.callbacks.onFailure({
+          code: 'groq_final_segment_commit_failed',
+          message: error instanceof Error ? error.message : String(error)
+        })
+        return
+      } finally {
+        this.activeEmit = false
+        this.notifyQueueCapacityAvailable()
+      }
     }
   }
 
@@ -375,13 +408,20 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }): Promise<void> {
     const sequence = this.nextSequence
     this.nextSequence += 1
-    await this.params.callbacks.onFinalSegment({
+    const segment = {
       sessionId: this.params.sessionId,
       sequence,
       text: params.text,
       startedAt: new Date(params.startedAtMs).toISOString(),
       endedAt: new Date(params.endedAtMs).toISOString()
-    })
+    }
+    const outcome = await Promise.race([
+      Promise.resolve(this.params.callbacks.onFinalSegment(segment)).then(() => 'completed' as const),
+      this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
+    ])
+    if (outcome === 'timed_out') {
+      throw new Error(`Groq final segment commit timed out after ${GROQ_USER_STOP_BUDGET_MS} ms.`)
+    }
   }
 
   private rememberCommittedText(text: string, endedAtMs: number): void {
@@ -415,7 +455,12 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private getQueuedUtteranceCount(): number {
-    return this.pendingUtterances.length + (this.activeAbortController ? 1 : 0)
+    return (
+      this.pendingUtterances.length +
+      this.completedUtterances.length +
+      (this.activeAbortController ? 1 : 0) +
+      (this.activeEmit ? 1 : 0)
+    )
   }
 
   private async waitForQueueCapacity(utteranceIndex: number): Promise<void> {
@@ -425,6 +470,9 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
     let didLogWait = false
     while (this.getQueuedUtteranceCount() >= this.chunkWindowPolicy.maxQueuedUtterances) {
+      if (this.rendererStopPrepared) {
+        return
+      }
       if (!didLogWait) {
         didLogWait = true
         logStructured({
@@ -467,7 +515,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private notifyQueueCapacityAvailable(): void {
-    if (this.getQueuedUtteranceCount() >= this.chunkWindowPolicy.maxQueuedUtterances) {
+    if (!this.rendererStopPrepared && this.getQueuedUtteranceCount() >= this.chunkWindowPolicy.maxQueuedUtterances) {
       return
     }
     for (const resolve of this.queueCapacityWaiters) {

--- a/src/main/services/streaming/streaming-session-controller.ts
+++ b/src/main/services/streaming/streaming-session-controller.ts
@@ -39,6 +39,7 @@ import { randomUUID } from 'node:crypto'
 export interface StreamingSessionController {
   start(config: StreamingSessionStartConfig): Promise<void>
   stop(reason?: StreamingSessionStopReason): Promise<void>
+  prepareForRendererStop?(reason: StreamingSessionStopReason): Promise<void>
   pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void>
   pushAudioUtteranceChunk(chunk: StreamingAudioUtteranceChunk): Promise<void>
   commitFinalSegment(segment: ProviderFinalSegmentInput): Promise<OutputApplyResult | null>
@@ -200,6 +201,13 @@ export class InMemoryStreamingSessionController implements StreamingSessionContr
       this.outputCoordinator.clearScope(stoppingSessionId)
     }
     this.clearCurrentSession()
+  }
+
+  async prepareForRendererStop(reason: StreamingSessionStopReason): Promise<void> {
+    if (this.snapshot.state !== 'active') {
+      return
+    }
+    await this.currentProviderRuntime?.prepareForRendererStop?.(reason)
   }
 
   async pushAudioFrameBatch(batch: StreamingAudioFrameBatch): Promise<void> {

--- a/src/main/services/streaming/types.ts
+++ b/src/main/services/streaming/types.ts
@@ -64,6 +64,7 @@ export interface StreamingProviderRuntime {
   stop: (reason: StreamingSessionStopReason) => Promise<void>
   pushAudioFrameBatch: (batch: StreamingAudioFrameBatch) => Promise<void>
   pushAudioUtteranceChunk?: (chunk: StreamingAudioUtteranceChunk) => Promise<void>
+  prepareForRendererStop?: (reason: StreamingSessionStopReason) => Promise<void>
 }
 
 export type CreateStreamingProviderRuntime = (params: {


### PR DESCRIPTION
## Summary
- add a Groq-only pre-stop preparation hook so renderer `user_stop` can bypass queue-capacity waits before the main ack timeout path
- count the full Groq backlog (active upload, pending uploads, completed uploads, active emit) and bound wedged final-segment commits
- restart upload/emit pumps if work lands during promise teardown, plus cover the new stop-ordering and backlog cases in tests

## Testing
- pnpm vitest run
- pnpm typecheck
- pnpm build
- git diff --check

## Review
- sub-agent review was requested on the final diff, but the agent did not return before completion in this environment
- Claude CLI review was attempted and blocked by quota: `You're out of extra usage · resets 10pm (UTC)`
