### PR TITLE
Fix Groq VAD chunk streaming coverage and stop handling

### DIFF
--- a/.github/workflows/e2e-playwright-electron.yml
+++ b/.github/workflows/e2e-playwright-electron.yml
@@ -77,6 +77,16 @@ jobs:
           PLAYWRIGHT_BYPASS_ACCESSIBILITY: '1'
         run: xvfb-run -a pnpm exec playwright test e2e/electron-groq-streaming-recording.e2e.ts -g "@fake-audio|@synthetic-audio"
 
+      - name: Run transcript-first output-failure contract E2E
+        run: xvfb-run -a pnpm exec playwright test e2e/electron-groq-streaming-recording.e2e.ts -g "@output-failure-contract"
+
+      - name: Run optional live provider utterance-IPC checks
+        if: ${{ inputs.run_live_provider_checks == true }}
+        env:
+          GROQ_APIKEY: ${{ secrets.GROQ_APIKEY }}
+          PLAYWRIGHT_BYPASS_ACCESSIBILITY: '1'
+        run: xvfb-run -a pnpm exec playwright test e2e/electron-groq-streaming-recording.e2e.ts -g "@live-provider"
+
       - name: Upload Playwright report (audio-linux)
         if: always()
         uses: actions/upload-artifact@v4
@@ -120,6 +130,7 @@ jobs:
       - name: Run optional live provider checks
         if: ${{ inputs.run_live_provider_checks == true }}
         env:
+          GROQ_APIKEY: ${{ secrets.GROQ_APIKEY }}
           GOOGLE_APIKEY: ${{ secrets.GOOGLE_APIKEY }}
           ELEVENLABS_APIKEY: ${{ secrets.ELEVENLABS_APIKEY }}
         run: pnpm exec playwright test -g "@live-provider"

--- a/docs/e2e-playwright.md
+++ b/docs/e2e-playwright.md
@@ -52,8 +52,13 @@ Audio-specific CI coverage now runs on `ubuntu-latest` under Xvfb and executes
 That Linux lane enables `PLAYWRIGHT_BYPASS_ACCESSIBILITY=1` so the test can
 exercise streaming transcription and renderer updates without failing on the
 product's macOS-only paste-at-cursor permission gate.
+That same Linux lane also runs `@output-failure-contract` without the bypass so
+CI proves transcript-first behavior when output application fails.
 Manual workflow runs can disable that Linux lane with the `run_audio_linux`
 dispatch input when only macOS smoke or live-provider checks are needed.
+When `run_live_provider_checks=true`, Linux also runs the optional
+`@live-provider @utterance-ipc` Groq path under Xvfb with `GROQ_APIKEY` from
+Actions secrets.
 
 ## Coverage included
 - App launch smoke test (Home/Settings navigation).
@@ -64,6 +69,8 @@ dispatch input when only macOS smoke or live-provider checks are needed.
 - Deterministic recording flow using an in-page synthetic microphone stream (mocked `getUserMedia`) with strict success-path assertions (`@macos` tagged in current CI workflow).
 - Cross-platform Groq streaming browser-VAD recording using a synthetic `getUserMedia` microphone backed by the PR 461 WAV speech fixtures, with the main-process Groq upload fetch stubbed so the test exercises utterance IPC and rendered streamed text.
 - Cross-platform Groq streaming browser-VAD recording using Chromium fake-media WAV capture from PR 461, with the main-process Groq upload fetch stubbed so the test verifies utterance IPC plus rendered streamed text (`@fake-audio` tagged).
+- Cross-platform Groq transcript-first failure contract coverage proving streamed text remains visible when paste-at-cursor fails (`@output-failure-contract` tagged).
+- Optional live Groq upload/output coverage after renderer utterance IPC injection using `GROQ_APIKEY` from process env or `/workspace/.env`, with assertions limited to a non-empty streamed-text activity entry (`@live-provider @utterance-ipc` tagged).
 - Transform preflight blocking when Google API key is missing.
 
 ## Config
@@ -89,6 +96,9 @@ dispatch input when only macOS smoke or live-provider checks are needed.
   - Keep a separate Groq streaming test that uses real speech WAV fixtures and checks that streamed text reaches the renderer without a capture-failure toast under both synthetic and Chromium fake-audio paths.
   - For CI determinism, the Groq streaming spec injects a fixture-derived utterance through the same renderer-to-main utterance IPC bridge after the recording session becomes active, so the test remains focused on the bug-bearing Groq handoff even when browser VAD itself is runner-sensitive.
   - On non-macOS E2E hosts, the spec opts into `PLAYWRIGHT_BYPASS_ACCESSIBILITY=1` so streamed output can be committed without the platform-specific paste permission check masking transport regressions.
+  - A separate non-macOS `@output-failure-contract` test intentionally omits the bypass and asserts both the committed transcript activity entry and the expected partial-output error.
+  - Live Groq checks read `GROQ_APIKEY` from process env first, then `/workspace/.env`, so local runs and CI use the same provider path without hardcoding secrets in the spec.
+  - The live-provider lane validates the real Groq upload/output contract after renderer utterance IPC injection; it does not claim deterministic browser-VAD chunk-boundary coverage.
   - Keep a deterministic synthetic-mic `@macos` test to provide stable CI/headless verification of the recording submission + success-toast path; CI-only synthetic chunk fallback remains in place for rare no-chunk runner behavior.
 - Retry/timeout policy:
   - Uses global Playwright retries from `playwright.config.ts` (`CI=2`, local `0`).

