### PR TITLE
Test Groq VAD deterministic harness coverage

### DIFF
--- a/docs/qa/streaming-raw-dictation-manual-checklist.md
+++ b/docs/qa/streaming-raw-dictation-manual-checklist.md
@@ -58,10 +58,13 @@
   - verify at least three finalized segments paste successfully
   - verify provider crash paths show actionable errors
 - Groq rolling-upload:
-  - verify pause-bounded chunks continue during one long recording session
+  - verify each natural pause emits one finalized chunk and the session stays active afterward
+  - verify repeated phrase-pause-phrase sequences continue emitting later chunks in the same session
   - verify a Groq auth/network failure appears as a streaming error toast and activity entry
   - verify the UX never claims Groq is a native realtime session API
-  - verify stopping during active speech still commits the last utterance before the session ends
+  - verify stopping during active speech commits at most one final utterance before the session ends
+  - verify cancel during active speech ends the session without committing a final utterance
   - simulate a slow network and verify backlog pause/resume activity appears instead of silent stalling
   - verify backlog recovery resumes live dictation without dropping later utterances
   - verify a quiet/short utterance near a misfire boundary does not leak a ghost stop chunk
+  - verify a false-start misfire does not poison the next valid utterance

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -302,6 +302,141 @@ describe('registerIpcHandlers', () => {
     }))
   })
 
