### PR TITLE
Refactor Groq utterance contract to remove max_chunk

### DIFF
--- a/docs/decisions/2026-03-11-groq-max-chunk-removal-decision.md
+++ b/docs/decisions/2026-03-11-groq-max-chunk-removal-decision.md
@@ -1,0 +1,64 @@
+<!--
+Where: docs/decisions/2026-03-11-groq-max-chunk-removal-decision.md
+What: Decision note for removing dead max_chunk and carryover handling from the Groq utterance path.
+Why: Ticket 3 must record why the team chose deletion over retuning or downstream continuation support.
+-->
+
+# Decision: Remove `max_chunk` And Carryover From The Groq Utterance Contract
+
+Date: 2026-03-11
+
+## Context
+
+Ticket 1 moved normal Groq utterance ownership to `MicVAD.onSpeechEnd(audio)`.
+Ticket 2 expanded the deterministic harness and IPC coverage around that thin
+contract.
+
+After those changes, the live Groq browser-VAD path now emits only:
+
+- `reason: "speech_pause"`
+- `reason: "session_stop"`
+
+It no longer emits renderer-owned `max_chunk` utterances or any overlap
+carryover flag.
+
+The remaining `max_chunk` and `hadCarryover` handling survived only as
+downstream compatibility scaffolding in shared IPC types, validation, tests, and
+the Groq rolling-upload adapter's overlap-dedupe logic.
+
+## Decision
+
+We are deleting `max_chunk` and `hadCarryover` from the Groq utterance contract
+instead of retuning or moving them downstream in this pass.
+
+Concretely:
+
+1. `StreamingAudioUtteranceChunk.reason` is narrowed to:
+   - `speech_pause`
+   - `session_stop`
+2. `StreamingAudioUtteranceChunk.hadCarryover` is removed.
+3. The Groq rolling-upload adapter no longer trims text based on overlap
+   carryover state.
+4. Tests and QA now treat uninterrupted Groq speech as waiting for a real pause
+   or explicit stop rather than forcing an artificial mid-speech split.
+
+## Why This Is The Right Ticket 3 Outcome
+
+- There is no longer a live producer for `max_chunk`, so keeping the type and
+  dedupe logic would preserve dead behavior.
+- Reintroducing `max_chunk` downstream would create a new policy problem
+  without evidence that uninterrupted-speech splitting is currently required to
+  fix the reported loss bug.
+- The carryover dedupe path only made sense when chunks could overlap. Once the
+  overlap producer is gone, that text-trimming logic becomes a silent source of
+  accidental regressions.
+
+## Trade-Offs
+
+- Benefit: the Groq utterance contract becomes smaller and easier to validate.
+- Benefit: fewer dead branches remain in the adapter and IPC boundary.
+- Cost: very long uninterrupted Groq speech now waits for a natural pause or
+  explicit stop before upload.
+- Deferred: if product evidence later demands mid-speech chunking, that should
+  be designed as a new, explicit policy with its own tests and decision note,
+  not by reviving the deleted hybrid behavior.

--- a/docs/qa/streaming-raw-dictation-manual-checklist.md
+++ b/docs/qa/streaming-raw-dictation-manual-checklist.md
@@ -60,6 +60,7 @@
 - Groq rolling-upload:
   - verify each natural pause emits one finalized chunk and the session stays active afterward
   - verify repeated phrase-pause-phrase sequences continue emitting later chunks in the same session
+  - verify uninterrupted Groq speech does not invent an artificial mid-speech chunk before a real pause or explicit stop
   - verify a Groq auth/network failure appears as a streaming error toast and activity entry
   - verify the UX never claims Groq is a native realtime session API
   - verify stopping during active speech commits at most one final utterance before the session ends