--- a/docs/plans/2026-03-10-groq-streaming-chunk-redesign-execution-plan.md
+++ b/docs/plans/2026-03-10-groq-streaming-chunk-redesign-execution-plan.md
@@ -1,0 +1,355 @@
+<!--
+Where: docs/plans/2026-03-10-groq-streaming-chunk-redesign-execution-plan.md
+What: PR-sized execution plan for Groq raw dictation streaming-by-chunk redesign and E2E coverage.
+Why: The current segment-first path is still dropping or hiding committed dictation, so implementation
+     must proceed in ticket order against the redesigned utterance-commit model instead of ad hoc fixes.
+-->
+
+# 2026-03-10 Groq Streaming Chunk Redesign Execution Plan
+
+Date: 2026-03-10
+Status: Planned on `develop`. No runtime changes from this plan had started when this file was created.
+
+## Problem Statement
+
+Groq raw dictation is currently treated too much like fine-grained streaming. That creates the wrong failure
+surface for a browser-VAD chunked provider:
+
+- renderer can discard speech after VAD already sealed an utterance
+- main can time out final commit work during `user_stop`
+- output failure can mask otherwise successful transcription
+- E2E coverage proves happy-path stubbing, but not the transcript-first contract or real `GROQ_APIKEY` wiring
+
+The redesign keeps existing batch STT intact, but stops preserving backward compatibility inside streaming
+internals for Groq raw dictation where the old segment-first model is the source of the bugs.
+
+## Target Model
+
+For Groq raw dictation:
+
+1. renderer VAD seals one utterance
+2. renderer sends one utterance chunk to main
+3. main uploads and transcribes that utterance
+4. app publishes committed transcript text immediately
+5. output application runs afterward as best-effort
+6. output failure is reported separately and must not hide the committed transcript
+
+For existing batch STT:
+
+- no behavior or contract change
+
+## Priority Summary
+
+| Priority | Ticket | PR | Goal | Feasibility | Main Risk |
+|---|---|---|---|---|---|
+| P0 | T1 | PR-1 | Freeze redesign contract and event model | High | Contract drift while code is changing |
+| P1 | T2 | PR-2 | Fix renderer VAD utterance sealing and stop-tail handling | High | Regressing chunk boundaries or capture teardown |
+| P2 | T3 | PR-3 | Fix Groq main-process commit/output ordering and stop drain | Medium | Session lifecycle races during stop |
+| P3 | T4 | PR-4 | Fix and extend E2E using `GROQ_APIKEY` and transcript-first failure contract | High | Brittle live-provider assertions |
+| P4 | T5 | PR-5 | Hardening, observability, and backlog accounting cleanup | Medium | Latency regressions under slow output |
+
+## Ticket T1 (P0): Contract Freeze
+
+### Goal
+
+Freeze the redesigned Groq raw dictation contract before implementation continues.
+
+### Approach
+
+- treat Groq browser VAD as utterance-chunk ingestion, not pseudo realtime segment streaming
+- keep existing `StreamingSegmentEvent` output for renderer transcript display during transition
+- add committed-transcript and output-failure events where needed to preserve transcript-first semantics
+- explicitly allow streaming-internal breakage from the old Groq path while keeping batch STT unchanged
+
+### Scope Files
+
+- `docs/plans/2026-03-10-groq-streaming-chunk-redesign-execution-plan.md`
+- `docs/decisions/2026-03-10-groq-raw-dictation-streaming-redesign-decision.md`
+- `src/shared/ipc.ts`
+- `src/preload/index.ts`
+- `src/main/ipc/register-handlers.ts`
+- `src/main/services/streaming/types.ts`
+- `src/main/services/streaming/streaming-session-controller.ts`
+
+### Trade-offs
+
+- Selected: provider-specific Groq raw contract.
+  - Pro: matches actual provider behavior and makes tests honest.
+  - Con: more IPC surface and less internal backward compatibility.
+- Rejected: keep overloading the existing segment-only contract.
+  - Pro: smaller short-term diff.
+  - Con: preserves the current ambiguity between transcription success and output success.
+
+### Checklist
+
+- [ ] contract states that Groq raw dictation is utterance-commit oriented
+- [ ] transcript success and output failure are modeled separately
+- [ ] stop reasons use `user_stop` and not leaked internal aliases
+- [ ] existing batch STT is explicitly out of scope
+
+### Tasks
+
+1. Add or update the redesign decision record.
+2. Freeze IPC and controller vocabulary for utterance commit and output failure.
+3. Add tests that lock the shared contract and listener wiring.
+
+### Gates
+
+- shared types compile cleanly
+- tests lock the public surface before runtime changes continue
+- reviewers can answer: "When transcription succeeds but output fails, what does the renderer receive?"
+
+### Code Snippet
+
+```ts
+type StreamingUtteranceCommitReason = 'speech_pause' | 'max_chunk' | 'user_stop'
+
+interface StreamingUtteranceCommittedEvent {
+  sessionId: string
+  utteranceIndex: number
+  text: string
+  reason: StreamingUtteranceCommitReason
+}
+
+interface StreamingOutputFailureEvent {
+  sessionId: string
+  utteranceIndex: number | null
+  message: string
+}
+```
+
+## Ticket T2 (P1): Renderer VAD Chunk Capture
+
+### Goal
+
+Remove renderer-side utterance loss after `MicVAD` already decided speech ended.
+
+### Approach
+
+- trust the sealed `onSpeechEnd(audio)` payload for pause-bounded commits
+- keep local frame accounting only for explicit stop-tail flush and diagnostics
+- preserve stop/cancel teardown barriers
+
+### Scope Files
+
+- `src/renderer/groq-browser-vad-capture.ts`
+- `src/renderer/groq-browser-vad-capture.test.ts`
+- `src/renderer/groq-browser-vad-config.ts`
+
+### Trade-offs
+
+- Selected: trust VAD callback audio.
+  - Pro: aligns with provider library semantics and removes double-gating.
+  - Con: less local opportunity to second-guess bad VAD callbacks.
+- Rejected: re-derive speech validity only from the renderer shadow buffer.
+  - Pro: feels internally consistent.
+  - Con: this is one of the observed loss points.
+
+### Checklist
+
+- [ ] natural pause path uses sealed callback audio
+- [ ] explicit stop still flushes short trailing speech when appropriate
+- [ ] `max_chunk` continuation does not erase the final tail
+- [ ] tests cover both pause and explicit-stop edge cases
+
+### Tasks
+
+1. Thread callback audio through `handleSpeechEnd`.
+2. Replace post-VAD speech validation on the natural pause path with a minimal sealed-audio sanity check.
+3. Add a stop-specific speech window check for trailing flush behavior.
+4. Add regression tests for callback-audio trust and `max_chunk` tail preservation.
+
+### Gates
+
+- renderer unit tests pass
+- stop path still destroys the VAD cleanly
+- no new capture API surface is introduced
+
+### Code Snippet
+
+```ts
+onSpeechEnd: async (sealedAudio) => {
+  const generation = this.callbackGeneration
+  await this.handleSpeechEnd(generation, sealedAudio)
+}
+```
+
+## Ticket T3 (P2): Main Groq Commit and Stop Drain
+
+### Goal
+
+Make Groq utterance commit transcription-first, and ensure `user_stop` drains already uploaded utterances instead of dropping them.
+
+### Approach
+
+- stop applying the 3s stop budget to normal commit processing
+- use the stop budget only for upload drain
+- await final commit/output drain after uploads settle
+- fall back to top-level Groq `text` when `segments` is present but unusable
+- keep output failure reporting separate from committed transcript publication
+
+### Scope Files
+
+- `src/main/services/streaming/groq-rolling-upload-adapter.ts`
+- `src/main/services/streaming/groq-rolling-upload-adapter.test.ts`
+- `src/main/services/streaming/streaming-segment-router.ts`
+- `src/main/services/streaming/streaming-segment-router.test.ts`
+- `src/main/services/streaming/streaming-session-controller.ts`
+- `src/main/services/streaming/streaming-session-controller.test.ts`
+
+### Trade-offs
+
+- Selected: transcription-first commit semantics.
+  - Pro: reflects what users care about when dictation succeeds.
+  - Con: output failures become a second event the UI must handle.
+- Rejected: tie session success to output success.
+  - Pro: fewer states.
+  - Con: hides working transcription behind unrelated paste/platform failures.
+
+### Checklist
+
+- [ ] `user_stop` drains uploaded utterances through commit/output
+- [ ] active-session commits are never stop-budget timed
+- [ ] top-level Groq text fallback works when segment payload is unusable
+- [ ] output failure does not suppress committed transcript delivery
+
+### Tasks
+
+1. Restrict the stop budget to upload drain only.
+2. Await `finishStopDrain()` after upload drain completes.
+3. Normalize Groq commit reasons and stop leaking `session_stop`.
+4. Add verbose-json text fallback when segments are unusable.
+5. Extend controller/router tests around late commit plus output failure during stop.
+
+### Gates
+
+- targeted streaming unit tests pass
+- no late committed utterance is lost during `user_stop`
+- renderer-visible transcript survives output failure
+
+### Code Snippet
+
+```ts
+const outcome = await Promise.race([
+  uploadDrainPromise.then(() => 'completed' as const),
+  this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
+])
+
+if (outcome === 'completed') {
+  await this.finishStopDrain()
+}
+```
+
+## Ticket T4 (P3): E2E With `GROQ_APIKEY`
+
+### Goal
+
+Make Groq streaming E2E reflect the redesigned contract and run both deterministic and optional live-provider coverage with `GROQ_APIKEY`.
+
+### Approach
+
+- keep stubbed synthetic/fake-audio tests for deterministic CI
+- add an output-failure contract test that proves transcript-first behavior
+- read `GROQ_APIKEY` from process env or `/workspace/.env`
+- keep live-provider assertions broad enough to be stable across real Groq transcript variations
+
+### Scope Files
+
+- `e2e/electron-groq-streaming-recording.e2e.ts`
+- `.github/workflows/e2e-playwright-electron.yml`
+- `docs/e2e-playwright.md`
+
+### Trade-offs
+
+- Selected: contract-level live assertions.
+  - Pro: stable across provider wording variance.
+  - Con: does not assert exact transcript strings from live Groq.
+- Rejected: exact-text assertions against live-provider responses.
+  - Pro: stronger signal if stable.
+  - Con: too brittle for CI.
+
+### Checklist
+
+- [ ] spec reads `GROQ_APIKEY` from env or `/workspace/.env`
+- [ ] live-provider path is optional in CI
+- [ ] deterministic contract test proves transcript survives output failure
+- [ ] docs explain both deterministic and live Groq paths
+
+### Tasks
+
+1. Add `.env` and env-variable fallback helper in the E2E spec.
+2. Add `@output-failure-contract` deterministic test.
+3. Add optional live-provider CI lane or step using `GROQ_APIKEY`.
+4. Update E2E docs with local and CI invocation details.
+
+### Gates
+
+- `playwright --list` shows the new tests
+- deterministic Groq E2E passes locally/CI
+- live-provider path is opt-in and does not run without credentials
+
+### Code Snippet
+
+```ts
+const groqApiKey = process.env.GROQ_APIKEY ?? readWorkspaceEnv('GROQ_APIKEY')
+
+test('keeps streamed text visible when output fails after Groq utterance commit @output-failure-contract', async () => {
+  await expect(page.getByText(`Streamed text: ${fixture.expectedText}`)).toBeVisible()
+  await expect(page.getByText(/Streaming output failed:/)).toBeVisible()
+})
+```
+
+## Ticket T5 (P4): Hardening and Observability
+
+### Goal
+
+Clean up the remaining latency accounting and observability risks after the core flow is fixed.
+
+### Approach
+
+- separate upload backlog from downstream output latency
+- improve activity events for utterance commit versus output failure
+- add targeted diagnostics for queue saturation and stop drain timing
+
+### Scope Files
+
+- `src/main/services/streaming/groq-rolling-upload-adapter.ts`
+- `src/main/services/streaming/streaming-activity-publisher.ts`
+- `src/renderer/**` activity consumers if needed
+- docs and test files adjacent to the touched code
+
+### Trade-offs
+
+- Selected: more precise metrics and logs.
+  - Pro: easier to debug future field failures.
+  - Con: extra event surface and maintenance.
+- Rejected: leave backlog and output latency conflated.
+  - Pro: no more code.
+  - Con: hides the next class of throughput bugs.
+
+### Checklist
+
+- [ ] queue/backpressure reflects upload pressure, not paste latency
+- [ ] activity log distinguishes transcript commit from output failure
+- [ ] tests cover backlog and observability semantics
+
+### Tasks
+
+1. Audit queue capacity accounting against upload and emit phases.
+2. Split or rename diagnostics where needed.
+3. Add tests for slow output versus full upload queue.
+4. Document remaining operational risks.
+
+### Gates
+
+- queue saturation logs match the actual bottleneck
+- no new user-facing regressions in Activity
+
+## Exit Criteria
+
+- deterministic Groq chunk E2E passes
+- optional live Groq E2E passes when `GROQ_APIKEY` is configured
+- renderer no longer drops VAD-sealed utterances
+- `user_stop` no longer loses already-uploaded Groq utterances
+- output failure is visible without hiding committed transcript
+- existing batch STT tests continue to pass unchanged

