### PR TITLE
fix: correct groq utterance time semantics

### DIFF
--- a/docs/decisions/2026-03-10-groq-timing-contract-decision.md
+++ b/docs/decisions/2026-03-10-groq-timing-contract-decision.md
@@ -1,0 +1,42 @@
+<!--
+Where: docs/decisions/2026-03-10-groq-timing-contract-decision.md
+What: Decision record for Groq utterance timing semantics.
+Why: Freeze the split between renderer-local monotonic timing and epoch timing
+     so Groq segments stop converting monotonic counters into ISO timestamps.
+-->
+
+# Decision: Groq utterance timing uses explicit epoch fields across IPC
+
+## Status
+
+Accepted on 2026-03-10.
+
+## Context
+
+The Groq browser-VAD renderer path originally emitted `startedAtMs` and
+`endedAtMs` values derived from `performance.now()`. Main then treated those
+numbers as wall-clock timestamps and converted them with:
+
+```ts
+new Date(monotonicMs).toISOString()
+```
+
+That produced formally valid ISO strings with the wrong meaning, typically
+landing near 1970 during tests and in misleading dates during live runs.
+
+## Decision
+
+- Renderer-internal lifecycle math may keep using monotonic clocks where needed.
+- The renderer-to-main utterance IPC contract now carries only explicit epoch
+  timing for utterance boundaries:
+  - `startedAtEpochMs`
+  - `endedAtEpochMs`
+- Main emits final Groq segment ISO timestamps only from those epoch fields.
+
+## Consequences
+
+- Groq segment metadata is now truthful wall-clock time instead of a monotonic
+  counter mislabelled as wall clock.
+- The contract is more explicit and less error-prone at the IPC boundary.
+- Tests must provide epoch millisecond fields on Groq utterance fixtures.
+- This does not change `whisper.cpp` segment timestamp handling.

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -270,8 +270,8 @@ describe('registerIpcHandlers', () => {
       utteranceIndex: 0,
       wavBytes: new ArrayBuffer(4),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 0,
-      endedAtMs: 500,
+      startedAtEpochMs: 0,
+      endedAtEpochMs: 500,
       hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
@@ -292,8 +292,8 @@ describe('registerIpcHandlers', () => {
       utteranceIndex: 1,
       wavBytes: new ArrayBuffer(4),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 600,
-      endedAtMs: 900,
+      startedAtEpochMs: 600,
+      endedAtEpochMs: 900,
       hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
@@ -374,8 +374,8 @@ describe('registerIpcHandlers', () => {
       utteranceIndex: 0,
       wavBytes: new ArrayBuffer(4),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 50,
-      endedAtMs: 10,
+      startedAtEpochMs: 50,
+      endedAtEpochMs: 10,
       hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
@@ -383,7 +383,7 @@ describe('registerIpcHandlers', () => {
 
     expect(malformedPayloadPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
       ok: false,
-      message: expect.stringContaining('endedAtMs must not precede startedAtMs')
+      message: expect.stringContaining('endedAtEpochMs must not precede startedAtEpochMs')
     }))
     expect(pushAudioUtteranceChunk).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -237,14 +237,14 @@ const validateStreamingAudioUtteranceChunkPayload = (payload: unknown): Streamin
   if (chunk.wavFormat !== 'wav_pcm_s16le_mono_16000') {
     throw new Error('Invalid streaming audio utterance chunk payload: wavFormat is unsupported.')
   }
-  if (typeof chunk.startedAtMs !== 'number' || !Number.isFinite(chunk.startedAtMs)) {
-    throw new Error('Invalid streaming audio utterance chunk payload: startedAtMs must be a finite number.')
+  if (typeof chunk.startedAtEpochMs !== 'number' || !Number.isFinite(chunk.startedAtEpochMs)) {
+    throw new Error('Invalid streaming audio utterance chunk payload: startedAtEpochMs must be a finite number.')
   }
-  if (typeof chunk.endedAtMs !== 'number' || !Number.isFinite(chunk.endedAtMs)) {
-    throw new Error('Invalid streaming audio utterance chunk payload: endedAtMs must be a finite number.')
+  if (typeof chunk.endedAtEpochMs !== 'number' || !Number.isFinite(chunk.endedAtEpochMs)) {
+    throw new Error('Invalid streaming audio utterance chunk payload: endedAtEpochMs must be a finite number.')
   }
-  if (chunk.endedAtMs < chunk.startedAtMs) {
-    throw new Error('Invalid streaming audio utterance chunk payload: endedAtMs must not precede startedAtMs.')
+  if (chunk.endedAtEpochMs < chunk.startedAtEpochMs) {
+    throw new Error('Invalid streaming audio utterance chunk payload: endedAtEpochMs must not precede startedAtEpochMs.')
   }
   if (typeof chunk.hadCarryover !== 'boolean') {
     throw new Error('Invalid streaming audio utterance chunk payload: hadCarryover must be a boolean.')

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -66,8 +66,8 @@ const makeUtterance = (params: {
   utteranceIndex: params.utteranceIndex,
   wavBytes: new Uint8Array(params.wavBytes ?? createPcm16WavBytes()).buffer,
   wavFormat: 'wav_pcm_s16le_mono_16000' as const,
-  startedAtMs: params.startMs,
-  endedAtMs: params.endMs,
+  startedAtEpochMs: params.startMs,
+  endedAtEpochMs: params.endMs,
   hadCarryover: params.hadCarryover ?? false,
   reason: params.reason,
   source: 'browser_vad' as const

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -53,15 +53,15 @@ interface PendingUtteranceUpload {
   utteranceIndex: number
   body: Blob
   hadCarryover: boolean
-  startedAtMs: number
-  endedAtMs: number
+  startedAtEpochMs: number
+  endedAtEpochMs: number
 }
 
 interface CompletedUtteranceUpload {
   utteranceIndex: number
   hadCarryover: boolean
-  startedAtMs: number
-  endedAtMs: number
+  startedAtEpochMs: number
+  endedAtEpochMs: number
   response: GroqVerboseResponse
 }
 
@@ -114,7 +114,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private stopUploadTimedOut = false
   private stopped = false
   private rendererStopPrepared = false
-  private lastCommittedEndedAtMs = Number.NEGATIVE_INFINITY
+  private lastCommittedEndedAtEpochMs = Number.NEGATIVE_INFINITY
   private lastCommittedTextTail = ''
 
   constructor(
@@ -211,8 +211,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       utteranceIndex: chunk.utteranceIndex,
       body: new Blob([Buffer.from(chunk.wavBytes)], { type: 'audio/wav' }),
       hadCarryover: chunk.hadCarryover,
-      startedAtMs: chunk.startedAtMs,
-      endedAtMs: chunk.endedAtMs
+      startedAtEpochMs: chunk.startedAtEpochMs,
+      endedAtEpochMs: chunk.endedAtEpochMs
     })
     this.ensureQueuePump()
   }
@@ -268,8 +268,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
         this.completedUtterances.push({
           utteranceIndex: utterance.utteranceIndex,
           hadCarryover: utterance.hadCarryover,
-          startedAtMs: utterance.startedAtMs,
-          endedAtMs: utterance.endedAtMs,
+          startedAtEpochMs: utterance.startedAtEpochMs,
+          endedAtEpochMs: utterance.endedAtEpochMs,
           response
         })
         this.ensureEmitPump()
@@ -389,14 +389,14 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
           continue
         }
 
-        const absoluteStartedAtMs = utterance.startedAtMs + Math.round(segment.start * 1000)
-        const absoluteEndedAtMs = utterance.startedAtMs + Math.round(segment.end * 1000)
-        if (absoluteEndedAtMs <= this.lastCommittedEndedAtMs) {
+        const absoluteStartedAtEpochMs = utterance.startedAtEpochMs + Math.round(segment.start * 1000)
+        const absoluteEndedAtEpochMs = utterance.startedAtEpochMs + Math.round(segment.end * 1000)
+        if (absoluteEndedAtEpochMs <= this.lastCommittedEndedAtEpochMs) {
           continue
         }
 
         let text = segment.text.trim()
-        if (absoluteStartedAtMs < this.lastCommittedEndedAtMs || utterance.hadCarryover) {
+        if (absoluteStartedAtEpochMs < this.lastCommittedEndedAtEpochMs || utterance.hadCarryover) {
           text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
         }
         if (text.length === 0) {
@@ -405,10 +405,10 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
         await this.emitFinalSegment({
           text,
-          startedAtMs: absoluteStartedAtMs,
-          endedAtMs: absoluteEndedAtMs
+          startedAtEpochMs: absoluteStartedAtEpochMs,
+          endedAtEpochMs: absoluteEndedAtEpochMs
         })
-        this.rememberCommittedText(text, absoluteEndedAtMs)
+        this.rememberCommittedText(text, absoluteEndedAtEpochMs)
       }
       return
     }
@@ -423,16 +423,16 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
     await this.emitFinalSegment({
       text,
-      startedAtMs: utterance.startedAtMs,
-      endedAtMs: utterance.endedAtMs
+      startedAtEpochMs: utterance.startedAtEpochMs,
+      endedAtEpochMs: utterance.endedAtEpochMs
     })
-    this.rememberCommittedText(text, utterance.endedAtMs)
+    this.rememberCommittedText(text, utterance.endedAtEpochMs)
   }
 
   private async emitFinalSegment(params: {
     text: string
-    startedAtMs: number
-    endedAtMs: number
+    startedAtEpochMs: number
+    endedAtEpochMs: number
   }): Promise<void> {
     const sequence = this.nextSequence
     this.nextSequence += 1
@@ -440,8 +440,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       sessionId: this.params.sessionId,
       sequence,
       text: params.text,
-      startedAt: new Date(params.startedAtMs).toISOString(),
-      endedAt: new Date(params.endedAtMs).toISOString()
+      startedAt: new Date(params.startedAtEpochMs).toISOString(),
+      endedAt: new Date(params.endedAtEpochMs).toISOString()
     }
     const outcome = await Promise.race([
       Promise.resolve(this.params.callbacks.onFinalSegment(segment)).then(() => 'completed' as const),
@@ -452,8 +452,8 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     }
   }
 
-  private rememberCommittedText(text: string, endedAtMs: number): void {
-    this.lastCommittedEndedAtMs = Math.max(this.lastCommittedEndedAtMs, endedAtMs)
+  private rememberCommittedText(text: string, endedAtEpochMs: number): void {
+    this.lastCommittedEndedAtEpochMs = Math.max(this.lastCommittedEndedAtEpochMs, endedAtEpochMs)
     const nextTail = `${this.lastCommittedTextTail} ${text}`.trim()
     this.lastCommittedTextTail = nextTail.slice(-160)
   }

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -286,8 +286,8 @@ describe('InMemoryStreamingSessionController', () => {
         utteranceIndex: 0,
         wavBytes: new ArrayBuffer(4),
         wavFormat: 'wav_pcm_s16le_mono_16000',
-        startedAtMs: 0,
-        endedAtMs: 100,
+        startedAtEpochMs: 0,
+        endedAtEpochMs: 100,
         hadCarryover: false,
         reason: 'speech_pause',
         source: 'browser_vad'
@@ -320,8 +320,8 @@ describe('InMemoryStreamingSessionController', () => {
       utteranceIndex: 0,
       wavBytes: new ArrayBuffer(4),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 0,
-      endedAtMs: 100,
+      startedAtEpochMs: 0,
+      endedAtEpochMs: 100,
       hadCarryover: true,
       reason: 'max_chunk',
       source: 'browser_vad'

--- a/src/main/test-support/streaming-groq-stop-budget.test.ts
+++ b/src/main/test-support/streaming-groq-stop-budget.test.ts
@@ -9,6 +9,36 @@ import { describe, expect, it, vi } from 'vitest'
 import { InMemoryStreamingSessionController } from '../services/streaming/streaming-session-controller'
 import { GroqRollingUploadAdapter } from '../services/streaming/groq-rolling-upload-adapter'
 
+const createPcm16WavBytes = (): ArrayBuffer => {
+  const sampleData = new Int16Array([0, 1024])
+  const bytesPerSample = 2
+  const buffer = new ArrayBuffer(44 + sampleData.length * bytesPerSample)
+  const view = new DataView(buffer)
+  const writeString = (offset: number, value: string): void => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + sampleData.length * bytesPerSample, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, 16_000, true)
+  view.setUint32(28, 16_000 * bytesPerSample, true)
+  view.setUint16(32, bytesPerSample, true)
+  view.setUint16(34, 16, true)
+  writeString(36, 'data')
+  view.setUint32(40, sampleData.length * bytesPerSample, true)
+  sampleData.forEach((sample, index) => {
+    view.setInt16(44 + index * bytesPerSample, sample, true)
+  })
+  return buffer
+}
+
 const GROQ_STREAMING_CONFIG = {
   provider: 'groq_whisper_large_v3_turbo' as const,
   transport: 'rolling_upload' as const,
@@ -58,10 +88,10 @@ describe('streaming Groq stop budget integration', () => {
       sampleRateHz: 16000,
       channels: 1,
       utteranceIndex: 0,
-      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
+      wavBytes: createPcm16WavBytes(),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 1000,
-      endedAtMs: 1500,
+      startedAtEpochMs: 1000,
+      endedAtEpochMs: 1500,
       hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'

--- a/src/main/test-support/streaming-stop-integration.test.ts
+++ b/src/main/test-support/streaming-stop-integration.test.ts
@@ -10,6 +10,36 @@ import { describe, expect, it, vi } from 'vitest'
 import { InMemoryStreamingSessionController } from '../services/streaming/streaming-session-controller'
 import { GroqRollingUploadAdapter } from '../services/streaming/groq-rolling-upload-adapter'
 
+const createPcm16WavBytes = (): ArrayBuffer => {
+  const sampleData = new Int16Array([0, 1024])
+  const bytesPerSample = 2
+  const buffer = new ArrayBuffer(44 + sampleData.length * bytesPerSample)
+  const view = new DataView(buffer)
+  const writeString = (offset: number, value: string): void => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index))
+    }
+  }
+
+  writeString(0, 'RIFF')
+  view.setUint32(4, 36 + sampleData.length * bytesPerSample, true)
+  writeString(8, 'WAVE')
+  writeString(12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, 1, true)
+  view.setUint32(24, 16_000, true)
+  view.setUint32(28, 16_000 * bytesPerSample, true)
+  view.setUint16(32, bytesPerSample, true)
+  view.setUint16(34, 16, true)
+  writeString(36, 'data')
+  view.setUint32(40, sampleData.length * bytesPerSample, true)
+  sampleData.forEach((sample, index) => {
+    view.setInt16(44 + index * bytesPerSample, sample, true)
+  })
+  return buffer
+}
+
 const GROQ_STREAMING_CONFIG = {
   provider: 'groq_whisper_large_v3_turbo' as const,
   transport: 'rolling_upload' as const,
@@ -67,10 +97,10 @@ describe('streaming stop integration', () => {
       sampleRateHz: 16000,
       channels: 1,
       utteranceIndex: 0,
-      wavBytes: new Uint8Array([82, 73, 70, 70]).buffer,
+      wavBytes: createPcm16WavBytes(),
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 1000,
-      endedAtMs: 2000,
+      startedAtEpochMs: 1000,
+      endedAtEpochMs: 2000,
       hadCarryover: false,
       reason: 'session_stop',
       source: 'browser_vad'

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -82,6 +82,7 @@ describe('startGroqBrowserVadCapture', () => {
     sink?: { pushStreamingAudioUtteranceChunk: ReturnType<typeof vi.fn> }
     onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
     nowMs?: () => number
+    nowEpochMs?: () => number
     startupTimeoutMs?: number
     maxUtteranceMs?: number
     backpressureSignalMs?: number
@@ -101,6 +102,7 @@ describe('startGroqBrowserVadCapture', () => {
       onFatalError: vi.fn(),
       onBackpressureStateChange: overrides.onBackpressureStateChange,
       nowMs: overrides.nowMs ?? (() => 5_000),
+      nowEpochMs: overrides.nowEpochMs ?? overrides.nowMs ?? (() => 5_000),
       config: {
         startupTimeoutMs: overrides.startupTimeoutMs,
         maxUtteranceMs: overrides.maxUtteranceMs,
@@ -161,8 +163,25 @@ describe('startGroqBrowserVadCapture', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       reason: 'speech_pause',
       source: 'browser_vad',
-      startedAtMs: 6_000,
-      endedAtMs: 7_000
+      startedAtEpochMs: 6_000,
+      endedAtEpochMs: 7_000
+    }))
+  })
+
+  it('uses epoch time for utterance timestamps even when the monotonic clock differs', async () => {
+    const { vad, sink } = await createCapture({
+      nowMs: () => 75,
+      nowEpochMs: () => 1_700_000_007_000
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(16_000).fill(0.2))
+    await vad.emitSpeechEnd(new Float32Array(16_000).fill(0.2))
+
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      startedAtEpochMs: 1_700_000_006_000,
+      endedAtEpochMs: 1_700_000_007_000
     }))
   })
 
@@ -176,7 +195,8 @@ describe('startGroqBrowserVadCapture', () => {
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError: vi.fn(),
-      nowMs: () => 7_000
+      nowMs: () => 7_000,
+      nowEpochMs: () => 1_700_000_007_000
     }, {
       createVad: FakeMicVad.create,
       getUserMedia: vi.fn(async () => ({
@@ -225,7 +245,7 @@ describe('startGroqBrowserVadCapture', () => {
       utteranceIndex: 0,
       reason: 'session_stop',
       source: 'browser_vad',
-      endedAtMs: 9_000
+      endedAtEpochMs: 9_000
     }))
   })
 

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -29,6 +29,7 @@ export interface GroqBrowserVadCaptureOptions {
   onFatalError: (error: unknown) => void
   onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
   nowMs?: () => number
+  nowEpochMs?: () => number
   config?: Partial<GroqBrowserVadConfig>
 }
 
@@ -89,6 +90,7 @@ const createBoundClearTimeout = (): typeof clearTimeout =>
 
 class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private readonly nowMs: () => number
+  private readonly nowEpochMs: () => number
   private readonly sink: GroqBrowserVadSink
   private readonly onFatalError: (error: unknown) => void
   private readonly onBackpressureStateChange: ((state: { paused: boolean; durationMs?: number }) => void) | null
@@ -124,6 +126,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       onFatalError: (error: unknown) => void
       onBackpressureStateChange: ((state: { paused: boolean; durationMs?: number }) => void) | null
       nowMs: () => number
+      nowEpochMs: () => number
       encodeWav: (audio: Float32Array) => ArrayBuffer
       config: GroqBrowserVadConfig
       setTimeoutFn: typeof setTimeout
@@ -134,6 +137,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.onFatalError = params.onFatalError
     this.onBackpressureStateChange = params.onBackpressureStateChange
     this.nowMs = params.nowMs
+    this.nowEpochMs = params.nowEpochMs
     this.encodeWav = params.encodeWav
     this.config = params.config
     this.setTimeoutFn = params.setTimeoutFn
@@ -411,9 +415,9 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       return
     }
 
-    const endedAtMs = this.nowMs()
     const durationMs = (audio.length / STREAM_SAMPLE_RATE_HZ) * 1000
-    const startedAtMs = Math.max(0, endedAtMs - durationMs)
+    const endedAtEpochMs = this.nowEpochMs()
+    const startedAtEpochMs = Math.max(0, endedAtEpochMs - durationMs)
     const utteranceIndex = this.utteranceIndex
     this.utteranceIndex += 1
 
@@ -423,8 +427,8 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       utteranceIndex,
       wavBytes: this.encodeWav(audio),
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
-      startedAtMs,
-      endedAtMs,
+      startedAtEpochMs,
+      endedAtEpochMs,
       hadCarryover,
       reason,
       source: 'browser_vad' as const
@@ -576,6 +580,7 @@ export const startGroqBrowserVadCapture = async (
     onFatalError: options.onFatalError,
     onBackpressureStateChange: options.onBackpressureStateChange ?? null,
     nowMs: options.nowMs ?? (() => performance.now()),
+    nowEpochMs: options.nowEpochMs ?? (() => Date.now()),
     encodeWav,
     config,
     setTimeoutFn,

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -356,8 +356,8 @@ describe('handleRecordingCommandDispatch', () => {
       utteranceIndex: 0,
       wavBytes,
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 1_500,
-      endedAtMs: 1_800,
+      startedAtEpochMs: 1_500,
+      endedAtEpochMs: 1_800,
       hadCarryover: true,
       reason: 'max_chunk',
       source: 'browser_vad'
@@ -370,8 +370,8 @@ describe('handleRecordingCommandDispatch', () => {
       utteranceIndex: 0,
       wavBytes,
       wavFormat: 'wav_pcm_s16le_mono_16000',
-      startedAtMs: 1_500,
-      endedAtMs: 1_800,
+      startedAtEpochMs: 1_500,
+      endedAtEpochMs: 1_800,
       hadCarryover: true,
       reason: 'max_chunk',
       source: 'browser_vad'

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -119,8 +119,8 @@ export interface StreamingAudioUtteranceChunk {
   utteranceIndex: number
   wavBytes: ArrayBuffer
   wavFormat: 'wav_pcm_s16le_mono_16000'
-  startedAtMs: number
-  endedAtMs: number
+  startedAtEpochMs: number
+  endedAtEpochMs: number
   hadCarryover: boolean
   reason: StreamingAudioUtteranceChunkFlushReason
   source: 'browser_vad'


### PR DESCRIPTION
## Summary
- rename the Groq utterance IPC timing fields to explicit epoch milliseconds
- make browser-VAD capture use a separate epoch clock for utterance timestamps
- emit Groq final segment ISO timestamps only from epoch values and lock the contract with tests and a decision note

## Verification
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/main/services/streaming/groq-rolling-upload-adapter.test.ts src/main/ipc/register-handlers.test.ts src/main/services/streaming/streaming-session-controller.test.ts src/renderer/native-recording.test.ts src/main/test-support/streaming-stop-integration.test.ts src/main/test-support/streaming-groq-stop-budget.test.ts
- pnpm typecheck
- pnpm build
- git diff --check
- git diff --cached --check

## Review
- Sub-agent review: attempted, but I could not retrieve a usable result from the available tooling in this environment
- Claude CLI review: attempted but quota-blocked in this environment (`You're out of extra usage`)
