### PR TITLE
fix: validate streaming utterance IPC payloads

### DIFF
--- a/docs/decisions/2026-03-10-streaming-utterance-ipc-validation-decision.md
+++ b/docs/decisions/2026-03-10-streaming-utterance-ipc-validation-decision.md
@@ -1,0 +1,45 @@
+<!--
+Where: docs/decisions/2026-03-10-streaming-utterance-ipc-validation-decision.md
+What: Decision note for validating Groq utterance payloads at the main IPC boundary.
+Why: T440-R3 adds runtime guards for malformed renderer->main utterance messages.
+-->
+
+# Decision: Validate Streaming Utterance Payloads at Main IPC Ingress
+
+Date: 2026-03-10
+
+## Context
+
+Issue 440 still had a secondary crash shape where main could dereference
+`chunk.sessionId` on a null or malformed Groq utterance payload. TypeScript
+types were not enough because the MessagePort payload arrives at runtime as
+`unknown`.
+
+## Decision
+
+Validate the minimum `StreamingAudioUtteranceChunk` shape in main before owner
+lookup or session-state checks.
+
+The ingress guard now checks:
+
+- object/non-null payload
+- `sessionId`
+- `sampleRateHz`
+- `channels`
+- `utteranceIndex`
+- `wavBytes`
+- `wavFormat`
+- `startedAtMs` / `endedAtMs`
+- `hadCarryover`
+- `reason`
+- `source`
+
+## Why
+
+This keeps malformed payloads contained at the IPC boundary and turns them into
+structured transport errors instead of opaque null dereferences.
+
+## Trade-off
+
+The guard intentionally stays local to main IPC ingress instead of introducing a
+new shared runtime-schema dependency in this ticket.

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -305,6 +305,89 @@ describe('registerIpcHandlers', () => {
     }))
   })
 