--- a/e2e/electron-groq-streaming-recording.e2e.ts
+++ b/e2e/electron-groq-streaming-recording.e2e.ts
@@ -19,11 +19,16 @@ type Fixtures = {
 type StreamingFixture = {
   audioFileName: string
   expectedText: string
+  expectedUtteranceTexts?: string[]
 }
 
 interface LaunchElectronAppOptions {
   extraEnv?: Record<string, string>
   chromiumArgs?: string[]
+}
+
+interface GroqFetchStubOptions {
+  splitResponsesByUtterance?: boolean
 }
 
 const STREAMING_AUDIO_FIXTURES: StreamingFixture[] = [
@@ -33,12 +38,64 @@ const STREAMING_AUDIO_FIXTURES: StreamingFixture[] = [
   },
   {
     audioFileName: 'Recording-2-sentences-jp.wav',
-    expectedText: 'これは二つ目のレコーディングのテストです。二つ目の文章を話しています。'
+    expectedText: 'これは二つ目のレコーディングのテストです。二つ目の文章を話しています。',
+    expectedUtteranceTexts: [
+      'これは二つ目のレコーディングのテストです。',
+      '二つ目の文章を話しています。'
+    ]
   }
 ]
 
 const GROQ_ACTIVE_SESSION_MESSAGE = 'Streaming session active with Groq Whisper Large v3 Turbo.'
 const PLAYWRIGHT_ACCESSIBILITY_BYPASS_ENV = 'PLAYWRIGHT_BYPASS_ACCESSIBILITY'
+const NON_MACOS_OUTPUT_FAILURE_MESSAGE =
+  'Streaming error (streaming_output_failed_partial): Paste-at-cursor is only supported on macOS.'
+
+const readEnvFromFile = (filePath: string, key: string): string => {
+  if (!fs.existsSync(filePath)) {
+    return ''
+  }
+
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/)
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue
+    }
+    const separatorIndex = trimmed.indexOf('=')
+    if (separatorIndex < 0) {
+      continue
+    }
+    const candidateKey = trimmed.slice(0, separatorIndex).trim()
+    if (candidateKey !== key) {
+      continue
+    }
+    const rawValue = trimmed.slice(separatorIndex + 1).trim()
+    return rawValue.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1')
+  }
+
+  return ''
+}
+
+const resolveGroqApiKey = (): string => {
+  const fromProcess = (process.env.GROQ_APIKEY ?? '').trim()
+  if (fromProcess.length > 0) {
+    return fromProcess
+  }
+
+  const candidatePaths = [
+    path.resolve(process.cwd(), '.env'),
+    '/workspace/.env'
+  ]
+  for (const candidatePath of candidatePaths) {
+    const value = readEnvFromFile(candidatePath, 'GROQ_APIKEY').trim()
+    if (value.length > 0) {
+      return value
+    }
+  }
+
+  return ''
+}
 
 const resolveFixturePath = (audioFileName: string): string => {
   const fixturePath = path.resolve(process.cwd(), 'e2e', 'fixtures', audioFileName)
@@ -68,22 +125,61 @@ const launchElectronApp = async (options?: LaunchElectronAppOptions): Promise<El
   })
 }
 
