### PR TITLE
chore: add groq utterance handoff trace

### DIFF
--- a/docs/research/2026-03-10-groq-utterance-trace-local-debugging.md
+++ b/docs/research/2026-03-10-groq-utterance-trace-local-debugging.md
@@ -1,0 +1,56 @@
+<!--
+Where: docs/research/2026-03-10-groq-utterance-trace-local-debugging.md
+What: Local usage note for the bounded Groq utterance handoff trace.
+Why: Keep issue-440 repro debugging repeatable without reopening broad logging.
+-->
+
+# Groq Utterance Trace: Local Debugging Note
+
+## What It Logs
+
+When enabled, the app emits a single bounded event named
+`streaming.groq_utterance_trace` on both renderer and main for Groq browser-VAD
+utterance handoff.
+
+Fixed field budget:
+
+- `sessionId`
+- `utteranceIndex`
+- `reason`
+- `wavBytesByteLength`
+- `endedAtEpochMs`
+- `result`
+
+The trace never logs raw audio bytes or transcript text.
+
+## How To Enable It Locally
+
+Open the renderer DevTools console and run:
+
+```js
+localStorage.setItem('speech-to-text.groq-utterance-trace', '1')
+location.reload()
+```
+
+To disable it again:
+
+```js
+localStorage.removeItem('speech-to-text.groq-utterance-trace')
+location.reload()
+```
+
+## Result Values
+
+- `sealed`: renderer created an utterance payload and is about to send it
+- `sent`: renderer received a successful acknowledgement
+- `fatal`: renderer send/handoff failed and capture is entering fatal cleanup
+- `accepted`: main accepted the utterance and handed it to the session controller
+- `rejected`: main rejected the utterance before or during ingress
+
+## Typical Repro Read
+
+- `sealed` without `accepted`: the payload did not make it through IPC/main ingress
+- `accepted` without `sent`: the reply path back to renderer failed
+- `rejected`: inspect the rejection message adjacent to the trace entry
+- repeated `sealed` with no later progress: renderer is producing utterances but
+  the handoff is blocked or failing

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -274,7 +274,8 @@ describe('registerIpcHandlers', () => {
       endedAtEpochMs: 500,
       hadCarryover: false,
       reason: 'speech_pause',
-      source: 'browser_vad'
+      source: 'browser_vad',
+      traceEnabled: true
     })
 
     expect(pushAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
@@ -282,6 +283,17 @@ describe('registerIpcHandlers', () => {
       utteranceIndex: 0
     }))
     expect(ownerPort.postMessage).toHaveBeenCalledWith({ ok: true })
+    expect(mocks.logStructured).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace',
+      context: expect.objectContaining({
+        sessionId: 'session-utterance',
+        utteranceIndex: 0,
+        reason: 'speech_pause',
+        wavBytesByteLength: 4,
+        endedAtEpochMs: 500,
+        result: 'accepted'
+      })
+    }))
 
     const nonOwnerPort = createFakeMessagePort()
     await utteranceHandler?.({ sender: mocks.windows[1]?.webContents, ports: [nonOwnerPort] }, undefined)
@@ -296,12 +308,24 @@ describe('registerIpcHandlers', () => {
       endedAtEpochMs: 900,
       hadCarryover: false,
       reason: 'speech_pause',
-      source: 'browser_vad'
+      source: 'browser_vad',
+      traceEnabled: true
     })
 
     expect(nonOwnerPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
       ok: false,
       message: expect.stringContaining('does not own session')
+    }))
+    expect(mocks.logStructured).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace',
+      context: expect.objectContaining({
+        sessionId: 'session-utterance',
+        utteranceIndex: 1,
+        reason: 'speech_pause',
+        wavBytesByteLength: 4,
+        endedAtEpochMs: 900,
+        result: 'rejected'
+      })
     }))
   })
 
@@ -386,6 +410,76 @@ describe('registerIpcHandlers', () => {
       message: expect.stringContaining('endedAtEpochMs must not precede startedAtEpochMs')
     }))
     expect(pushAudioUtteranceChunk).not.toHaveBeenCalled()
