### PR TITLE
fix: enforce groq pcm16 wav payloads

### DIFF
--- a/docs/decisions/2026-03-10-groq-pcm16-wav-contract-decision.md
+++ b/docs/decisions/2026-03-10-groq-pcm16-wav-contract-decision.md
@@ -1,0 +1,35 @@
+<!--
+Where: docs/decisions/2026-03-10-groq-pcm16-wav-contract-decision.md
+What: Decision note for the Groq utterance WAV payload contract.
+Why: T440-R4 makes the WAV bytes match the existing PCM16 contract label.
+-->
+
+# Decision: Enforce PCM16 WAV for Groq Utterance Payloads
+
+Date: 2026-03-10
+
+## Context
+
+The Groq utterance contract already claimed `wav_pcm_s16le_mono_16000`, but the
+upstream `@ricky0123/vad-web` default `encodeWAV(samples)` implementation emits
+float32 WAV unless `format = 1` and `bitDepth = 16` are passed explicitly.
+
+## Decision
+
+Keep the existing public contract label and make it true:
+
+- renderer encodes WAV with `format = 1`, `sampleRate = 16000`,
+  `numChannels = 1`, `bitDepth = 16`
+- main validates the WAV header so byte content cannot silently drift away from
+  the declared label
+
+## Why
+
+This is smaller and safer than relabeling the payload format because the rest of
+the Groq path already expects mono PCM16 at 16 kHz.
+
+## Trade-off
+
+Header validation is intentionally strict. If new WAV variants are introduced in
+the future, this validator must be updated in lockstep with the shared payload
+type.

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -23,6 +23,35 @@ const LOCAL_CONFIG = {
   transformationProfile: null
 }
 
+const createPcm16WavBytes = (samples: Int16Array = new Int16Array([0, 1024])): Uint8Array => {
+  const bytesPerSample = 2
+  const buffer = new ArrayBuffer(44 + samples.length * bytesPerSample)
+  const view = new DataView(buffer)
+  const writeString = (offset: number, value: string): void => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + samples.length * bytesPerSample, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, 16_000, true)
+  view.setUint32(28, 16_000 * bytesPerSample, true)
+  view.setUint16(32, bytesPerSample, true)
+  view.setUint16(34, 16, true)
+  writeString(36, 'data')
+  view.setUint32(40, samples.length * bytesPerSample, true)
+  samples.forEach((sample, index) => {
+    view.setInt16(44 + index * bytesPerSample, sample, true)
+  })
+  return new Uint8Array(buffer)
+}
+
 const makeUtterance = (params: {
   utteranceIndex: number
   startMs: number
@@ -35,7 +64,7 @@ const makeUtterance = (params: {
   sampleRateHz: 16000,
   channels: 1,
   utteranceIndex: params.utteranceIndex,
-  wavBytes: new Uint8Array(params.wavBytes ?? [82, 73, 70, 70]).buffer,
+  wavBytes: new Uint8Array(params.wavBytes ?? createPcm16WavBytes()).buffer,
   wavFormat: 'wav_pcm_s16le_mono_16000' as const,
   startedAtMs: params.startMs,
   endedAtMs: params.endMs,
@@ -342,6 +371,32 @@ describe('GroqRollingUploadAdapter', () => {
         reason: 'speech_pause'
       }))
     ).rejects.toThrow('expected utteranceIndex=0')
+  })
+
+  it('rejects utterances whose WAV bytes do not match the PCM16 label', async () => {
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn()
+    })
+
+    await adapter.start()
+
+    await expect(
+      adapter.pushAudioUtteranceChunk(makeUtterance({
+        utteranceIndex: 0,
+        startMs: 0,
+        endMs: 500,
+        reason: 'speech_pause',
+        wavBytes: [82, 73, 70, 70]
+      }))
+    ).rejects.toThrow('complete WAV header')
   })
 
   it('retries one transient Groq failure without duplicating committed text', async () => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -68,6 +68,33 @@ interface CompletedUtteranceUpload {
 const GROQ_DEFAULT_BASE = 'https://api.groq.com'
 const GROQ_STT_PATH = '/openai/v1/audio/transcriptions'
 const GROQ_USER_STOP_BUDGET_MS = 3_000
+const PCM16_WAV_HEADER_SIZE_BYTES = 44
+
+const assertPcm16Mono16000WavBytes = (wavBytes: ArrayBuffer): void => {
+  if (wavBytes.byteLength < PCM16_WAV_HEADER_SIZE_BYTES) {
+    throw new Error('Groq rolling upload requires a complete WAV header.')
+  }
+
+  const view = new DataView(wavBytes)
+  const readAscii = (offset: number, length: number): string =>
+    String.fromCharCode(...Array.from({ length }, (_value, index) => view.getUint8(offset + index)))
+
+  if (readAscii(0, 4) !== 'RIFF' || readAscii(8, 4) !== 'WAVE' || readAscii(12, 4) !== 'fmt ') {
+    throw new Error('Groq rolling upload requires RIFF/WAVE utterances.')
+  }
+  if (view.getUint16(20, true) !== 1) {
+    throw new Error('Groq rolling upload requires PCM WAV encoding.')
+  }
+  if (view.getUint16(22, true) !== 1) {
+    throw new Error('Groq rolling upload currently requires mono WAV utterances.')
+  }
+  if (view.getUint32(24, true) !== 16_000) {
+    throw new Error('Groq rolling upload requires 16 kHz WAV utterances.')
+  }
+  if (view.getUint16(34, true) !== 16) {
+    throw new Error('Groq rolling upload requires 16-bit PCM WAV utterances.')
+  }
+}
 
 export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private readonly secretStore: Pick<SecretStore, 'getApiKey'>
@@ -173,6 +200,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     if (chunk.wavFormat !== 'wav_pcm_s16le_mono_16000') {
       throw new Error(`Groq rolling upload requires wav_pcm_s16le_mono_16000 utterances. Received ${chunk.wavFormat}.`)
     }
+    assertPcm16Mono16000WavBytes(chunk.wavBytes)
     if (chunk.utteranceIndex !== this.nextExpectedUtteranceIndex) {
       throw new Error(`Groq rolling upload expected utteranceIndex=${this.nextExpectedUtteranceIndex}, received ${chunk.utteranceIndex}.`)
     }

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -166,6 +166,43 @@ describe('startGroqBrowserVadCapture', () => {
     }))
   })
 