-const configureGroqStreamingSettings = async (page: Page): Promise<void> => {
+const configureGroqStreamingSettings = async (page: Page, groqApiKey = 'e2e-fake-groq-key'): Promise<void> => {
   await page.waitForFunction(() => Boolean(window.speechToTextApi), { timeout: 10_000 })
-  await page.evaluate(async () => {
-    await window.speechToTextApi.setApiKey('groq', 'e2e-fake-groq-key')
+  await page.evaluate(async ({ apiKey }) => {
+    await window.speechToTextApi.setApiKey('groq', apiKey)
     const settings = await window.speechToTextApi.getSettings()
+    const processing = settings.processing ?? {
+      mode: 'default',
+      streaming: {
+        enabled: false,
+        provider: null,
+        transport: null,
+        model: null,
+        apiKeyRef: null,
+        baseUrlOverride: null,
+        outputMode: null,
+        maxInFlightTransforms: 2,
+        language: 'auto',
+        delimiterPolicy: {
+          mode: 'space',
+          value: null
+        }
+      }
+    }
+    const output = settings.output ?? {
+      selectedTextSource: 'transcript',
+      transcript: {
+        copyToClipboard: false,
+        pasteAtCursor: true
+      },
+      transformed: {
+        copyToClipboard: false,
+        pasteAtCursor: false
+      }
+    }
+    const transcription = settings.transcription ?? {
+      provider: 'groq',
+      model: 'whisper-large-v3-turbo',
+      outputLanguage: 'ja',
+      temperature: 0,
+      hints: {
+        contextText: '',
+        dictionaryTerms: []
+      }
+    }
     await window.speechToTextApi.setSettings({
       ...settings,
       output: {
-        ...settings.output,
+        ...output,
         selectedTextSource: 'transcript'
       },
       processing: {
-        ...settings.processing,
+        ...processing,
         mode: 'streaming',
         streaming: {
-          ...settings.processing.streaming,
+          ...processing.streaming,
           enabled: true,
           provider: 'groq_whisper_large_v3_turbo',
           transport: 'rolling_upload',
@@ -98,13 +194,13 @@ const configureGroqStreamingSettings = async (page: Page): Promise<void> => {
         }
       },
       transcription: {
-        ...settings.transcription,
+        ...transcription,
         provider: 'groq',
         model: 'whisper-large-v3-turbo',
         outputLanguage: 'ja'
       }
     })
-  })
+  }, { apiKey: groqApiKey })
   await page.reload()
   await page.waitForSelector('[data-route-tab="activity"]')
   await page.waitForFunction(async () => {
@@ -202,6 +298,63 @@ const installSyntheticWavMicrophone = async (page: Page, audioFileName: string):
   }, { encodedWav: wavBase64 })
 }
 
+const installUtteranceIndexTracker = async (page: Page): Promise<void> => {
+  await page.evaluate(() => {
+    const win = window as Window & {
+      speechToTextApi: typeof window.speechToTextApi
+      __e2eNextStreamingUtteranceIndex?: number
+      __e2eObservedUtteranceChunks?: Array<{
+        utteranceIndex: number
+        reason: string
+        hadCarryover: boolean
+        wavBytesByteLength: number
+      }>
+      __e2eOriginalPushStreamingAudioUtteranceChunk?: typeof window.speechToTextApi.pushStreamingAudioUtteranceChunk
+    }
+
+    win.__e2eNextStreamingUtteranceIndex = 0
+    win.__e2eObservedUtteranceChunks = []
+    if (!win.__e2eOriginalPushStreamingAudioUtteranceChunk) {
+      const api = win.speechToTextApi
+      win.__e2eOriginalPushStreamingAudioUtteranceChunk = api.pushStreamingAudioUtteranceChunk.bind(api)
+      api.pushStreamingAudioUtteranceChunk = async (
+        chunk: Parameters<typeof api.pushStreamingAudioUtteranceChunk>[0]
+      ) => {
+        const nextIndex = typeof win.__e2eNextStreamingUtteranceIndex === 'number'
+          ? win.__e2eNextStreamingUtteranceIndex
+          : 0
+        win.__e2eNextStreamingUtteranceIndex = Math.max(nextIndex + 1, chunk.utteranceIndex + 1)
+        win.__e2eObservedUtteranceChunks?.push({
+          utteranceIndex: chunk.utteranceIndex,
+          reason: chunk.reason,
+          hadCarryover: chunk.hadCarryover,
+          wavBytesByteLength: chunk.wavBytes.byteLength
+        })
+        await win.__e2eOriginalPushStreamingAudioUtteranceChunk!(chunk)
+      }
+    }
+  })
+}
+
+type RendererStructuredLog = {
+  event?: string
+  context?: Record<string, unknown>
+}
+
+const installRendererStructuredLogCollector = (page: Page): Array<RendererStructuredLog> => {
+  const logs: RendererStructuredLog[] = []
+  page.on('console', (message) => {
+    const text = message.text()
+    try {
+      const parsed = JSON.parse(text) as RendererStructuredLog
+      logs.push(parsed)
+    } catch {
+      // Ignore non-JSON console output from the page.
+    }
+  })
+  return logs
+}
+
 const pushFixtureUtterance = async (page: Page, audioFileName: string): Promise<void> => {
   const wavBase64 = fs.readFileSync(resolveFixturePath(audioFileName)).toString('base64')
   await page.evaluate(async ({ encodedWav }) => {
@@ -273,6 +426,9 @@ const pushFixtureUtterance = async (page: Page, audioFileName: string): Promise<
     if (!session.sessionId) {
       throw new Error('Streaming session is not active; cannot inject fixture utterance.')
     }
+    const win = window as Window & {
+      __e2eNextStreamingUtteranceIndex?: number
+    }
 
     const decoderContext = new AudioContext()
     try {
@@ -280,11 +436,14 @@ const pushFixtureUtterance = async (page: Page, audioFileName: string): Promise<
       const mono16k = await resampleToMono16k(decoded)
       const endedAtEpochMs = Date.now()
       const startedAtEpochMs = endedAtEpochMs - Math.round((mono16k.length / 16_000) * 1000)
+      const utteranceIndex = typeof win.__e2eNextStreamingUtteranceIndex === 'number'
+        ? win.__e2eNextStreamingUtteranceIndex
+        : 0
       await window.speechToTextApi.pushStreamingAudioUtteranceChunk({
         sessionId: session.sessionId,
         sampleRateHz: 16_000,
         channels: 1,
-        utteranceIndex: 0,
+        utteranceIndex,
         wavBytes: encodePcm16Mono16kWav(mono16k),
         wavFormat: 'wav_pcm_s16le_mono_16000',
         startedAtEpochMs,
@@ -300,9 +459,31 @@ const pushFixtureUtterance = async (page: Page, audioFileName: string): Promise<
   }, { encodedWav: wavBase64 })
 }
 
+const startStreamingSessionFromApi = async (page: Page): Promise<void> => {
+  await page.evaluate(async () => {
+    await window.speechToTextApi.runRecordingCommand('toggleRecording')
+  })
+  await page.waitForFunction(async () => {
+    const snapshot = await window.speechToTextApi.getStreamingSessionSnapshot()
+    return snapshot.state === 'active' && snapshot.sessionId !== null
+  }, { timeout: 15_000 })
+}
+
+const stopStreamingSessionFromApi = async (page: Page): Promise<void> => {
+  const snapshot = await page.evaluate(async () => await window.speechToTextApi.getStreamingSessionSnapshot())
+  if (!snapshot.sessionId) {
+    return
+  }
+
+  await page.evaluate(async () => {
+    await window.speechToTextApi.runRecordingCommand('toggleRecording')
+  })
+}
+
 const installGroqFetchStub = async (
   electronApp: ElectronApplication,
-  fixture: StreamingFixture
+  fixture: StreamingFixture,
+  options?: GroqFetchStubOptions
 ): Promise<void> => {
   await electronApp.evaluate(async ({ app }, input) => {
     void app
@@ -314,7 +495,9 @@ const installGroqFetchStub = async (
     }
 
     globalScope.__e2eGroqFetchRequests = []
-    globalScope.__e2eGroqFetchTexts = [input.expectedText]
+    globalScope.__e2eGroqFetchTexts = input.splitResponsesByUtterance
+      ? input.expectedUtteranceTexts?.slice() ?? [input.expectedText]
+      : [input.expectedText]
     if (!globalScope.__e2eGroqFetchStubInstalled) {
       globalScope.__e2eOriginalFetch = globalThis.fetch.bind(globalThis)
       globalThis.fetch = async (resource: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -351,7 +534,10 @@ const installGroqFetchStub = async (
       }
       globalScope.__e2eGroqFetchStubInstalled = true
     }
-  }, fixture)
+  }, {
+    ...fixture,
+    splitResponsesByUtterance: options?.splitResponsesByUtterance ?? false
+  })
 }
 
 const test = base.extend<Fixtures>({
@@ -364,6 +550,95 @@ const test = base.extend<Fixtures>({
     const window = await electronApp.firstWindow()
     await window.waitForSelector('[data-route-tab="activity"]')
     await use(window)
+  }
+})
+
+test('splits Recording-2-sentences-jp.wav into two speech_pause Groq utterances via natural browser VAD @natural-vad-pause', async () => {
+  test.setTimeout(90_000)
+
+  const fixture = STREAMING_AUDIO_FIXTURES.find((candidate) => candidate.audioFileName === 'Recording-2-sentences-jp.wav')
+  if (!fixture || !fixture.expectedUtteranceTexts || fixture.expectedUtteranceTexts.length !== 2) {
+    throw new Error('Expected the two-sentence Japanese fixture with two utterance texts to be configured.')
+  }
+
+  const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'speech-to-text-groq-natural-vad-e2e-'))
+  const xdgConfigHome = path.join(profileRoot, 'xdg-config')
+  const app = await launchElectronApp({
+    extraEnv: {
+      XDG_CONFIG_HOME: xdgConfigHome,
+      GROQ_APIKEY: 'e2e-fake-groq-key',
+      [PLAYWRIGHT_ACCESSIBILITY_BYPASS_ENV]: '1'
+    }
+  })
+
+  try {
+    const page = await app.firstWindow()
+    const rendererLogs = installRendererStructuredLogCollector(page)
+    await page.waitForSelector('[data-route-tab="activity"]')
+    await configureGroqStreamingSettings(page)
+    await installGroqFetchStub(app, fixture, { splitResponsesByUtterance: true })
+    await installSyntheticWavMicrophone(page, fixture.audioFileName)
+    await page.locator('[data-route-tab="activity"]').click()
+
+    await startStreamingSessionFromApi(page)
+    await expect(page.getByText(GROQ_ACTIVE_SESSION_MESSAGE)).toBeVisible({
+      timeout: 15_000
+    })
+
+    await expect.poll(() => {
+      return rendererLogs.filter((entry) => {
+        return entry.event === 'streaming.groq_vad.utterance_ready'
+          && entry.context?.reason === 'speech_pause'
+      }).length
+    }, { timeout: 25_000 }).toBeGreaterThanOrEqual(2)
+
+    const observedUtteranceLogs = rendererLogs.filter((entry) => {
+      return entry.event === 'streaming.groq_vad.utterance_ready'
+        && entry.context?.reason === 'speech_pause'
+    })
+
+    expect(observedUtteranceLogs.slice(0, 2)).toEqual([
+      expect.objectContaining({
+        context: expect.objectContaining({
+          utteranceIndex: 0,
+          reason: 'speech_pause',
+          hadCarryover: false,
+          samples: expect.any(Number)
+        })
+      }),
+      expect.objectContaining({
+        context: expect.objectContaining({
+          utteranceIndex: 1,
+          reason: 'speech_pause',
+          hadCarryover: false,
+          samples: expect.any(Number)
+        })
+      })
+    ])
+
+    await expect(page.getByText(`Streamed text: ${fixture.expectedUtteranceTexts[0]}`)).toBeVisible({
+      timeout: 25_000
+    })
+    await expect(page.getByText(`Streamed text: ${fixture.expectedUtteranceTexts[1]}`)).toBeVisible({
+      timeout: 25_000
+    })
+
+    await expect.poll(async () => {
+      return await app.evaluate(async () => {
+        const globalScope = globalThis as typeof globalThis & {
+          __e2eGroqFetchRequests?: Array<{ url: string; method: string }>
+        }
+        return globalScope.__e2eGroqFetchRequests?.length ?? 0
+      })
+    }, { timeout: 10_000 }).toBeGreaterThanOrEqual(2)
+
+    await stopStreamingSessionFromApi(page)
+    await expect(page.getByText('Streaming session stopped.')).toBeVisible({
+      timeout: 15_000
+    })
+  } finally {
+    await app.close()
+    fs.rmSync(profileRoot, { recursive: true, force: true })
   }
 })
 
@@ -385,14 +660,12 @@ for (const fixture of STREAMING_AUDIO_FIXTURES) {
       const page = await app.firstWindow()
       await page.waitForSelector('[data-route-tab="activity"]')
       await configureGroqStreamingSettings(page)
+      await installUtteranceIndexTracker(page)
       await installGroqFetchStub(app, fixture)
       await installSyntheticWavMicrophone(page, fixture.audioFileName)
       await page.locator('[data-route-tab="activity"]').click()
 
-      const startButton = page.getByRole('button', { name: 'Start recording' })
-      await expect(startButton).toBeEnabled()
-      await startButton.click()
-
+      await startStreamingSessionFromApi(page)
       await expect(page.getByText(GROQ_ACTIVE_SESSION_MESSAGE)).toBeVisible({
         timeout: 15_000
       })
@@ -413,7 +686,7 @@ for (const fixture of STREAMING_AUDIO_FIXTURES) {
         })
       }, { timeout: 10_000 }).toBeGreaterThan(0)
 
-      await page.getByRole('button', { name: 'Stop recording' }).click()
+      await stopStreamingSessionFromApi(page)
       await expect(page.getByText('Streaming session stopped.')).toBeVisible({
         timeout: 15_000
       })
@@ -448,13 +721,11 @@ for (const fixture of STREAMING_AUDIO_FIXTURES) {
       const page = await app.firstWindow()
       await page.waitForSelector('[data-route-tab="activity"]')
       await configureGroqStreamingSettings(page)
+      await installUtteranceIndexTracker(page)
       await installGroqFetchStub(app, fixture)
       await page.locator('[data-route-tab="activity"]').click()
 
-      const startButton = page.getByRole('button', { name: 'Start recording' })
-      await expect(startButton).toBeEnabled()
-      await startButton.click()
-
+      await startStreamingSessionFromApi(page)
       await expect(page.getByText(GROQ_ACTIVE_SESSION_MESSAGE)).toBeVisible({
         timeout: 15_000
       })
@@ -475,7 +746,7 @@ for (const fixture of STREAMING_AUDIO_FIXTURES) {
         })
       }, { timeout: 10_000 }).toBeGreaterThan(0)
 