--- a/src/main/ipc/register-handlers.test.ts
+++ b/src/main/ipc/register-handlers.test.ts
@@ -253,7 +253,6 @@ describe('registerIpcHandlers', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 0,
       endedAtEpochMs: 500,
-      hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad',
       traceEnabled: true
@@ -284,7 +283,6 @@ describe('registerIpcHandlers', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 600,
       endedAtEpochMs: 900,
-      hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad',
       traceEnabled: true
@@ -380,7 +378,6 @@ describe('registerIpcHandlers', () => {
         wavFormat: 'wav_pcm_s16le_mono_16000' as const,
         startedAtEpochMs: 0,
         endedAtEpochMs: 500,
-        hadCarryover: false,
         reason: 'speech_pause' as const,
         source: 'browser_vad' as const
       },
@@ -393,7 +390,6 @@ describe('registerIpcHandlers', () => {
         wavFormat: 'wav_pcm_s16le_mono_16000' as const,
         startedAtEpochMs: 600,
         endedAtEpochMs: 1200,
-        hadCarryover: false,
         reason: 'speech_pause' as const,
         source: 'browser_vad' as const
       },
@@ -406,7 +402,6 @@ describe('registerIpcHandlers', () => {
         wavFormat: 'wav_pcm_s16le_mono_16000' as const,
         startedAtEpochMs: 1300,
         endedAtEpochMs: 1700,
-        hadCarryover: false,
         reason: 'session_stop' as const,
         source: 'browser_vad' as const
       }
@@ -420,20 +415,17 @@ describe('registerIpcHandlers', () => {
     expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(1, expect.objectContaining({
       sessionId: 'session-sequence',
       utteranceIndex: 0,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
     expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(2, expect.objectContaining({
       sessionId: 'session-sequence',
       utteranceIndex: 1,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
     expect(pushAudioUtteranceChunk).toHaveBeenNthCalledWith(3, expect.objectContaining({
       sessionId: 'session-sequence',
       utteranceIndex: 2,
-      reason: 'session_stop',
-      hadCarryover: false
+      reason: 'session_stop'
     }))
   })
 
@@ -501,7 +493,6 @@ describe('registerIpcHandlers', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 50,
       endedAtEpochMs: 10,
-      hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
     })).rejects.toThrow('endedAtEpochMs must not precede startedAtEpochMs')
@@ -566,7 +557,6 @@ describe('registerIpcHandlers', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 0,
       endedAtEpochMs: 500,
-      hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
     })

--- a/src/main/ipc/register-handlers.ts
+++ b/src/main/ipc/register-handlers.ts
@@ -270,10 +270,7 @@ const validateStreamingAudioUtteranceChunkPayload = (payload: unknown): Streamin
   if (chunk.endedAtEpochMs < chunk.startedAtEpochMs) {
     throw new Error('Invalid streaming audio utterance chunk payload: endedAtEpochMs must not precede startedAtEpochMs.')
   }
-  if (typeof chunk.hadCarryover !== 'boolean') {
-    throw new Error('Invalid streaming audio utterance chunk payload: hadCarryover must be a boolean.')
-  }
-  if (chunk.reason !== 'speech_pause' && chunk.reason !== 'max_chunk' && chunk.reason !== 'session_stop') {
+  if (chunk.reason !== 'speech_pause' && chunk.reason !== 'session_stop') {
     throw new Error('Invalid streaming audio utterance chunk payload: reason is unsupported.')
   }
   if (chunk.source !== 'browser_vad') {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.test.ts
@@ -56,8 +56,7 @@ const makeUtterance = (params: {
   utteranceIndex: number
   startMs: number
   endMs: number
-  reason: 'speech_pause' | 'max_chunk' | 'session_stop'
-  hadCarryover?: boolean
+  reason: 'speech_pause' | 'session_stop'
   wavBytes?: number[]
 }) => ({
   sessionId: 'session-1',
@@ -68,7 +67,6 @@ const makeUtterance = (params: {
   wavFormat: 'wav_pcm_s16le_mono_16000' as const,
   startedAtEpochMs: params.startMs,
   endedAtEpochMs: params.endMs,
-  hadCarryover: params.hadCarryover ?? false,
   reason: params.reason,
   source: 'browser_vad' as const
 })
@@ -135,7 +133,6 @@ describe('GroqRollingUploadAdapter', () => {
       utteranceIndex: 0,
       startMs: 2_000,
       endMs: 2_500,
-      hadCarryover: true,
       reason: 'speech_pause'
     }))
     await adapter.stop('user_stop')
@@ -429,43 +426,6 @@ describe('GroqRollingUploadAdapter', () => {
       text: 'recovered chunk',
       sequence: 0
     }))
-  })
-
-  it('trims duplicated fallback text when a max_chunk continuation carries overlap into the next utterance', async () => {
-    const fetchFn = vi
-      .fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'hello world' }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ text: 'world again' }), { status: 200 }))
-    const onFinalSegment = vi.fn()
-    const adapter = new GroqRollingUploadAdapter({
-      sessionId: 'session-1',
-      config: LOCAL_CONFIG,
-      callbacks: {
-        onFinalSegment,
-        onFailure: vi.fn()
-      }
-    }, {
-      secretStore: { getApiKey: vi.fn(() => 'test-key') },
-      fetchFn
-    })
-
-    await adapter.start()
-    await adapter.pushAudioUtteranceChunk(makeUtterance({
-      utteranceIndex: 0,
-      startMs: 0,
-      endMs: 1000,
-      reason: 'max_chunk'
-    }))
-    await adapter.pushAudioUtteranceChunk(makeUtterance({
-      utteranceIndex: 1,
-      startMs: 1000,
-      endMs: 1800,
-      reason: 'speech_pause',
-      hadCarryover: true
-    }))
-    await adapter.stop('user_stop')
-
-    expect(onFinalSegment.mock.calls.map(([segment]) => segment.text)).toEqual(['hello world', 'again'])
   })
 
   it('does not trim repeated words across normal pause-bounded utterances without carryover', async () => {

--- a/src/main/services/streaming/groq-rolling-upload-adapter.ts
+++ b/src/main/services/streaming/groq-rolling-upload-adapter.ts
@@ -52,14 +52,12 @@ interface GroqVerboseResponse {
 interface PendingUtteranceUpload {
   utteranceIndex: number
   body: Blob
-  hadCarryover: boolean
   startedAtEpochMs: number
   endedAtEpochMs: number
 }
 
 interface CompletedUtteranceUpload {
   utteranceIndex: number
-  hadCarryover: boolean
   startedAtEpochMs: number
   endedAtEpochMs: number
   response: GroqVerboseResponse
@@ -120,8 +118,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
   private stopUploadTimedOut = false
   private stopped = false
   private rendererStopPrepared = false
-  private lastCommittedEndedAtEpochMs = Number.NEGATIVE_INFINITY
-  private lastCommittedTextTail = ''
 
   constructor(
     private readonly params: GroqRollingUploadAdapterParams,
@@ -222,7 +218,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
     this.pendingUtterances.push({
       utteranceIndex: chunk.utteranceIndex,
       body: new Blob([Buffer.from(chunk.wavBytes)], { type: 'audio/wav' }),
-      hadCarryover: chunk.hadCarryover,
       startedAtEpochMs: chunk.startedAtEpochMs,
       endedAtEpochMs: chunk.endedAtEpochMs
     })
@@ -279,7 +274,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
         })
         this.completedUtterances.push({
           utteranceIndex: utterance.utteranceIndex,
-          hadCarryover: utterance.hadCarryover,
           startedAtEpochMs: utterance.startedAtEpochMs,
           endedAtEpochMs: utterance.endedAtEpochMs,
           response
@@ -399,10 +393,7 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       return
     }
 
-    let text = normalized.text
-    if (utterance.hadCarryover) {
-      text = trimOverlappingPrefix(text, this.lastCommittedTextTail)
-    }
+    const text = normalized.text
     if (text.length === 0) {
       return
     }
@@ -412,7 +403,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       startedAtEpochMs: normalized.startedAtEpochMs,
       endedAtEpochMs: normalized.endedAtEpochMs
     })
-    this.rememberCommittedText(text, normalized.endedAtEpochMs)
   }
 
   private async emitFinalSegment(params: {
@@ -430,12 +420,6 @@ export class GroqRollingUploadAdapter implements StreamingProviderRuntime {
       endedAt: new Date(params.endedAtEpochMs).toISOString()
     }
     await this.params.callbacks.onFinalSegment(segment)
-  }
-
-  private rememberCommittedText(text: string, endedAtEpochMs: number): void {
-    this.lastCommittedEndedAtEpochMs = Math.max(this.lastCommittedEndedAtEpochMs, endedAtEpochMs)
-    const nextTail = `${this.lastCommittedTextTail} ${text}`.trim()
-    this.lastCommittedTextTail = nextTail.slice(-160)
   }
 
   private async finishStopDrain(): Promise<void> {
@@ -559,25 +543,6 @@ const normalizeGroqUtteranceText = (utterance: CompletedUtteranceUpload): Normal
     startedAtEpochMs: utterance.startedAtEpochMs + Math.round((usableSegments[0]?.start ?? 0) * 1000),
     endedAtEpochMs: utterance.startedAtEpochMs + Math.round((usableSegments.at(-1)?.end ?? 0) * 1000)
   }
-}
-
-const trimOverlappingPrefix = (text: string, previousTail: string): string => {
-  const nextText = text.trim()
-  const tail = previousTail.trim()
-  if (nextText.length === 0 || tail.length === 0) {
-    return nextText
-  }
-
-  const maxLength = Math.min(nextText.length, tail.length, 80)
-  for (let length = maxLength; length >= 4; length -= 1) {
-    const previousSuffix = tail.slice(-length).toLowerCase()
-    const nextPrefix = nextText.slice(0, length).toLowerCase()
-    if (previousSuffix === nextPrefix) {
-      return nextText.slice(length).trimStart()
-    }
-  }
-
-  return nextText
 }
 
 const shouldRetryResponse = (status: number, attempt: number, maxRetryCount: number): boolean =>

--- a/src/main/services/streaming/streaming-session-controller.test.ts
+++ b/src/main/services/streaming/streaming-session-controller.test.ts
@@ -288,7 +288,6 @@ describe('InMemoryStreamingSessionController', () => {
         wavFormat: 'wav_pcm_s16le_mono_16000',
         startedAtEpochMs: 0,
         endedAtEpochMs: 100,
-        hadCarryover: false,
         reason: 'speech_pause',
         source: 'browser_vad'
       })
@@ -322,16 +321,14 @@ describe('InMemoryStreamingSessionController', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 0,
       endedAtEpochMs: 100,
-      hadCarryover: true,
-      reason: 'max_chunk',
+      reason: 'speech_pause',
       source: 'browser_vad'
     })
 
     expect(pushAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-1',
       utteranceIndex: 0,
-      hadCarryover: true,
-      reason: 'max_chunk'
+      reason: 'speech_pause'
     }))
   })
 

