### PR TITLE
fix: preserve fatal streaming stop semantics

### DIFF
--- a/docs/decisions/2026-03-10-streaming-fatal-stop-semantics-decision.md
+++ b/docs/decisions/2026-03-10-streaming-fatal-stop-semantics-decision.md
@@ -1,0 +1,46 @@
+<!--
+Where: docs/decisions/2026-03-10-streaming-fatal-stop-semantics-decision.md
+What: Stop-reason contract for renderer/main streaming fatal cleanup.
+Why: T440-R2 changes observable stop reasons and needs an explicit compatibility record.
+-->
+
+# Decision: Keep Fatal Streaming Cleanup Distinct From User Cancel
+
+Date: 2026-03-10
+
+## Context
+
+The Groq browser-VAD renderer was reporting internal transport failures as
+`user_cancel` because fatal cleanup called `cancel()`. The renderer also treated
+terminal session updates with `state: failed` the same way as explicit
+`user_cancel`, which hid the difference between user intent and internal
+failure.
+
+## Decision
+
+Use this stop-reason contract:
+
+| Origin | Renderer stop reason | Main/session reason |
+|---|---|---|
+| User presses cancel | `user_cancel` | `user_cancel` |
+| User presses stop | `user_stop` | `user_stop` |
+| Renderer capture/transport fails | `fatal_error` | `fatal_error` |
+| Main/provider fails after a valid renderer send | `fatal_error` | `fatal_error` |
+
+Implementation consequences for this ticket:
+
+- Groq renderer fatal cleanup calls `stop('fatal_error')`, not `cancel()`
+- renderer handling of terminal session snapshots calls `stop('fatal_error')`
+  for failed/fatal sessions
+- explicit `user_cancel` handling remains on the `cancel()` path
+
+## Why
+
+This preserves the existing user-cancel behavior while making logs and session
+reasons truthful enough to debug transport failures.
+
+## Deferred
+
+This ticket does not change the main-process stop state machine beyond staying
+compatible with the fatal reason. Payload validation and later transport
+hardening remain in follow-up tickets.

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -8,6 +8,7 @@ Why: Lock down startup, natural utterance emission, stop flush, cancel cleanup, 
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as errorLogging from '../shared/error-logging'
 import {
   type GroqBrowserVadCapture,
   startGroqBrowserVadCapture
@@ -452,6 +453,7 @@ describe('startGroqBrowserVadCapture', () => {
   })
 
   it('routes sink failures into fatal cleanup once', async () => {
+    const logStructuredSpy = vi.spyOn(errorLogging, 'logStructured')
     const onFatalError = vi.fn()
     const sink = {
       pushStreamingAudioUtteranceChunk: vi.fn(async () => {
@@ -483,6 +485,10 @@ describe('startGroqBrowserVadCapture', () => {
     expect(onFatalError).toHaveBeenCalledWith(expect.objectContaining({ message: 'utterance push failed' }))
     expect(vad.pause).toHaveBeenCalledOnce()
     expect(vad.destroy).toHaveBeenCalledOnce()
+    expect(logStructuredSpy).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_vad.stop_begin',
+      context: expect.objectContaining({ reason: 'fatal_error' })
+    }))
     expect(capture).toBeDefined()
   })
 

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -517,7 +517,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       return
     }
     this.fatalNotified = true
-    void this.cancel().finally(() => {
+    void this.stop('fatal_error').finally(() => {
       this.onFatalError(error)
     })
   }

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -566,6 +566,91 @@ describe('handleRecordingCommandDispatch', () => {
     expect(state.hasCommandError).toBe(true)
   })
 
+  it('stops Groq browser-VAD capture with fatal_error when the main session fails', async () => {
+    const stop = vi.fn(async () => {})
+    const cancel = vi.fn(async () => {})
+    startGroqBrowserVadCaptureMock.mockResolvedValueOnce({
+      stop,
+      cancel
+    })
+
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'groq_whisper_large_v3_turbo'
+    state.settings.processing.streaming.transport = 'rolling_upload'
+    state.settings.processing.streaming.model = 'whisper-large-v3-turbo'
+    state.streamingSessionState = {
+      sessionId: 'session-groq-fatal',
+      state: 'active',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-groq-fatal',
+      preferredDeviceId: 'mic-1'
+    })
+    await handleStreamingSessionStateUpdate(deps, {
+      sessionId: 'session-groq-fatal',
+      state: 'failed',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: 'fatal_error'
+    })
+
+    expect(stop).toHaveBeenCalledWith('fatal_error')
+    expect(cancel).not.toHaveBeenCalled()
+    expect(state.hasCommandError).toBe(true)
+  })
+
+  it('still cancels Groq browser-VAD capture for explicit user_cancel terminal states', async () => {
+    const stop = vi.fn(async () => {})
+    const cancel = vi.fn(async () => {})
+    startGroqBrowserVadCaptureMock.mockResolvedValueOnce({
+      stop,
+      cancel
+    })
+
+    const { deps, state } = createDeps()
+    state.settings = structuredClone(DEFAULT_SETTINGS)
+    state.settings.processing.mode = 'streaming'
+    state.settings.processing.streaming.enabled = true
+    state.settings.processing.streaming.provider = 'groq_whisper_large_v3_turbo'
+    state.settings.processing.streaming.transport = 'rolling_upload'
+    state.settings.processing.streaming.model = 'whisper-large-v3-turbo'
+    state.streamingSessionState = {
+      sessionId: 'session-groq-cancel',
+      state: 'active',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: null
+    }
+
+    await handleRecordingCommandDispatch(deps, {
+      kind: 'streaming_start',
+      sessionId: 'session-groq-cancel',
+      preferredDeviceId: 'mic-1'
+    })
+    await handleStreamingSessionStateUpdate(deps, {
+      sessionId: 'session-groq-cancel',
+      state: 'ended',
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      reason: 'user_cancel'
+    })
+
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(stop).not.toHaveBeenCalled()
+  })
+
   it('ignores terminal session updates for a stale session while a newer capture is active', async () => {
     const { deps, state } = createDeps()
     state.settings = structuredClone(DEFAULT_SETTINGS)

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -601,7 +601,9 @@ export const handleStreamingSessionStateUpdate = async (
   const streamingCapture = recorderState.streamingCapture
   cleanupRecorderResources()
 
-  if (snapshot.state === 'failed' || snapshot.reason === 'fatal_error' || snapshot.reason === 'user_cancel') {
+  if (snapshot.state === 'failed' || snapshot.reason === 'fatal_error') {
+    await streamingCapture.stop('fatal_error')
+  } else if (snapshot.reason === 'user_cancel') {
     await streamingCapture.cancel()
   } else {
     await streamingCapture.stop(snapshot.reason ?? 'user_stop')


### PR DESCRIPTION
## Summary
- route Groq renderer-local fatal cleanup through `fatal_error` instead of `user_cancel`
- preserve `fatal_error` on renderer handling of terminal streaming session snapshots while keeping explicit `user_cancel` on the cancel path
- add focused tests and a decision note for the stop-reason contract in T440-R2

## Testing
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/renderer/native-recording.test.ts src/renderer/streaming-live-capture.test.ts src/main/ipc/register-handlers.test.ts src/main/services/streaming/streaming-session-controller.test.ts
- pnpm typecheck
- git diff --cached --check

## Review
- sub-agent review: clean, no findings
- Claude CLI review: attempted, but quota-blocked in this environment