-      await page.getByRole('button', { name: 'Stop recording' }).click()
+      await stopStreamingSessionFromApi(page)
       await expect(page.getByText('Streaming session stopped.')).toBeVisible({
         timeout: 15_000
       })
@@ -487,4 +758,95 @@ for (const fixture of STREAMING_AUDIO_FIXTURES) {
       fs.rmSync(profileRoot, { recursive: true, force: true })
     }
   })
+
+  test(`keeps streamed text visible when output fails after Groq utterance commit from ${fixture.audioFileName} @output-failure-contract`, async () => {
+    test.skip(process.platform === 'darwin', 'Non-macOS contract test for deterministic output failure messaging')
+    test.setTimeout(90_000)
+
+    const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'speech-to-text-groq-streaming-output-failure-e2e-'))
+    const xdgConfigHome = path.join(profileRoot, 'xdg-config')
+    const app = await launchElectronApp({
+      extraEnv: {
+        XDG_CONFIG_HOME: xdgConfigHome,
+        GROQ_APIKEY: 'e2e-fake-groq-key'
+      }
+    })
+
+    try {
+      const page = await app.firstWindow()
+      await page.waitForSelector('[data-route-tab="activity"]')
+      await configureGroqStreamingSettings(page)
+      await installUtteranceIndexTracker(page)
+      await installGroqFetchStub(app, fixture)
+      await installSyntheticWavMicrophone(page, fixture.audioFileName)
+      await page.locator('[data-route-tab="activity"]').click()
+
+      await startStreamingSessionFromApi(page)
+      await expect(page.getByText(GROQ_ACTIVE_SESSION_MESSAGE)).toBeVisible({
+        timeout: 15_000
+      })
+      await pushFixtureUtterance(page, fixture.audioFileName)
+      await expect(page.getByText(`Streamed text: ${fixture.expectedText}`)).toBeVisible({
+        timeout: 25_000
+      })
+      await expect(page.getByText(NON_MACOS_OUTPUT_FAILURE_MESSAGE).first()).toBeVisible({
+        timeout: 25_000
+      })
+      await expect(page.getByText('Streaming session failed.')).toHaveCount(0)
+
+      await stopStreamingSessionFromApi(page)
+      await expect(page.getByText('Streaming session stopped.')).toBeVisible({
+        timeout: 15_000
+      })
+    } finally {
+      await app.close()
+      fs.rmSync(profileRoot, { recursive: true, force: true })
+    }
+  })
 }