+  it('rejects null and malformed utterance chunk payloads before owner lookup', async () => {
+    const pushAudioUtteranceChunk = vi.fn(async () => {})
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi.fn().mockResolvedValue({
+        kind: 'streaming_start',
+        sessionId: 'session-utterance-invalid',
+        preferredDeviceId: 'mic-1'
+      }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession: vi.fn()
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: {
+        onSessionState: vi.fn(),
+        onSegment: vi.fn(),
+        onError: vi.fn(),
+        pushAudioFrameBatch: vi.fn(),
+        pushAudioUtteranceChunk
+      } as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    await getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
+    const utteranceHandler = getRegisteredOn(IPC_CHANNELS.pushStreamingAudioUtteranceChunk)
+    expect(utteranceHandler).toBeTypeOf('function')
+
+    const nullPayloadPort = createFakeMessagePort()
+    await utteranceHandler?.({ sender: mocks.windows[0]?.webContents, ports: [nullPayloadPort] }, undefined)
+    await nullPayloadPort.emitMessage(null)
+
+    expect(nullPayloadPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      message: expect.stringContaining('expected an object')
+    }))
+
+    const malformedPayloadPort = createFakeMessagePort()
+    await utteranceHandler?.({ sender: mocks.windows[0]?.webContents, ports: [malformedPayloadPort] }, undefined)
+    await malformedPayloadPort.emitMessage({
+      sessionId: 'session-utterance-invalid',
+      sampleRateHz: 16_000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtMs: 50,
+      endedAtMs: 10,
+      hadCarryover: false,
+      reason: 'speech_pause',
+      source: 'browser_vad'
+    })
+
+    expect(malformedPayloadPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      message: expect.stringContaining('endedAtMs must not precede startedAtMs')
+    }))
+    expect(pushAudioUtteranceChunk).not.toHaveBeenCalled()
+  })
+
   it('logs and returns when recording command dispatch finds no renderer windows', async () => {
     mocks.getAllWindows.mockReturnValueOnce([])
     const commandRouter = {

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -213,6 +213,52 @@ const assertStreamingAudioUtteranceChunkAllowed = (
   }
 }
 
+const validateStreamingAudioUtteranceChunkPayload = (payload: unknown): StreamingAudioUtteranceChunk => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid streaming audio utterance chunk payload: expected an object.')
+  }
+
+  const chunk = payload as Partial<StreamingAudioUtteranceChunk>
+  if (typeof chunk.sessionId !== 'string' || chunk.sessionId.trim().length === 0) {
+    throw new Error('Invalid streaming audio utterance chunk payload: sessionId must be a non-empty string.')
+  }
+  if (typeof chunk.sampleRateHz !== 'number' || !Number.isFinite(chunk.sampleRateHz) || chunk.sampleRateHz <= 0) {
+    throw new Error('Invalid streaming audio utterance chunk payload: sampleRateHz must be a positive number.')
+  }
+  if (typeof chunk.channels !== 'number' || !Number.isFinite(chunk.channels) || chunk.channels <= 0) {
+    throw new Error('Invalid streaming audio utterance chunk payload: channels must be a positive number.')
+  }
+  if (!Number.isInteger(chunk.utteranceIndex) || (chunk.utteranceIndex ?? -1) < 0) {
+    throw new Error('Invalid streaming audio utterance chunk payload: utteranceIndex must be a non-negative integer.')
+  }
+  if (!(chunk.wavBytes instanceof ArrayBuffer)) {
+    throw new Error('Invalid streaming audio utterance chunk payload: wavBytes must be an ArrayBuffer.')
+  }
+  if (chunk.wavFormat !== 'wav_pcm_s16le_mono_16000') {
+    throw new Error('Invalid streaming audio utterance chunk payload: wavFormat is unsupported.')
+  }
+  if (typeof chunk.startedAtMs !== 'number' || !Number.isFinite(chunk.startedAtMs)) {
+    throw new Error('Invalid streaming audio utterance chunk payload: startedAtMs must be a finite number.')
+  }
+  if (typeof chunk.endedAtMs !== 'number' || !Number.isFinite(chunk.endedAtMs)) {
+    throw new Error('Invalid streaming audio utterance chunk payload: endedAtMs must be a finite number.')
+  }
+  if (chunk.endedAtMs < chunk.startedAtMs) {
+    throw new Error('Invalid streaming audio utterance chunk payload: endedAtMs must not precede startedAtMs.')
+  }
+  if (typeof chunk.hadCarryover !== 'boolean') {
+    throw new Error('Invalid streaming audio utterance chunk payload: hadCarryover must be a boolean.')
+  }
+  if (chunk.reason !== 'speech_pause' && chunk.reason !== 'max_chunk' && chunk.reason !== 'session_stop') {
+    throw new Error('Invalid streaming audio utterance chunk payload: reason is unsupported.')
+  }
+  if (chunk.source !== 'browser_vad') {
+    throw new Error('Invalid streaming audio utterance chunk payload: source is unsupported.')
+  }
+
+  return chunk as StreamingAudioUtteranceChunk
+}
+
 const initializeServices = (): MainServices => {
   if (services) {
     return services
@@ -688,7 +734,7 @@ const bindIpcHandlers = (svc: MainServices): void => {
 
     replyPort.on('message', async (messageEvent) => {
       try {
-        const chunk = messageEvent.data as StreamingAudioUtteranceChunk
+        const chunk = validateStreamingAudioUtteranceChunkPayload(messageEvent.data)
         assertStreamingAudioUtteranceChunkAllowed(chunk, senderWindowId)
         await svc.streamingSessionController.pushAudioUtteranceChunk(chunk)
         replyPort.postMessage({ ok: true })


### PR DESCRIPTION
## Summary
- validate streaming utterance payloads in main before owner/session lookup
- reject null and malformed MessagePort payloads with structured transport errors instead of null dereferences
- add focused ingress tests and a decision note for the IPC validation contract

## Testing
- pnpm vitest run src/main/ipc/register-handlers.test.ts src/preload/index.test.ts src/main/services/streaming/streaming-session-controller.test.ts
- pnpm typecheck
- git diff --cached --check

## Review
- sub-agent review: requested; no result returned before PR creation in this environment
- Claude CLI review: attempted, but quota-blocked in this environment