--- a/src/main/test-support/streaming-groq-stop-budget.test.ts
+++ b/src/main/test-support/streaming-groq-stop-budget.test.ts
@@ -92,7 +92,6 @@ describe('streaming Groq stop budget integration', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 1000,
       endedAtEpochMs: 1500,
-      hadCarryover: false,
       reason: 'speech_pause',
       source: 'browser_vad'
     })

--- a/src/main/test-support/streaming-stop-integration.test.ts
+++ b/src/main/test-support/streaming-stop-integration.test.ts
@@ -101,7 +101,6 @@ describe('streaming stop integration', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 1000,
       endedAtEpochMs: 2000,
-      hadCarryover: false,
       reason: 'session_stop',
       source: 'browser_vad'
     })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -42,7 +42,6 @@ describe('preload speechToTextApi', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
       startedAtEpochMs: 100,
       endedAtEpochMs: 240,
-      hadCarryover: false,
       reason: 'speech_pause' as const,
       source: 'browser_vad' as const
     }
@@ -64,7 +63,6 @@ describe('preload speechToTextApi', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
       startedAtEpochMs: 0,
       endedAtEpochMs: 32,
-      hadCarryover: false,
       reason: 'session_stop' as const,
       source: 'browser_vad' as const
     }

--- a/src/renderer/groq-browser-vad-capture.test.ts
+++ b/src/renderer/groq-browser-vad-capture.test.ts
@@ -205,7 +205,6 @@ describe('startGroqBrowserVadCapture', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       reason: 'speech_pause',
       source: 'browser_vad',
-      hadCarryover: false,
       startedAtEpochMs: 6_000,
       endedAtEpochMs: 7_000
     }))