+  })
+
+  it('does not emit the Groq utterance handoff trace when traceEnabled is absent', async () => {
+    const pushAudioUtteranceChunk = vi.fn(async () => {})
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi.fn().mockResolvedValue({
+        kind: 'streaming_start',
+        sessionId: 'session-utterance-no-trace',
+        preferredDeviceId: 'mic-1'
+      }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession: vi.fn()
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: {
+        onSessionState: vi.fn(),
+        onSegment: vi.fn(),
+        onError: vi.fn(),
+        pushAudioFrameBatch: vi.fn(),
+        pushAudioUtteranceChunk
+      } as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    await getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
+    const utteranceHandler = getRegisteredOn(IPC_CHANNELS.pushStreamingAudioUtteranceChunk)
+    const ownerPort = createFakeMessagePort()
+    await utteranceHandler?.({ sender: mocks.windows[0]?.webContents, ports: [ownerPort] }, undefined)
+    await ownerPort.emitMessage({
+      sessionId: 'session-utterance-no-trace',
+      sampleRateHz: 16000,
+      channels: 1,
+      utteranceIndex: 0,
+      wavBytes: new ArrayBuffer(4),
+      wavFormat: 'wav_pcm_s16le_mono_16000',
+      startedAtEpochMs: 0,
+      endedAtEpochMs: 500,
+      hadCarryover: false,
+      reason: 'speech_pause',
+      source: 'browser_vad'
+    })
+
+    expect(mocks.logStructured).not.toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace'
+    }))
   })
 
   it('logs and returns when recording command dispatch finds no renderer windows', async () => {

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -213,6 +213,30 @@ const assertStreamingAudioUtteranceChunkAllowed = (
   }
 }
 
+const logGroqUtteranceTrace = (
+  chunk: StreamingAudioUtteranceChunk,
+  result: 'accepted' | 'rejected'
+): void => {
+  if (!chunk.traceEnabled) {
+    return
+  }
+
+  logStructured({
+    level: result === 'rejected' ? 'warn' : 'info',
+    scope: 'main',
+    event: 'streaming.groq_utterance_trace',
+    message: 'Groq utterance handoff trace.',
+    context: {
+      sessionId: chunk.sessionId,
+      utteranceIndex: chunk.utteranceIndex,
+      reason: chunk.reason,
+      wavBytesByteLength: chunk.wavBytes.byteLength,
+      endedAtEpochMs: chunk.endedAtEpochMs,
+      result
+    }
+  })
+}
+
 const validateStreamingAudioUtteranceChunkPayload = (payload: unknown): StreamingAudioUtteranceChunk => {
   if (!payload || typeof payload !== 'object') {
     throw new Error('Invalid streaming audio utterance chunk payload: expected an object.')
@@ -254,6 +278,9 @@ const validateStreamingAudioUtteranceChunkPayload = (payload: unknown): Streamin
   }
   if (chunk.source !== 'browser_vad') {
     throw new Error('Invalid streaming audio utterance chunk payload: source is unsupported.')
+  }
+  if (chunk.traceEnabled !== undefined && typeof chunk.traceEnabled !== 'boolean') {
+    throw new Error('Invalid streaming audio utterance chunk payload: traceEnabled must be a boolean when provided.')
   }
 
   return chunk as StreamingAudioUtteranceChunk
@@ -733,12 +760,17 @@ const bindIpcHandlers = (svc: MainServices): void => {
     }
 
     replyPort.on('message', async (messageEvent) => {
+      let chunk: StreamingAudioUtteranceChunk | null = null
       try {
-        const chunk = validateStreamingAudioUtteranceChunkPayload(messageEvent.data)
+        chunk = validateStreamingAudioUtteranceChunkPayload(messageEvent.data)
         assertStreamingAudioUtteranceChunkAllowed(chunk, senderWindowId)
         await svc.streamingSessionController.pushAudioUtteranceChunk(chunk)
+        logGroqUtteranceTrace(chunk, 'accepted')
         replyPort.postMessage({ ok: true })
       } catch (error) {
+        if (chunk) {
+          logGroqUtteranceTrace(chunk, 'rejected')
+        }
         replyPort.postMessage({
           ok: false,
           message: error instanceof Error ? error.message : String(error)

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -68,8 +68,8 @@ describe('preload speechToTextApi', () => {
       utteranceIndex: 3,
       wavBytes: new ArrayBuffer(8),
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
-      startedAtMs: 100,
-      endedAtMs: 240,
+      startedAtEpochMs: 100,
+      endedAtEpochMs: 240,
       hadCarryover: false,
       reason: 'speech_pause' as const,
       source: 'browser_vad' as const
@@ -100,8 +100,8 @@ describe('preload speechToTextApi', () => {
       utteranceIndex: 0,
       wavBytes: new ArrayBuffer(4),
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
-      startedAtMs: 0,
-      endedAtMs: 32,
+      startedAtEpochMs: 0,
+      endedAtEpochMs: 32,
       hadCarryover: false,
       reason: 'session_stop' as const,
       source: 'browser_vad' as const

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -79,10 +79,12 @@ describe('startGroqBrowserVadCapture', () => {
   })
 
   const createCapture = async (overrides: {
+    sessionId?: string
     sink?: { pushStreamingAudioUtteranceChunk: ReturnType<typeof vi.fn> }
     onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
     nowMs?: () => number
     nowEpochMs?: () => number
+    traceEnabled?: boolean
     startupTimeoutMs?: number
     maxUtteranceMs?: number
     backpressureSignalMs?: number
@@ -97,12 +99,14 @@ describe('startGroqBrowserVadCapture', () => {
       pushStreamingAudioUtteranceChunk: vi.fn(async () => {})
     }
     const capture = await startGroqBrowserVadCapture({
+      sessionId: overrides.sessionId ?? 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError: vi.fn(),
       onBackpressureStateChange: overrides.onBackpressureStateChange,
       nowMs: overrides.nowMs ?? (() => 5_000),
       nowEpochMs: overrides.nowEpochMs ?? overrides.nowMs ?? (() => 5_000),
+      traceEnabled: overrides.traceEnabled,
       config: {
         startupTimeoutMs: overrides.startupTimeoutMs,
         maxUtteranceMs: overrides.maxUtteranceMs,
@@ -185,6 +189,59 @@ describe('startGroqBrowserVadCapture', () => {
     }))
   })
 
+  it('emits the bounded Groq handoff trace only when explicitly enabled', async () => {
+    const logSpy = vi.spyOn(errorLogging, 'logStructured')
+    const { vad } = await createCapture({
+      sessionId: 'session-trace',
+      traceEnabled: true,
+      nowEpochMs: () => 1_700_000_007_000
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(1_600).fill(0.2))
+    await vad.emitSpeechEnd(new Float32Array(1_600).fill(0.2))
+
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace',
+      context: expect.objectContaining({
+        sessionId: 'session-trace',
+        utteranceIndex: 0,
+        reason: 'speech_pause',
+        wavBytesByteLength: expect.any(Number),
+        endedAtEpochMs: 1_700_000_007_000,
+        result: 'sealed'
+      })
+    }))
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace',
+      context: expect.objectContaining({
+        sessionId: 'session-trace',
+        utteranceIndex: 0,
+        reason: 'speech_pause',
+        wavBytesByteLength: expect.any(Number),
+        endedAtEpochMs: 1_700_000_007_000,
+        result: 'sent'
+      })
+    }))
+  })
+
+  it('does not emit the Groq handoff trace by default', async () => {
+    const logSpy = vi.spyOn(errorLogging, 'logStructured')
+    const { vad } = await createCapture({
+      nowEpochMs: () => 1_700_000_007_000
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(1_600).fill(0.2))
+    await vad.emitSpeechEnd(new Float32Array(1_600).fill(0.2))
+
+    expect(logSpy).not.toHaveBeenCalledWith(expect.objectContaining({
+      event: 'streaming.groq_utterance_trace'
+    }))
+  })
+
   it('uses PCM16 mono 16 kHz WAV bytes by default', async () => {
     const sink = {
       pushStreamingAudioUtteranceChunk: vi.fn(async (chunk: { wavBytes: ArrayBuffer }) => {
@@ -192,6 +249,7 @@ describe('startGroqBrowserVadCapture', () => {
       })
     }
     await startGroqBrowserVadCapture({
+      sessionId: 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError: vi.fn(),
@@ -441,6 +499,7 @@ describe('startGroqBrowserVadCapture', () => {
     const timerError = new TypeError('Illegal invocation')
     const onFatalError = vi.fn()
     const capture = await startGroqBrowserVadCapture({
+      sessionId: 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError,
@@ -518,6 +577,7 @@ describe('startGroqBrowserVadCapture', () => {
       })
     }
     const capture = await startGroqBrowserVadCapture({
+      sessionId: 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink,
       onFatalError,
@@ -553,6 +613,7 @@ describe('startGroqBrowserVadCapture', () => {
     const never = new Promise<FakeMicVad>(() => {})
 
     const startupPromise = startGroqBrowserVadCapture({
+      sessionId: 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink: {
         pushStreamingAudioUtteranceChunk: vi.fn(async () => {})
@@ -582,6 +643,7 @@ describe('startGroqBrowserVadCapture', () => {
     const lateVad = new FakeMicVad({})
 
     const startupPromise = startGroqBrowserVadCapture({
+      sessionId: 'session-1',
       deviceConstraints: { channelCount: { ideal: 1 } },
       sink: {
         pushStreamingAudioUtteranceChunk: vi.fn(async () => {})

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -24,12 +24,14 @@ export interface GroqBrowserVadCapture {
 }
 
 export interface GroqBrowserVadCaptureOptions {
+  sessionId: string
   deviceConstraints: MediaTrackConstraints
   sink: GroqBrowserVadSink
   onFatalError: (error: unknown) => void
   onBackpressureStateChange?: (state: { paused: boolean; durationMs?: number }) => void
   nowMs?: () => number
   nowEpochMs?: () => number
+  traceEnabled?: boolean
   config?: Partial<GroqBrowserVadConfig>
 }
 
@@ -79,6 +81,8 @@ const resolveMaxUtteranceSamples = (config: GroqBrowserVadConfig): number =>
 const encodePcm16Mono16000Wav = (audio: Float32Array): ArrayBuffer =>
   utils.encodeWAV(audio, 1, STREAM_SAMPLE_RATE_HZ, 1, 16)
 
+const GROQ_UTTERANCE_TRACE_STORAGE_KEY = 'speech-to-text.groq-utterance-trace'
+
 const createBoundSetTimeout = (): typeof setTimeout =>
   ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
     globalThis.setTimeout(handler, timeout, ...args)) as typeof setTimeout
@@ -89,6 +93,7 @@ const createBoundClearTimeout = (): typeof clearTimeout =>
   }) as typeof clearTimeout
 
 class BrowserGroqVadCapture implements GroqBrowserVadCapture {
+  private readonly sessionId: string
   private readonly nowMs: () => number
   private readonly nowEpochMs: () => number
   private readonly sink: GroqBrowserVadSink
@@ -98,6 +103,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   private readonly config: GroqBrowserVadConfig
   private readonly setTimeoutFn: typeof setTimeout
   private readonly clearTimeoutFn: typeof clearTimeout
+  private readonly traceEnabled: boolean
 
   private vad: MicVadLike | null = null
   private stopping = false
@@ -122,22 +128,26 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
 
   constructor(
     params: {
+      sessionId: string
       sink: GroqBrowserVadSink
       onFatalError: (error: unknown) => void
       onBackpressureStateChange: ((state: { paused: boolean; durationMs?: number }) => void) | null
       nowMs: () => number
       nowEpochMs: () => number
+      traceEnabled: boolean
       encodeWav: (audio: Float32Array) => ArrayBuffer
       config: GroqBrowserVadConfig
       setTimeoutFn: typeof setTimeout
       clearTimeoutFn: typeof clearTimeout
     }
   ) {
+    this.sessionId = params.sessionId
     this.sink = params.sink
     this.onFatalError = params.onFatalError
     this.onBackpressureStateChange = params.onBackpressureStateChange
     this.nowMs = params.nowMs
     this.nowEpochMs = params.nowEpochMs
+    this.traceEnabled = params.traceEnabled
     this.encodeWav = params.encodeWav
     this.config = params.config
     this.setTimeoutFn = params.setTimeoutFn
@@ -431,12 +441,14 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       endedAtEpochMs,
       hadCarryover,
       reason,
-      source: 'browser_vad' as const
+      source: 'browser_vad' as const,
+      traceEnabled: this.traceEnabled || undefined
     }
     let pushPromise: Promise<void> | null = null
     let backpressureTimeout: ReturnType<typeof setTimeout> | null = null
 
     try {
+      this.logUtteranceTrace(chunk, 'sealed')
       // Start the timer before transport so a synchronous timer setup failure
       // cannot orphan an already-started utterance push.
       backpressureTimeout = this.setTimeoutFn(() => {
@@ -445,6 +457,10 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       pushPromise = this.sink.pushStreamingAudioUtteranceChunk(chunk)
       this.activeUtterancePushPromise = pushPromise
       await pushPromise
+      this.logUtteranceTrace(chunk, 'sent')
+    } catch (error) {
+      this.logUtteranceTrace(chunk, 'fatal')
+      throw error
     } finally {
       this.activeUtterancePushPromise = null
       if (backpressureTimeout) {
@@ -528,6 +544,38 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       this.onFatalError(error)
     })
   }
+
+  private logUtteranceTrace(
+    chunk: Omit<StreamingAudioUtteranceChunk, 'sessionId'>,
+    result: 'sealed' | 'sent' | 'fatal'
+  ): void {
+    if (!this.traceEnabled) {
+      return
+    }
+
+    logStructured({
+      level: result === 'fatal' ? 'warn' : 'info',
+      scope: 'renderer',
+      event: 'streaming.groq_utterance_trace',
+      message: 'Groq utterance handoff trace.',
+      context: {
+        sessionId: this.sessionId,
+        utteranceIndex: chunk.utteranceIndex,
+        reason: chunk.reason,
+        wavBytesByteLength: chunk.wavBytes.byteLength,
+        endedAtEpochMs: chunk.endedAtEpochMs,
+        result
+      }
+    })
+  }
+}
+
+const resolveGroqUtteranceTraceEnabled = (): boolean => {
+  try {
+    return globalThis.localStorage?.getItem(GROQ_UTTERANCE_TRACE_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
 }
 
 const createStartupTimeout = (
@@ -576,11 +624,13 @@ export const startGroqBrowserVadCapture = async (
   }
 
   const capture = new BrowserGroqVadCapture({
+    sessionId: options.sessionId,
     sink: options.sink,
     onFatalError: options.onFatalError,
     onBackpressureStateChange: options.onBackpressureStateChange ?? null,
     nowMs: options.nowMs ?? (() => performance.now()),
     nowEpochMs: options.nowEpochMs ?? (() => Date.now()),
+    traceEnabled: options.traceEnabled ?? resolveGroqUtteranceTraceEnabled(),
     encodeWav,
     config,
     setTimeoutFn,

--- a/src/renderer/native-recording.ts
+++ b/src/renderer/native-recording.ts
@@ -446,6 +446,7 @@ export const startNativeRecording = async (
 
       recorderState.streamingCapture = streamingProvider === 'groq_whisper_large_v3_turbo'
         ? await startGroqBrowserVadCapture({
+            sessionId: streamingSessionId,
             deviceConstraints: constraints.audio as MediaTrackConstraints,
             sink: createGroqBrowserVadSink(streamingSessionId),
             onFatalError,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -124,6 +124,7 @@ export interface StreamingAudioUtteranceChunk {
   hadCarryover: boolean
   reason: StreamingAudioUtteranceChunkFlushReason
   source: 'browser_vad'
+  traceEnabled?: boolean
 }
 
 export interface StreamingErrorEvent {


### PR DESCRIPTION
## Summary
- add a bounded, opt-in Groq utterance handoff trace across renderer send and main ingress
- keep the trace Groq-only, disabled by default, and limited to non-content-bearing fields
- update the preload utterance fixture to the epoch-timestamp contract and document local trace usage

## Verification
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts src/main/ipc/register-handlers.test.ts src/preload/index.test.ts src/renderer/native-recording.test.ts
- pnpm vitest run src/main/services/streaming/whispercpp-streaming-adapter.test.ts src/renderer/groq-browser-vad-capture.test.ts src/main/ipc/register-handlers.test.ts src/preload/index.test.ts src/renderer/native-recording.test.ts
- pnpm typecheck
- git diff --check
- git diff --cached --check

## Review
- local self-review completed
- Claude CLI review: attempted earlier in this environment and quota-blocked
- sub-agent review tooling did not return a usable result in this environment