+  it('routes a thin-capture utterance sequence through owner validation into the active controller runtime', async () => {
+    const pushAudioUtteranceChunk = vi.fn(async () => {})
+    const streamingSessionController = new InMemoryStreamingSessionController({
+      createSessionId: () => 'session-sequence',
+      createProviderRuntime: () => ({
+        start: async () => {},
+        stop: async () => {},
+        pushAudioFrameBatch: async () => {},
+        pushAudioUtteranceChunk
+      })
+    })
+    const commandRouter = {
+      getAudioInputSources: vi.fn().mockResolvedValue([]),
+      runRecordingCommand: vi.fn().mockResolvedValue({
+        kind: 'streaming_start',
+        sessionId: 'session-sequence',
+        preferredDeviceId: 'mic-1'
+      }),
+      submitRecordedAudio: vi.fn(),
+      startStreamingSession: vi.fn(),
+      stopStreamingSession: vi.fn()
+    }
+
+    registerIpcHandlersWithServices({
+      settingsService: { getSettings: vi.fn(), setSettings: vi.fn() } as any,
+      secretStore: {
+        getApiKey: vi.fn().mockReturnValue(null),
+        setApiKey: vi.fn(),
+        deleteApiKey: vi.fn()
+      } as any,
+      historyService: { getRecords: vi.fn().mockReturnValue([]) } as any,
+      transcriptionService: {} as any,
+      transformationService: {} as any,
+      outputService: {} as any,
+      networkCompatibilityService: {} as any,
+      soundService: { play: vi.fn() } as any,
+      clipboardClient: {} as any,
+      selectionClient: {} as any,
+      profilePickerService: {} as any,
+      apiKeyConnectionService: { testConnection: vi.fn() } as any,
+      commandRouter: commandRouter as any,
+      streamingSessionController: streamingSessionController as any,
+      hotkeyService: {
+        registerFromSettings: vi.fn(),
+        unregisterAll: vi.fn(),
+        runPickAndRunTransform: vi.fn()
+      } as any
+    } as any)
+
+    await streamingSessionController.start({
+      provider: 'groq_whisper_large_v3_turbo',
+      transport: 'rolling_upload',
+      model: 'whisper-large-v3-turbo',
+      outputMode: 'stream_raw_dictation',
+      maxInFlightTransforms: 2,
+      apiKeyRef: 'groq',
+      delimiterPolicy: {
+        mode: 'space',
+        value: null
+      },
+      transformationProfile: null
+    })
+
+    await getRegisteredHandle(IPC_CHANNELS.runRecordingCommand)?.({ sender: mocks.windows[0]?.webContents }, 'toggleRecording')
+
+    const utteranceHandler = getRegisteredHandle(IPC_CHANNELS.pushStreamingAudioUtteranceChunk)
+    expect(utteranceHandler).toBeTypeOf('function')
+
+    const sequence = [
+      {
+        sessionId: 'session-sequence',
+        sampleRateHz: 16000,
+        channels: 1,
+        utteranceIndex: 0,
+        wavBytes: new ArrayBuffer(4),
+        wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+        startedAtEpochMs: 0,
+        endedAtEpochMs: 500,
+        hadCarryover: false,
+        reason: 'speech_pause' as const,
+        source: 'browser_vad' as const
+      },
+      {
+        sessionId: 'session-sequence',
+        sampleRateHz: 16000,
+        channels: 1,
+        utteranceIndex: 1,
+        wavBytes: new ArrayBuffer(6),
+        wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+        startedAtEpochMs: 600,
+        endedAtEpochMs: 1200,
+        hadCarryover: false,
+        reason: 'speech_pause' as const,
+        source: 'browser_vad' as const
+      },
+      {
+        sessionId: 'session-sequence',
+        sampleRateHz: 16000,
+        channels: 1,
+        utteranceIndex: 2,
+        wavBytes: new ArrayBuffer(8),
+        wavFormat: 'wav_pcm_s16le_mono_16000' as const,
+        startedAtEpochMs: 1300,
+        endedAtEpochMs: 1700,
+        hadCarryover: false,
+        reason: 'session_stop' as const,
+        source: 'browser_vad' as const
+      }
+    ]
+
+    for (const chunk of sequence) {
+      await utteranceHandler?.({ sender: mocks.windows[0]?.webContents }, chunk)
+    }
+
+    expect(pushAudioUtteranceChunk).toHaveBeenCalledTimes(3)
+    expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      sessionId: 'session-sequence',
+      utteranceIndex: 0,
+      reason: 'speech_pause',
+      hadCarryover: false
+    }))
+    expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      sessionId: 'session-sequence',
+      utteranceIndex: 1,
+      reason: 'speech_pause',
+      hadCarryover: false
+    }))
+    expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      sessionId: 'session-sequence',
+      utteranceIndex: 2,
+      reason: 'session_stop',
+      hadCarryover: false
+    }))
+  })
+
   it('rejects null and malformed utterance chunk payloads before owner lookup', async () => {
     const pushAudioUtteranceChunk = vi.fn(async () => {})
     const commandRouter = {

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -68,6 +68,35 @@ class FakeMicVad {
   }
 }
 
+type FakeVadStep =
+  | { type: 'speechStart' }
+  | { type: 'speechRealStart' }
+  | { type: 'misfire' }
+  | { type: 'frame'; probabilities: SpeechProbabilities; frame: Float32Array }
+  | { type: 'speechEnd'; audio: Float32Array }
+
+const playVadScript = async (vad: FakeMicVad, steps: readonly FakeVadStep[]): Promise<void> => {
+  for (const step of steps) {
+    switch (step.type) {
+      case 'speechStart':
+        await vad.emitSpeechStart()
+        break
+      case 'speechRealStart':
+        await vad.emitSpeechRealStart()
+        break
+      case 'misfire':
+        await vad.emitMisfire()
+        break
+      case 'frame':
+        await vad.emitFrame(step.probabilities, step.frame)
+        break
+      case 'speechEnd':
+        await vad.emitSpeechEnd(step.audio)
+        break
+    }
+  }
+}
+
 describe('startGroqBrowserVadCapture', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -205,12 +234,14 @@ describe('startGroqBrowserVadCapture', () => {
       nowMs: () => 7_000
     })
 
-    await vad.emitSpeechStart()
-    await vad.emitSpeechEnd(new Float32Array(3_200).fill(0.2))
-    await vad.emitSpeechStart()
-    await vad.emitSpeechEnd(new Float32Array(4_800).fill(0.3))
-    await vad.emitSpeechStart()
-    await vad.emitSpeechEnd(new Float32Array(1_600).fill(0.1))
+    await playVadScript(vad, [
+      { type: 'speechStart' },
+      { type: 'speechEnd', audio: new Float32Array(3_200).fill(0.2) },
+      { type: 'speechStart' },
+      { type: 'speechEnd', audio: new Float32Array(4_800).fill(0.3) },
+      { type: 'speechStart' },
+      { type: 'speechEnd', audio: new Float32Array(1_600).fill(0.1) }
+    ])
 
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(1, expect.objectContaining({
       utteranceIndex: 0,
@@ -227,6 +258,58 @@ describe('startGroqBrowserVadCapture', () => {
       reason: 'speech_pause',
       hadCarryover: false
     }))
+  })
+
+  it('clears a misfire so the next valid utterance emits cleanly', async () => {
+    const { vad, sink } = await createCapture({
+      nowMs: () => 7_000
+    })
+
+    await playVadScript(vad, [
+      { type: 'speechStart' },
+      { type: 'frame', probabilities: { isSpeech: 0.2, notSpeech: 0.8 }, frame: new Float32Array(800).fill(0.05) },
+      { type: 'misfire' },
+      { type: 'speechStart' },
+      { type: 'frame', probabilities: { isSpeech: 0.9, notSpeech: 0.1 }, frame: new Float32Array(1_600).fill(0.2) },
+      { type: 'speechEnd', audio: new Float32Array(3_200).fill(0.2) }
+    ])
+
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledTimes(1)
+    expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
+      utteranceIndex: 0,
+      reason: 'speech_pause',
+      hadCarryover: false
+    }))
+  })
+
+  it('keeps emitting after mixed pause and misfire sequences', async () => {
+    const { vad, sink } = await createCapture({
+      nowMs: () => 7_000
+    })
+
+    await playVadScript(vad, [
+      { type: 'speechStart' },
+      { type: 'speechEnd', audio: new Float32Array(3_200).fill(0.2) },
+      { type: 'speechStart' },
+      { type: 'frame', probabilities: { isSpeech: 0.2, notSpeech: 0.8 }, frame: new Float32Array(600).fill(0.05) },
+      { type: 'misfire' },
+      { type: 'speechStart' },
+      { type: 'speechEnd', audio: new Float32Array(2_400).fill(0.3) },
+      { type: 'speechStart' },
+      { type: 'speechRealStart' },
+      { type: 'frame', probabilities: { isSpeech: 0.9, notSpeech: 0.1 }, frame: new Float32Array(1_600).fill(0.2) },
+      { type: 'speechEnd', audio: new Float32Array(1_600).fill(0.2) }
+    ])
+
+    expect(sink.pushStreamingAudioUtteranceChunk.mock.calls.map(([chunk]) => ({
+      utteranceIndex: chunk.utteranceIndex,
+      reason: chunk.reason,
+      hadCarryover: chunk.hadCarryover
+    }))).toEqual([
+      { utteranceIndex: 0, reason: 'speech_pause', hadCarryover: false },
+      { utteranceIndex: 1, reason: 'speech_pause', hadCarryover: false },
+      { utteranceIndex: 2, reason: 'speech_pause', hadCarryover: false }
+    ])
   })
 
   it('uses epoch time for utterance timestamps even when the monotonic clock differs', async () => {


### PR DESCRIPTION
## Summary
- expand the renderer-side fake VAD harness around misfire and repeated pause sequences
- add an IPC sequence test that exercises owner validation plus the real active controller runtime path
- update Groq manual QA expectations for pause, stop, cancel, and misfire behavior

## Verification
- pnpm vitest run src/renderer/groq-browser-vad-capture.test.ts
- pnpm vitest run src/main/ipc/register-handlers.test.ts
- pnpm exec tsc --noEmit

## Process note
- Claude review is currently blocked locally because the CLI is rate-limited until 2026-03-13 03:00 UTC.