### PR TITLE
fix: harden Groq VAD renderer timer binding

### DIFF
--- a/docs/decisions/2026-03-10-groq-vad-bound-global-timers-decision.md
+++ b/docs/decisions/2026-03-10-groq-vad-bound-global-timers-decision.md
@@ -1,0 +1,66 @@
+<!--
+Where: docs/decisions/2026-03-10-groq-vad-bound-global-timers-decision.md
+What: Decision note for the Groq browser-VAD timer binding and utterance push ordering fix.
+Why: Record why the renderer now wraps global timers and starts backpressure timing
+     before transport in order to prevent the packaged Illegal invocation crash.
+-->
+
+# Decision: Bind Global Timers Through Wrappers in Groq Browser VAD
+
+Date: 2026-03-10
+
+## Context
+
+The packaged Groq browser-VAD repro showed a renderer crash on the first sealed
+utterance:
+
+- `TypeError: Illegal invocation`
+- thrown from the backpressure timer setup inside `pushUtterance()`
+
+The prior implementation stored `setTimeout` and `clearTimeout` as detached
+instance function references and invoked them later. In the packaged runtime,
+that detached host-method call shape was not safe.
+
+The prior implementation also created the utterance send promise before starting
+the backpressure timer. That left a narrow sync-failure window where the send
+could already be in flight when timer setup threw.
+
+## Decision
+
+Use bound wrapper functions for global timers and start the backpressure timer
+before transport begins.
+
+Specifically:
+
+- default timer dependencies are now plain wrapper functions that call
+  `globalThis.setTimeout(...)` and `globalThis.clearTimeout(...)`
+- `pushUtterance()` starts the backpressure timer before
+  `sink.pushStreamingAudioUtteranceChunk(...)`
+- `activeUtterancePushPromise` is only assigned after transport starts
+
+## Why
+
+This is the smallest fix that addresses both confirmed defects:
+
+- it removes the detached-host invocation shape that caused the packaged crash
+- it eliminates the known post-send sync-throw window that could orphan an
+  in-flight utterance push
+
+## Trade-offs
+
+Accepted:
+
+- keep timer dependency injection, but normalize the default production path to
+  safe wrapper functions
+- slightly reorder the backpressure timer relative to transport start
+
+Rejected:
+
+- keep detached timer references and only add logging
+- move to a broader timer abstraction across the whole renderer stack in this PR
+
+## Consequences
+
+- packaged/browser runtimes no longer depend on detached host-method behavior
+- a synchronous timer setup failure now aborts before transport starts
+- broader fatal-stop semantics are intentionally deferred to the next ticket

--- a/docs/qa/issue-440-r1-packaged-repro-checklist.md
+++ b/docs/qa/issue-440-r1-packaged-repro-checklist.md
@@ -1,0 +1,41 @@
+<!--
+Where: docs/qa/issue-440-r1-packaged-repro-checklist.md
+What: Manual packaged-app verification checklist for the Issue 440 renderer crash containment fix.
+Why: T440-R1 must prove the fix in the packaged runtime, not only in dev-mode tests.
+-->
+
+# Issue 440 R1 Packaged Repro Checklist
+
+## Goal
+
+Prove that the first sealed Groq browser-VAD utterance no longer crashes the
+packaged renderer with `Illegal invocation`.
+
+## Setup
+
+- Build or install the packaged app from the `T440-R1` branch artifacts.
+- Select the Groq streaming provider path that uses browser VAD.
+- Open DevTools or collect renderer logs.
+
+## Steps
+
+1. Start recording.
+2. Speak one short phrase.
+3. Pause long enough for a natural `speech_pause` utterance to seal.
+4. Watch the renderer log stream through the first utterance handoff.
+
+## Expected
+
+- `streaming.groq_vad.start_begin` appears.
+- `streaming.groq_vad.start_complete` appears.
+- `streaming.groq_vad.utterance_ready` appears for `reason: "speech_pause"`.
+- No renderer `TypeError: Illegal invocation` is thrown.
+- No immediate fatal cleanup is triggered from the first utterance push.
+- No secondary uncaught renderer promise error appears during this exact step.
+
+## Not Covered by This Ticket
+
+- fatal-stop reason truthfulness
+- malformed/null IPC payload handling
+- WAV format contract correction
+- timestamp semantics

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -322,6 +322,99 @@ describe('startGroqBrowserVadCapture', () => {
     ])
   })
 
