### PR TITLE
fix: play sound after saved default profile change

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -223,7 +223,7 @@ The app **MUST** play notification sounds for:
 `changeTransformationDefault` sound semantics:
 - The app **MUST** play `skyscraper_seven-click-buttons-ui-menu-sounds-effects-button-7-203601.mp3` only when shortcut-driven default profile change is committed.
 - The app **MUST NOT** play that sound when picker selection is cancelled or keeps the same default profile.
-- Direct default profile changes from renderer window controls **MUST NOT** play that sound.
+- Direct default profile changes from renderer window controls **MUST** also play that sound after the settings update succeeds and the default profile actually changed.
 
 Additional notes:
 - Distinct tones **SHOULD** be used for success vs failure.

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -231,6 +231,8 @@ Steps:
 7. No transformation request is enqueued during this action.
 8. Later `runTransform` requests use the updated default preset.
 
+Renderer settings note: saving a new default profile from the Settings window follows the same sound rule. The menu-click sound plays only after the save succeeds and the default preset actually changed.
+
 ---
 
 ## Cross-Flow User Guarantees

--- a/src/renderer/settings-mutations.test.ts
+++ b/src/renderer/settings-mutations.test.ts
@@ -28,7 +28,8 @@ describe('createSettingsMutations.saveApiKey', () => {
       setApiKey: vi.fn(noopAsync),
       deleteApiKey: vi.fn(noopAsync),
       testApiKeyConnection: vi.fn(async () => ({ provider: 'google' as ApiKeyProvider, status: 'success', message: 'ok' })),
-      getApiKeyStatus: vi.fn(async () => ({ groq: true, elevenlabs: false, google: false }))
+      getApiKeyStatus: vi.fn(async () => ({ groq: true, elevenlabs: false, google: false })),
+      playSound: vi.fn(noopAsync)
     }
   })
 
@@ -229,7 +230,8 @@ describe('createSettingsMutations.deleteApiKey', () => {
       setApiKey: vi.fn(async () => {}),
       deleteApiKey: vi.fn(async () => {}),
       testApiKeyConnection: vi.fn(async () => ({ provider: 'google' as ApiKeyProvider, status: 'success', message: 'ok' })),
-      getApiKeyStatus: vi.fn(async () => ({ groq: false, elevenlabs: false, google: false }))
+      getApiKeyStatus: vi.fn(async () => ({ groq: false, elevenlabs: false, google: false })),
+      playSound: vi.fn(async () => {})
     }
   })
 
@@ -375,7 +377,8 @@ describe('createSettingsMutations profile persistence helpers', () => {
       setApiKey: vi.fn(async () => {}),
       deleteApiKey: vi.fn(async () => {}),
       testApiKeyConnection: vi.fn(async () => ({ provider: 'google' as ApiKeyProvider, status: 'success', message: 'ok' })),
-      getApiKeyStatus: vi.fn(async () => ({ groq: false, elevenlabs: false, google: false }))
+      getApiKeyStatus: vi.fn(async () => ({ groq: false, elevenlabs: false, google: false })),
+      playSound: vi.fn(async () => {})
     }
   })
 
@@ -426,6 +429,87 @@ describe('createSettingsMutations profile persistence helpers', () => {
     await mutations.setDefaultTransformationPresetAndSave('preset-b')
 
     expect(window.speechToTextApi.setSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('plays the default-profile-changed sound after a successful default profile save', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.setDefaultTransformationPresetAndSave('preset-b')
+
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledTimes(1)
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('default_profile_changed')
+  })
+
+  it('does not play the default-profile-changed sound when the saved default profile is unchanged', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError: vi.fn()
+    })
+
+    await mutations.setDefaultTransformationPresetAndSave('preset-a')
+
+    expect(window.speechToTextApi.playSound).not.toHaveBeenCalled()
+  })
+
+  it('logs and tolerates default-profile-changed sound playback failure after a successful save', async () => {
+    const settings = structuredClone(DEFAULT_SETTINGS)
+    settings.transformation.defaultPresetId = 'preset-a'
+    settings.transformation.presets = [
+      { ...settings.transformation.presets[0], id: 'preset-a', name: 'Alpha' },
+      { ...settings.transformation.presets[0], id: 'preset-b', name: 'Beta' }
+    ]
+    const state = createState(settings)
+    const logError = vi.fn()
+    vi.mocked(window.speechToTextApi.playSound).mockRejectedValueOnce(new Error('speaker busy'))
+
+    const mutations = createSettingsMutations({
+      state,
+      onStateChange: vi.fn(),
+      invalidatePendingAutosave: vi.fn(),
+      setSettingsValidationErrors: vi.fn(),
+      addActivity: vi.fn(),
+      addToast: vi.fn(),
+      logError
+    })
+
+    const didSave = await mutations.setDefaultTransformationPresetAndSave('preset-b')
+    await Promise.resolve()
+
+    expect(didSave).toBe(true)
+    expect(window.speechToTextApi.playSound).toHaveBeenCalledWith('default_profile_changed')
+    expect(logError).toHaveBeenCalledWith('renderer.default_profile_changed_sound_failed', expect.any(Error), {
+      previousDefaultPresetId: 'preset-a',
+      savedDefaultPresetId: 'preset-b'
+    })
   })
 
   it('persists a new profile only when explicit create-from-draft save is called', async () => {

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -425,6 +425,7 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
 
   const setDefaultTransformationPresetAndSave = async (defaultPresetId: string): Promise<boolean> => {
     if (!state.settings) return false
+    const previousDefaultPresetId = state.settings.transformation.defaultPresetId
     const nextSettings = buildSettingsWithDefaultPreset(state.settings, defaultPresetId)
     try {
       invalidatePendingAutosave()
@@ -432,6 +433,14 @@ export const createSettingsMutations = (deps: SettingsMutationDeps) => {
       state.settings = saved
       state.persistedSettings = structuredClone(saved)
       onStateChange()
+      if (previousDefaultPresetId !== saved.transformation.defaultPresetId) {
+        void window.speechToTextApi.playSound('default_profile_changed').catch((error) => {
+          logError('renderer.default_profile_changed_sound_failed', error, {
+            previousDefaultPresetId,
+            savedDefaultPresetId: saved.transformation.defaultPresetId
+          })
+        })
+      }
       return true
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown default profile save error'


### PR DESCRIPTION
## Summary
- play the renderer default-profile-changed sound only after settings save succeeds and the persisted default actually changed
- cover changed, unchanged, and playback-failure renderer cases in settings mutation tests
- update spec and user flow docs for renderer parity with shortcut behavior

## Testing
- pnpm vitest run src/renderer/settings-mutations.test.ts
- pnpm typecheck