+
+test('streams Groq recording through the live provider utterance IPC path @live-provider @utterance-ipc', async () => {
+  test.setTimeout(90_000)
+
+  const groqApiKey = resolveGroqApiKey()
+  test.skip(groqApiKey.length === 0, 'No GROQ_APIKEY configured in env or /workspace/.env')
+
+  const fixture = STREAMING_AUDIO_FIXTURES[0]!
+  const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'speech-to-text-groq-live-provider-e2e-'))
+  const xdgConfigHome = path.join(profileRoot, 'xdg-config')
+  const app = await launchElectronApp({
+    extraEnv: {
+      XDG_CONFIG_HOME: xdgConfigHome,
+      GROQ_APIKEY: groqApiKey,
+      [PLAYWRIGHT_ACCESSIBILITY_BYPASS_ENV]: '1'
+    }
+  })
+
+  try {
+    const page = await app.firstWindow()
+    await page.waitForSelector('[data-route-tab="activity"]')
+    await configureGroqStreamingSettings(page, groqApiKey)
+    await installUtteranceIndexTracker(page)
+    await installSyntheticWavMicrophone(page, fixture.audioFileName)
+    await page.locator('[data-route-tab="activity"]').click()
+
+    await startStreamingSessionFromApi(page)
+    await expect(page.getByText(GROQ_ACTIVE_SESSION_MESSAGE)).toBeVisible({
+      timeout: 15_000
+    })
+    await pushFixtureUtterance(page, fixture.audioFileName)
+    await expect(page.getByText(/^Streamed text:\s.+/)).toBeVisible({
+      timeout: 30_000
+    })
+    await expect(page.getByText('Streaming session failed.')).toHaveCount(0)
+    await expect(page.getByText(/Streaming error \(/)).toHaveCount(0)
+
+    await stopStreamingSessionFromApi(page)
+    await expect(page.getByText('Streaming session stopped.')).toBeVisible({
+      timeout: 15_000
+    })
+  } finally {
+    await app.close()
+    fs.rmSync(profileRoot, { recursive: true, force: true })
+  }
+})

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -103,16 +103,12 @@ describe('GroqRollingUploadAdapter', () => {
     }))
     await adapter.stop('user_stop')
 
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1])
+    expect(onFinalSegment).toHaveBeenCalledOnce()
     expect(onFinalSegment).toHaveBeenNthCalledWith(1, expect.objectContaining({
       sessionId: 'session-1',
-      text: 'hello',
+      sequence: 0,
+      text: 'hello world',
       startedAt: '1970-01-01T00:00:01.000Z',
-      endedAt: '1970-01-01T00:00:01.500Z'
-    }))
-    expect(onFinalSegment).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      text: 'world',
-      startedAt: '1970-01-01T00:00:01.500Z',
       endedAt: '1970-01-01T00:00:02.000Z'
     }))
   })
@@ -669,15 +665,14 @@ describe('GroqRollingUploadAdapter', () => {
     expect(seenSignals[0]?.aborted).toBe(true)
   })
 
-  it('lets already-uploaded segments finish committing even when final-segment processing is slow', async () => {
-    let releaseFirstSegment: (() => void) | null = null
-    const onFinalSegment = vi.fn(async (segment: { text: string }) => {
-      if (segment.text === 'hello') {
-        await new Promise<void>((resolve) => {
-          releaseFirstSegment = resolve
-        })
-      }
+  it('does not fail the session when commit processing is slow during user_stop drain', async () => {
+    let releaseCommit: (() => void) | null = null
+    const onFinalSegment = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        releaseCommit = resolve
+      })
     })
+    let releaseStopBudget: (() => void) | null = null
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
       config: LOCAL_CONFIG,
@@ -688,12 +683,11 @@ describe('GroqRollingUploadAdapter', () => {
     }, {
       secretStore: { getApiKey: vi.fn(() => 'test-key') },
       fetchFn: vi.fn(async () => new Response(JSON.stringify({
-        text: 'hello world',
-        segments: [
-          { start: 0, end: 0.5, text: 'hello' },
-          { start: 0.5, end: 1.0, text: 'world' }
-        ]
-      }), { status: 200 }))
+        text: 'hello world'
+      }), { status: 200 })),
+      stopBudgetDelayMs: vi.fn(async (_ms: number): Promise<void> => await new Promise<void>((resolve) => {
+        releaseStopBudget = resolve
+      }))
     })
 
     await adapter.start()
@@ -708,15 +702,14 @@ describe('GroqRollingUploadAdapter', () => {
       expect(onFinalSegment).toHaveBeenCalledTimes(1)
     })
 
-    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
-      text: 'hello'
-    }))
-    ;(releaseFirstSegment as (() => void) | null)?.()
+    const release = releaseCommit as (() => void) | null
+    if (!release) {
+      throw new Error('Expected commit processing to be pending.')
+    }
+    release()
     await stopPromise
-    expect(onFinalSegment).toHaveBeenCalledTimes(2)
-    expect(onFinalSegment).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      text: 'world'
-    }))
+    releaseStopBudget?.()
+    expect(onFinalSegment).toHaveBeenCalledTimes(1)
   })
 
   it('counts slow final-segment emission as queue backlog for later utterances', async () => {
@@ -843,20 +836,21 @@ describe('GroqRollingUploadAdapter', () => {
     expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['first', 'second'])
   })
 
-  it('fails the session when final-segment commit exceeds the stop budget', async () => {
-    const onFailure = vi.fn()
-    const stopBudgetDelayMs = vi
-      .fn()
-      .mockImplementationOnce(async () => await new Promise(() => {}))
-      .mockImplementationOnce(async () => {})
+  it('does not apply the stop budget while active-session Groq commit work is still running', async () => {
+    let releaseCommit: (() => void) | null = null
+    let commitCompleted = false
+    const stopBudgetDelayMs = vi.fn(async () => {})
     const adapter = new GroqRollingUploadAdapter({
       sessionId: 'session-1',
       config: LOCAL_CONFIG,
       callbacks: {
         onFinalSegment: vi.fn(async () => {
-          await new Promise(() => {})
+          await new Promise<void>((resolve) => {
+            releaseCommit = resolve
+          })
+          commitCompleted = true
         }),
-        onFailure
+        onFailure: vi.fn()
       }
     }, {
       secretStore: { getApiKey: vi.fn(() => 'test-key') },
@@ -871,12 +865,48 @@ describe('GroqRollingUploadAdapter', () => {
       endMs: 500,
       reason: 'speech_pause'
     }))
-    await adapter.stop('user_stop')
+    await vi.waitFor(() => {
+      expect(releaseCommit).not.toBeNull()
+    })
+    ;(releaseCommit as (() => void) | null)?.()
+    await vi.waitFor(() => {
+      expect(stopBudgetDelayMs).not.toHaveBeenCalled()
+    })
+    await vi.waitFor(() => {
+      expect(commitCompleted).toBe(true)
+    })
+    await adapter.stop('user_cancel')
+  })
 
-    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({
-      code: 'groq_final_segment_commit_failed',
-      message: expect.stringContaining('timed out')
+  it('fails the session when final-segment commit exceeds the stop budget during user_stop drain', async () => {
+    const stopBudgetDelayMs = vi
+      .fn()
+      .mockImplementationOnce(async () => await new Promise(() => {}))
+      .mockImplementationOnce(async () => {})
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment: vi.fn(async () => {
+          await new Promise(() => {})
+        }),
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({ text: 'hello' }), { status: 200 })),
+      stopBudgetDelayMs
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
     }))
+
+    await expect(adapter.stop('user_stop')).rejects.toThrow('Groq final segment commit timed out')
   })
 
   it('uses monotonic final segment sequences across utterances with many provider segments', async () => {
@@ -923,7 +953,41 @@ describe('GroqRollingUploadAdapter', () => {
     }))
     await adapter.stop('user_stop')
 
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1, 2])
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['alpha', 'bravo', 'charlie'])
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.sequence)).toEqual([0, 1])
+    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['alpha bravo', 'charlie'])
+  })
+
+  it('falls back to top-level Groq text when verbose_json segments are unusable', async () => {
+    const onFinalSegment = vi.fn()
+    const adapter = new GroqRollingUploadAdapter({
+      sessionId: 'session-1',
+      config: LOCAL_CONFIG,
+      callbacks: {
+        onFinalSegment,
+        onFailure: vi.fn()
+      }
+    }, {
+      secretStore: { getApiKey: vi.fn(() => 'test-key') },
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({
+        text: 'fallback text',
+        segments: [
+          { id: 1, text: 'missing timestamps' }
+        ]
+      }), { status: 200 }))
+    })
+
+    await adapter.start()
+    await adapter.pushAudioUtteranceChunk(makeUtterance({
+      utteranceIndex: 0,
+      startMs: 0,
+      endMs: 500,
+      reason: 'speech_pause'
+    }))
+    await adapter.stop('user_stop')
+
+    expect(onFinalSegment).toHaveBeenCalledWith(expect.objectContaining({
+      sequence: 0,
+      text: 'fallback text'
+    }))
   })
 })

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -65,6 +65,12 @@ interface CompletedUtteranceUpload {
   response: GroqVerboseResponse
 }
 