@@ -245,18 +244,15 @@ describe('startGroqBrowserVadCapture', () => {
 
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(1, expect.objectContaining({
       utteranceIndex: 0,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(2, expect.objectContaining({
       utteranceIndex: 1,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenNthCalledWith(3, expect.objectContaining({
       utteranceIndex: 2,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
   })
 
@@ -277,8 +273,7 @@ describe('startGroqBrowserVadCapture', () => {
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledTimes(1)
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
       utteranceIndex: 0,
-      reason: 'speech_pause',
-      hadCarryover: false
+      reason: 'speech_pause'
     }))
   })
 
@@ -303,12 +298,11 @@ describe('startGroqBrowserVadCapture', () => {
 
     expect(sink.pushStreamingAudioUtteranceChunk.mock.calls.map(([chunk]) => ({
       utteranceIndex: chunk.utteranceIndex,
-      reason: chunk.reason,
-      hadCarryover: chunk.hadCarryover
+      reason: chunk.reason
     }))).toEqual([
-      { utteranceIndex: 0, reason: 'speech_pause', hadCarryover: false },
-      { utteranceIndex: 1, reason: 'speech_pause', hadCarryover: false },
-      { utteranceIndex: 2, reason: 'speech_pause', hadCarryover: false }
+      { utteranceIndex: 0, reason: 'speech_pause' },
+      { utteranceIndex: 1, reason: 'speech_pause' },
+      { utteranceIndex: 2, reason: 'speech_pause' }
     ])
   })
 
@@ -419,7 +413,6 @@ describe('startGroqBrowserVadCapture', () => {
     expect(sink.pushStreamingAudioUtteranceChunk).toHaveBeenCalledWith(expect.objectContaining({
       utteranceIndex: 0,
       reason: 'session_stop',
-      hadCarryover: false,
       source: 'browser_vad',
       endedAtEpochMs: 9_000
     }))

--- a/src/renderer/groq-browser-vad-capture.ts
+++ b/src/renderer/groq-browser-vad-capture.ts
@@ -359,7 +359,6 @@ class BrowserGroqVadCapture implements GroqBrowserVadCapture {
       wavFormat: 'wav_pcm_s16le_mono_16000' as const,
       startedAtEpochMs,
       endedAtEpochMs,
-      hadCarryover: false,
       reason,
       source: 'browser_vad' as const,
       traceEnabled: this.traceEnabled || undefined

--- a/src/renderer/native-recording.test.ts
+++ b/src/renderer/native-recording.test.ts
@@ -358,8 +358,7 @@ describe('handleRecordingCommandDispatch', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 1_500,
       endedAtEpochMs: 1_800,
-      hadCarryover: true,
-      reason: 'max_chunk',
+      reason: 'speech_pause',
       source: 'browser_vad'
     })
 
@@ -372,8 +371,7 @@ describe('handleRecordingCommandDispatch', () => {
       wavFormat: 'wav_pcm_s16le_mono_16000',
       startedAtEpochMs: 1_500,
       endedAtEpochMs: 1_800,
-      hadCarryover: true,
-      reason: 'max_chunk',
+      reason: 'speech_pause',
       source: 'browser_vad'
     })
   })

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -102,7 +102,7 @@ export interface StreamingAudioFrame {
 }
 
 export type StreamingAudioChunkFlushReason = 'speech_pause' | 'max_chunk' | 'session_stop' | 'discard_pending'
-export type StreamingAudioUtteranceChunkFlushReason = Exclude<StreamingAudioChunkFlushReason, 'discard_pending'>
+export type StreamingAudioUtteranceChunkFlushReason = 'speech_pause' | 'session_stop'
 
 export interface StreamingAudioFrameBatch {
   sessionId: string
@@ -121,7 +121,6 @@ export interface StreamingAudioUtteranceChunk {
   wavFormat: 'wav_pcm_s16le_mono_16000'
   startedAtEpochMs: number
   endedAtEpochMs: number
-  hadCarryover: boolean
   reason: StreamingAudioUtteranceChunkFlushReason
   source: 'browser_vad'
   traceEnabled?: boolean


### PR DESCRIPTION
## Summary
- remove `max_chunk` and `hadCarryover` from the Groq utterance IPC contract
- delete the downstream overlap-trimming compatibility path from the Groq rolling upload adapter
- update focused tests, QA guidance, and add a decision note for the removal

## Verification
- pnpm vitest run src/main/services/streaming/groq-rolling-upload-adapter.test.ts
- pnpm vitest run src/renderer/native-recording.test.ts src/main/services/streaming/streaming-session-controller.test.ts src/main/ipc/register-handlers.test.ts src/preload/index.test.ts src/renderer/groq-browser-vad-capture.test.ts
- pnpm exec tsc --noEmit