+  it('keeps working when the global timer host methods require the global receiver', async () => {
+    const originalSetTimeout = globalThis.setTimeout
+    const originalClearTimeout = globalThis.clearTimeout
+
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      value: function receiverSensitiveSetTimeout(
+        this: typeof globalThis,
+        handler: TimerHandler,
+        timeout?: number,
+        ...args: unknown[]
+      ): ReturnType<typeof setTimeout> {
+        if (this !== globalThis) {
+          throw new TypeError('Illegal invocation')
+        }
+        return originalSetTimeout(handler, timeout, ...args) as unknown as ReturnType<typeof setTimeout>
+      }
+    })
+    Object.defineProperty(globalThis, 'clearTimeout', {
+      configurable: true,
+      value: function receiverSensitiveClearTimeout(
+        this: typeof globalThis,
+        timeoutId?: ReturnType<typeof setTimeout>
+      ): void {
+        if (this !== globalThis) {
+          throw new TypeError('Illegal invocation')
+        }
+        originalClearTimeout(timeoutId)
+      }
+    })
+
+    try {
+      const { vad, sink } = await createCapture({
+        nowMs: () => 7_000
+      })
+
+      await vad.emitSpeechStart()
+      await vad.emitSpeechRealStart()
+      await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(16_000).fill(0.2))
+      await vad.emitSpeechEnd(new Float32Array(16_000).fill(0.2))
+
+      expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledOnce()
+    } finally {
+      Object.defineProperty(globalThis, 'setTimeout', {
+        configurable: true,
+        value: originalSetTimeout
+      })
+      Object.defineProperty(globalThis, 'clearTimeout', {
+        configurable: true,
+        value: originalClearTimeout
+      })
+    }
+  })
+
+  it('does not orphan an utterance push when timer setup throws before transport starts', async () => {
+    const sink = {
+      pushStreamingAudioUtteranceChunk: vi.fn(async () => {})
+    }
+    const timerError = new TypeError('Illegal invocation')
+    const onFatalError = vi.fn()
+    const capture = await startGroqBrowserVadCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      sink,
+      onFatalError,
+      nowMs: () => 8_000
+    }, {
+      createVad: FakeMicVad.create,
+      encodeWav: (audio) => audio.buffer.slice(0),
+      getUserMedia: vi.fn(async () => ({
+        getTracks: () => [{ stop: vi.fn() }]
+      }) as unknown as MediaStream)
+    })
+    const vad = FakeMicVad.instances[0]!
+    ;(capture as unknown as { setTimeoutFn: typeof setTimeout }).setTimeoutFn =
+      vi.fn((): never => {
+        throw timerError
+      }) as unknown as typeof setTimeout
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(4_000).fill(0.2))
+
+    await expect(vad.emitSpeechEnd(new Float32Array(4_000).fill(0.2))).resolves.toBeUndefined()
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await Promise.resolve()
+    }
+
+    expect(sink.pushStreamingAudioUtteranceChunk).not.toHaveBeenCalled()
+    expect(onFatalError).toHaveBeenCalledWith(timerError)
+    expect(vad.pause).toHaveBeenCalledOnce()
+    expect(vad.destroy).toHaveBeenCalledOnce()
+  })
+
   it('does not emit a stop utterance when speech never becomes valid', async () => {
     const { capture, vad, sink } = await createCapture()
 

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -75,6 +75,15 @@ const resolveMinSpeechSamples = (config: GroqBrowserVadConfig): number =>
 const resolveMaxUtteranceSamples = (config: GroqBrowserVadConfig): number =>
   Math.ceil((config.maxUtteranceMs / 1000) * STREAM_SAMPLE_RATE_HZ)
 
+const createBoundSetTimeout = (): typeof setTimeout =>
+  ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+    globalThis.setTimeout(handler, timeout, ...args)) as typeof setTimeout
+
+const createBoundClearTimeout = (): typeof clearTimeout =>
+  ((timeoutId?: ReturnType<typeof setTimeout>) => {
+    globalThis.clearTimeout(timeoutId)
+  }) as typeof clearTimeout
+
 class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private readonly nowMs: () => number
   private readonly sink: GroqBrowserVadSink
@@ -405,24 +414,29 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     const utteranceIndex = this.utteranceIndex
     this.utteranceIndex += 1
 
-    const pushPromise = this.sink.pushStreamingAudioUtteranceChunk({
+    const chunk = {
       sampleRateHz: STREAM_SAMPLE_RATE_HZ,
       channels: 1,
       utteranceIndex,
       wavBytes: this.encodeWav(audio),
-      wavFormat: 'wav_pcm_s16le_mono_16000',
+      wavFormat: 'wav_pcm_s16le_mono_16000' as const,
       startedAtMs,
       endedAtMs,
       hadCarryover,
       reason,
-      source: 'browser_vad'
-    })
-    this.activeUtterancePushPromise = pushPromise
-    let backpressureTimeout: ReturnType<typeof setTimeout> | null = this.setTimeoutFn(() => {
-      this.markBackpressureStarted()
-    }, this.config.backpressureSignalMs)
+      source: 'browser_vad' as const
+    }
+    let pushPromise: Promise<void> | null = null
+    let backpressureTimeout: ReturnType<typeof setTimeout> | null = null
 
     try {
+      // Start the timer before transport so a synchronous timer setup failure
+      // cannot orphan an already-started utterance push.
+      backpressureTimeout = this.setTimeoutFn(() => {
+        this.markBackpressureStarted()
+      }, this.config.backpressureSignalMs)
+      pushPromise = this.sink.pushStreamingAudioUtteranceChunk(chunk)
+      this.activeUtterancePushPromise = pushPromise
       await pushPromise
     } finally {
       this.activeUtterancePushPromise = null
@@ -548,6 +562,8 @@ export const startGroqBrowserVadCapture = async (
   const createVad = dependencies.createVad ?? (async (vadOptions) => await MicVAD.new(vadOptions))
   const encodeWav = dependencies.encodeWav ?? utils.encodeWAV
   const getUserMedia = dependencies.getUserMedia ?? navigator.mediaDevices?.getUserMedia?.bind(navigator.mediaDevices)
+  const setTimeoutFn = dependencies.setTimeoutFn ?? createBoundSetTimeout()
+  const clearTimeoutFn = dependencies.clearTimeoutFn ?? createBoundClearTimeout()
   if (!getUserMedia) {
     throw new Error('This environment does not support microphone recording.')
   }
@@ -559,8 +575,8 @@ export const startGroqBrowserVadCapture = async (
     nowMs: options.nowMs ?? (() => performance.now()),
     encodeWav,
     config,
-    setTimeoutFn: dependencies.setTimeoutFn ?? setTimeout,
-    clearTimeoutFn: dependencies.clearTimeoutFn ?? clearTimeout
+    setTimeoutFn,
+    clearTimeoutFn
   })
   capture.setDeviceConstraints(options.deviceConstraints)
 
@@ -569,8 +585,8 @@ export const startGroqBrowserVadCapture = async (
   let startupClosed = false
   const startupTimeout = createStartupTimeout(
     config.startupTimeoutMs,
-    dependencies.setTimeoutFn ?? setTimeout,
-    dependencies.clearTimeoutFn ?? clearTimeout,
+    setTimeoutFn,
+    clearTimeoutFn,
     () => {
       startupExpired = true
     }


### PR DESCRIPTION
## Summary
- wrap default Groq browser-VAD timer usage so packaged renderer code no longer calls detached global timer host methods
- start the backpressure timer before utterance transport begins so sync timer setup failures cannot orphan an in-flight push
- add focused regression tests plus a decision note and packaged repro checklist for T440-R1

## Testing
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/renderer/native-recording.test.ts src/renderer/streaming-live-capture.test.ts
- pnpm typecheck
- git diff --cached --check

## Review
- sub-agent review: clean, no findings
- Claude CLI review: attempted, but the CLI did not return usable output in this environment before timeout