+interface NormalizedGroqUtteranceText {
+  text: string
+  startedAtEpochMs: number
+  endedAtEpochMs: number
+}
+
 const GROQ_DEFAULT_BASE = 'https://api.groq.com'
 const GROQ_STT_PATH = '/openai/v1/audio/transcriptions'
 const GROQ_USER_STOP_BUDGET_MS = 3_000
@@ -174,7 +180,13 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       return
     }
 
-    await this.finishStopDrain()
+    const commitDrainOutcome = await Promise.race([
+      this.finishStopDrain().then(() => 'completed' as const),
+      this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
+    ])
+    if (commitDrainOutcome === 'timed_out') {
+      throw new Error(`Groq final segment commit timed out after ${GROQ_USER_STOP_BUDGET_MS} ms.`)
+    }
   }
 
   async prepareForRendererStop(reason: StreamingSessionStopReason): Promise<void> {
@@ -382,38 +394,12 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   }
 
   private async emitCompletedUtterance(utterance: CompletedUtteranceUpload): Promise<void> {
-    const segments = utterance.response.segments ?? []
-    if (segments.length > 0) {
-      for (const segment of segments) {
-        if (typeof segment.start !== 'number' || typeof segment.end !== 'number' || typeof segment.text !== 'string') {
-          continue
-        }
-
-        const absoluteStartedAtEpochMs = utterance.startedAtEpochMs + Math.round(segment.start * 1000)
-        const absoluteEndedAtEpochMs = utterance.startedAtEpochMs + Math.round(segment.end * 1000)
-        if (absoluteEndedAtEpochMs <= this.lastCommittedEndedAtEpochMs) {
-          continue
-        }
-
-        let text = segment.text.trim()
-        if (absoluteStartedAtEpochMs < this.lastCommittedEndedAtEpochMs || utterance.hadCarryover) {
-          text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
-        }
-        if (text.length === 0) {
-          continue
-        }
-
-        await this.emitFinalSegment({
-          text,
-          startedAtEpochMs: absoluteStartedAtEpochMs,
-          endedAtEpochMs: absoluteEndedAtEpochMs
-        })
-        this.rememberCommittedText(text, absoluteEndedAtEpochMs)
-      }
+    const normalized = normalizeGroqUtteranceText(utterance)
+    if (!normalized) {
       return
     }
 
-    let text = (utterance.response.text ?? '').trim()
+    let text = normalized.text
     if (utterance.hadCarryover) {
       text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
     }
@@ -423,10 +409,10 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
 
     await this.emitFinalSegment({
       text,
-      startedAtEpochMs: utterance.startedAtEpochMs,
-      endedAtEpochMs: utterance.endedAtEpochMs
+      startedAtEpochMs: normalized.startedAtEpochMs,
+      endedAtEpochMs: normalized.endedAtEpochMs
     })
-    this.rememberCommittedText(text, utterance.endedAtEpochMs)
+    this.rememberCommittedText(text, normalized.endedAtEpochMs)
   }
 
   private async emitFinalSegment(params: {
@@ -443,13 +429,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       startedAt: new Date(params.startedAtEpochMs).toISOString(),
       endedAt: new Date(params.endedAtEpochMs).toISOString()
     }
-    const outcome = await Promise.race([
-      Promise.resolve(this.params.callbacks.onFinalSegment(segment)).then(() => 'completed' as const),
-      this.stopBudgetDelayMs(GROQ_USER_STOP_BUDGET_MS).then(() => 'timed_out' as const)
-    ])
-    if (outcome === 'timed_out') {
-      throw new Error(`Groq final segment commit timed out after ${GROQ_USER_STOP_BUDGET_MS} ms.`)
-    }
+    await this.params.callbacks.onFinalSegment(segment)
   }
 
   private rememberCommittedText(text: string, endedAtEpochMs: number): void {
@@ -550,6 +530,34 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       resolve()
     }
     this.queueCapacityWaiters.clear()
+  }
+}
+
+const normalizeGroqUtteranceText = (utterance: CompletedUtteranceUpload): NormalizedGroqUtteranceText | null => {
+  const topLevelText = utterance.response.text?.trim() ?? ''
+  if (topLevelText.length > 0) {
+    return {
+      text: topLevelText,
+      startedAtEpochMs: utterance.startedAtEpochMs,
+      endedAtEpochMs: utterance.endedAtEpochMs
+    }
+  }
+
+  const usableSegments = (utterance.response.segments ?? []).filter((segment) =>
+    typeof segment.start === 'number' &&
+    typeof segment.end === 'number' &&
+    typeof segment.text === 'string' &&
+    segment.text.trim().length > 0
+  )
+
+  if (usableSegments.length === 0) {
+    return null
+  }
+
+  return {
+    text: usableSegments.map((segment) => segment.text!.trim()).join(' ').trim(),
+    startedAtEpochMs: utterance.startedAtEpochMs + Math.round((usableSegments[0]?.start ?? 0) * 1000),
+    endedAtEpochMs: utterance.startedAtEpochMs + Math.round((usableSegments.at(-1)?.end ?? 0) * 1000)
   }
 }
 

--- a/src/main/services/streaming/streaming-segment-router.test.ts
+++ b/src/main/services/streaming/streaming-segment-router.test.ts
@@ -211,6 +211,55 @@ describe('StreamingSegmentRouter', () => {
     expect(publishError).not.toHaveBeenCalled()
   })
 