+  it('uses PCM16 mono 16 kHz WAV bytes by default', async () => {
+    const sink = {
+      pushStreamingAudioUtteranceChunk: vi.fn(async (chunk: { wavBytes: ArrayBuffer }) => {
+        void chunk
+      })
+    }
+    await startGroqBrowserVadCapture({
+      deviceConstraints: { channelCount: { ideal: 1 } },
+      sink,
+      onFatalError: vi.fn(),
+      nowMs: () => 7_000
+    }, {
+      createVad: FakeMicVad.create,
+      getUserMedia: vi.fn(async () => ({
+        getTracks: () => [{ stop: vi.fn() }]
+      }) as unknown as MediaStream)
+    })
+    const vad = FakeMicVad.instances[0]!
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(1_600).fill(0.2))
+    await vad.emitSpeechEnd(new Float32Array(1_600).fill(0.2))
+
+    const chunk = sink.pushStreamingAudioUtteranceChunk.mock.calls[0]?.[0]
+    if (!chunk) {
+      throw new Error('Expected a Groq utterance chunk to be emitted.')
+    }
+    const wavView = new DataView(chunk.wavBytes)
+    expect(String.fromCharCode(wavView.getUint8(0), wavView.getUint8(1), wavView.getUint8(2), wavView.getUint8(3))).toBe('RIFF')
+    expect(String.fromCharCode(wavView.getUint8(8), wavView.getUint8(9), wavView.getUint8(10), wavView.getUint8(11))).toBe('WAVE')
+    expect(wavView.getUint16(20, true)).toBe(1)
+    expect(wavView.getUint16(22, true)).toBe(1)
+    expect(wavView.getUint32(24, true)).toBe(16_000)
+    expect(wavView.getUint16(34, true)).toBe(16)
+  })
+
   it('flushes one stop utterance from buffered live frames when confirmed speech exists', async () => {
     const encodeWav = vi.fn((audio: Float32Array) => audio.buffer.slice(0))
     const { capture, vad, sink } = await createCapture({

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -75,6 +75,9 @@ const resolveMinSpeechSamples = (config: GroqBrowserVadConfig): number =>
 const resolveMaxUtteranceSamples = (config: GroqBrowserVadConfig): number =>
   Math.ceil((config.maxUtteranceMs / 1000) * STREAM_SAMPLE_RATE_HZ)
 
+const encodePcm16Mono16000Wav = (audio: Float32Array): ArrayBuffer =>
+  utils.encodeWAV(audio, 1, STREAM_SAMPLE_RATE_HZ, 1, 16)
+
 const createBoundSetTimeout = (): typeof setTimeout =>
   ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
     globalThis.setTimeout(handler, timeout, ...args)) as typeof setTimeout
@@ -560,7 +563,7 @@ export const startGroqBrowserVadCapture = async (
     ...options.config
   }
   const createVad = dependencies.createVad ?? (async (vadOptions) => await MicVAD.new(vadOptions))
-  const encodeWav = dependencies.encodeWav ?? utils.encodeWAV
+  const encodeWav = dependencies.encodeWav ?? encodePcm16Mono16000Wav
   const getUserMedia = dependencies.getUserMedia ?? navigator.mediaDevices?.getUserMedia?.bind(navigator.mediaDevices)
   const setTimeoutFn = dependencies.setTimeoutFn ?? createBoundSetTimeout()
   const clearTimeoutFn = dependencies.clearTimeoutFn ?? createBoundClearTimeout()


### PR DESCRIPTION
## Summary
- encode Groq browser-VAD utterances as explicit PCM16 mono 16 kHz WAV by default
- validate the WAV header in the Groq upload adapter so the byte payload matches the IPC label
- add renderer and main tests that inspect the real WAV contract and document the decision

## Verification
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm typecheck
- git diff --check
- git diff --cached --check

## Review
- Sub-agent review: clean, no findings
- Claude CLI review: attempted but quota-blocked in this environment (`You're out of extra usage`)