+  it('publishes committed raw text before reporting partial output failure', async () => {
+    const publishSegment = vi.fn()
+    const publishError = vi.fn()
+    const router = new StreamingSegmentRouter('session-1', {
+      ...TRANSFORMED_CONFIG,
+      outputMode: 'stream_raw_dictation',
+      transformationProfile: null
+    }, {
+      outputCoordinator: new SerialOutputCoordinator(),
+      outputService: {
+        applyStreamingSegmentWithDetail: vi.fn(async () => ({
+          status: 'output_failed_partial' as const,
+          message: 'Paste-at-cursor is only supported on macOS.'
+        }))
+      },
+      clipboardPolicy: {
+        canRead: () => false,
+        canWrite: () => true,
+        willWrite: () => {},
+        didWrite: () => {}
+      },
+      transformationService: {
+        transform: async () => ({
+          text: 'unused',
+          model: 'gemini-2.5-flash'
+        })
+      },
+      secretStore: {
+        getApiKey: () => 'google-key'
+      },
+      publishError,
+      publishSegment
+    })
+
+    await expect(router.commitFinalizedSegment(createSegment(0, 'alpha'))).resolves.toEqual({
+      status: 'output_failed_partial',
+      message: 'Paste-at-cursor is only supported on macOS.'
+    })
+
+    expect(publishSegment).toHaveBeenCalledWith(expect.objectContaining({
+      sequence: 0,
+      text: 'alpha'
+    }))
+    expect(publishError).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'streaming_output_failed_partial',
+      message: 'Paste-at-cursor is only supported on macOS.'
+    }))
+  })
+
   it('refreshes rolling summary context so older segments are not dropped forever', async () => {
     const contextPayloads: string[] = []
     const router = new StreamingSegmentRouter('session-1', TRANSFORMED_CONFIG, {

--- a/src/main/services/streaming/streaming-segment-router.ts
+++ b/src/main/services/streaming/streaming-segment-router.ts
@@ -236,7 +236,7 @@ export class StreamingSegmentRouter {
       }))
     }
 
-    if (outputResult.status === 'succeeded' && !this.closed) {
+    if (!this.closed) {
       this.dependencies.publishSegment(createStreamingSegmentEvent(segment))
     }
 

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -636,7 +636,15 @@ describe('InMemoryStreamingSessionController', () => {
       code: 'streaming_output_failed_partial',
       message: 'Enable Accessibility permission in System Settings.'
     })
-    expect(onSegment).not.toHaveBeenCalled()
+    expect(onSegment).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      sequence: 0,
+      text: 'hello',
+      delimiter: ' ',
+      isFinal: true,
+      startedAt: '2026-03-07T00:00:00.000Z',
+      endedAt: '2026-03-07T00:00:01.000Z'
+    })
   })
 
   it('resolves parked segment commits when the session stops', async () => {

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -172,6 +172,24 @@ describe('startGroqBrowserVadCapture', () => {
     }))
   })
 
+  it('trusts MicVAD sealed audio even when speechRealStart never fired', async () => {
+    const encodeWav = vi.fn((audio: Float32Array) => audio.buffer.slice(0))
+    const { vad, sink } = await createCapture({
+      nowMs: () => 7_000,
+      encodeWav
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitFrame({ isSpeech: 0.1, notSpeech: 0.9 }, new Float32Array(400).fill(0.2))
+    await vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
+
+    expect(encodeWav).toHaveBeenCalledOnce()
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      utteranceIndex: 0,
+      reason: 'speech_pause'
+    }))
+  })
+
   it('uses epoch time for utterance timestamps even when the monotonic clock differs', async () => {
     const { vad, sink } = await createCapture({
       nowMs: () => 75,
@@ -365,6 +383,32 @@ describe('startGroqBrowserVadCapture', () => {
     }))
   })
 
+  it('preserves the short explicit-stop tail after a max_chunk continuation', async () => {
+    const { capture, vad, sink } = await createCapture({
+      nowMs: () => 10_000,
+      maxUtteranceMs: 200
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(1_600).fill(0.2))
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(1_600).fill(0.2))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(400).fill(0.2))
+    await capture.stop()
+
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      utteranceIndex: 0,
+      reason: 'max_chunk'
+    }))
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      utteranceIndex: 1,
+      reason: 'session_stop'
+    }))
+  })
+
   it('waits for an in-flight speech_pause push before stop completes', async () => {
     let releasePush: (() => void) | null = null
     const sink = {
@@ -398,6 +442,37 @@ describe('startGroqBrowserVadCapture', () => {
     await stopPromise
 
     expect(vad.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a late MicVAD speech_end callback after stop already flushed session_stop', async () => {
+    const { capture, vad, sink } = await createCapture({
+      nowMs: () => 9_000
+    })
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(3_200).fill(0.2))
+
+    await capture.stop()
+    await vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
+
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledTimes(1)
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      reason: 'session_stop'
+    }))
+  })
+
+  it('does not let cancel trigger a late MicVAD speech_end flush', async () => {
+    const { capture, vad, sink } = await createCapture()
+
+    await vad.emitSpeechStart()
+    await vad.emitSpeechRealStart()
+    await vad.emitFrame({ isSpeech: 0.9, notSpeech: 0.1 }, new Float32Array(3_200).fill(0.2))
+
+    await capture.cancel()
+    await vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
+
+    expect(sink.pushStreamingAudioUtteranceChunk).not.toHaveBeenCalled()
   })
 
   it('signals backpressure pause and resume when utterance delivery blocks past the threshold', async () => {

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -167,6 +167,8 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       preSpeechPadMs: this.config.preSpeechPadMs,
       minSpeechMs: this.config.minSpeechMs,
       startOnLoad: false,
+      // Keep MicVAD pause passive. This capture owns explicit stop flushing so
+      // `pause()` cannot emit a duplicate library-level SpeechEnd callback.
       submitUserSpeechOnPause: false,
       baseAssetPath: GROQ_BROWSER_VAD_ASSET_PATHS.baseAssetPath,
       onnxWASMBasePath: GROQ_BROWSER_VAD_ASSET_PATHS.onnxWASMBasePath,
@@ -189,9 +191,9 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       onVADMisfire: () => {
         this.handleMisfire()
       },
-      onSpeechEnd: async (_audio) => {
+      onSpeechEnd: async (sealedAudio) => {
         const generation = this.callbackGeneration
-        await this.handleSpeechEnd(generation)
+        await this.handleSpeechEnd(generation, sealedAudio)
       }
     }
   }
@@ -299,7 +301,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
     this.resetSpeechWindow()
   }
 
-  private async handleSpeechEnd(generation: number): Promise<void> {
+  private async handleSpeechEnd(generation: number, sealedAudio: Float32Array): Promise<void> {
     if (this.stopped || this.stopping || this.ignoreVadSpeechEnd || generation !== this.callbackGeneration) {
       return
     }
@@ -309,12 +311,12 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       return
     }
 
-    if (!this.hasValidSpeechWindow() || this.liveFrames.length === 0) {
+    if (sealedAudio.length === 0) {
       this.resetSpeechWindow()
       return
     }
 
-    const audio = concatFrames(this.liveFrames)
+    const audio = new Float32Array(sealedAudio)
     const hadCarryover = this.nextUtteranceHadCarryover
     this.resetSpeechWindow()
 
@@ -352,7 +354,7 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
   }
 
   private async flushStopUtterance(): Promise<void> {
-    if (!this.hasValidSpeechWindow() || this.liveFrames.length === 0) {
+    if (!this.hasStopFlushSpeechWindow() || this.liveFrames.length === 0) {
       this.resetSpeechWindow()
       return
     }
@@ -483,6 +485,10 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
 
   private hasValidSpeechWindow(): boolean {
     return this.speechRealStarted || this.confirmedSpeechSamples >= resolveMinSpeechSamples(this.config)
+  }
+
+  private hasStopFlushSpeechWindow(): boolean {
+    return this.speechRealStarted || this.confirmedSpeechSamples > 0
   }
 
   private async awaitContinuationFlush(): Promise<void> {


### PR DESCRIPTION
## Summary
- fix Groq browser VAD chunk handling so sealed MicVAD audio is trusted and stop/cancel cannot double-flush late speech end callbacks
- make the Groq rolling upload path transcript-first and preserve committed text visibility even when output partially fails
- add natural browser-VAD coverage for `Recording-2-sentences-jp.wav`, plus live-provider and output-failure E2E updates using `GROQ_APIKEY`

## Testing
- pnpm exec vitest run src/renderer/groq-browser-vad-capture.test.ts
- pnpm exec vitest run src/main/services/streaming/groq-rolling-upload-adapter.test.ts src/main/services/streaming/streaming-segment-router.test.ts src/main/services/streaming/streaming-session-controller.test.ts
- xvfb-run -a pnpm exec playwright test e2e/electron-groq-streaming-recording.e2e.ts
