### PR TITLE
fix: reject empty transformed capture output

### DIFF
--- a/src/main/orchestrators/capture-pipeline.test.ts
+++ b/src/main/orchestrators/capture-pipeline.test.ts
@@ -473,6 +473,84 @@ describe('createCaptureProcessor', () => {
     )
   })
 
+  it('returns transformation_failed and falls back to transcript when transformation returns empty text', async () => {
+    const applyOutputWithDetail = vi.fn(async () => ({ status: 'succeeded' as TerminalJobStatus, message: null }))
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => ({
+          text: '',
+          model: 'gemini-2.5-flash' as const
+        }))
+      },
+      outputService: { applyOutputWithDetail }
+    })
+    const processor = createCaptureProcessor(deps)
+    const snapshot = buildCaptureRequestSnapshot({
+      transformationProfile: {
+        profileId: 'p1',
+        provider: 'google',
+        model: 'gemini-2.5-flash',
+        baseUrlOverride: null,
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      }
+    })
+
+    const status = await processor(snapshot)
+
+    expect(status).toBe('transformation_failed')
+    expect(applyOutputWithDetail).toHaveBeenCalledWith('hello world', snapshot.output.transcript)
+    expect(deps.historyService.appendRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcriptText: 'hello world',
+        transformedText: null,
+        terminalStatus: 'transformation_failed',
+        failureDetail: 'Transformation returned empty text.',
+        failureCategory: 'unknown'
+      })
+    )
+    expect(deps.soundService!.play).toHaveBeenCalledWith('transformation_failed')
+  })
+
+  it('returns transformation_failed and falls back to transcript when transformation returns whitespace-only text', async () => {
+    const applyOutputWithDetail = vi.fn(async () => ({ status: 'succeeded' as TerminalJobStatus, message: null }))
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => ({
+          text: '   \n\t',
+          model: 'gemini-2.5-flash' as const
+        }))
+      },
+      outputService: { applyOutputWithDetail }
+    })
+    const processor = createCaptureProcessor(deps)
+    const snapshot = buildCaptureRequestSnapshot({
+      transformationProfile: {
+        profileId: 'p1',
+        provider: 'google',
+        model: 'gemini-2.5-flash',
+        baseUrlOverride: null,
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      }
+    })
+
+    const status = await processor(snapshot)
+
+    expect(status).toBe('transformation_failed')
+    expect(applyOutputWithDetail).toHaveBeenCalledWith('hello world', snapshot.output.transcript)
+    expect(deps.historyService.appendRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcriptText: 'hello world',
+        transformedText: null,
+        terminalStatus: 'transformation_failed',
+        failureDetail: 'Transformation returned empty text.',
+        failureCategory: 'unknown'
+      })
+    )
+    expect(deps.soundService!.play).toHaveBeenCalledWith('transformation_failed')
+  })
+
   it('returns output_failed_partial when output application fails', async () => {
     const deps = makeDeps({
       outputService: {

--- a/src/main/orchestrators/capture-pipeline.ts
+++ b/src/main/orchestrators/capture-pipeline.ts
@@ -21,6 +21,7 @@ import { logStructured } from '../../shared/error-logging'
 import { selectCaptureOutput } from '../../shared/output-selection'
 import { validateSafeUserPromptTemplate } from '../../shared/prompt-template-safety'
 import { applyDictionaryReplacement } from '../services/transcription/dictionary-replacement'
+import { hasUsableTransformText } from './usable-transform-text'
 
 export interface CapturePipelineDeps {
   secretStore: Pick<SecretStore, 'getApiKey'>
@@ -120,7 +121,13 @@ export function createCaptureProcessor(deps: CapturePipelineDeps): CaptureProces
                 userPrompt: profile.userPrompt
               }
             })
-            transformedText = result.text
+            if (hasUsableTransformText(result.text)) {
+              transformedText = result.text
+            } else {
+              terminalStatus = 'transformation_failed'
+              failureDetail = 'Transformation returned empty text.'
+              failureCategory = 'unknown'
+            }
           } catch (error) {
             terminalStatus = 'transformation_failed'
             failureCategory = classifyAdapterError(error)

--- a/src/main/orchestrators/usable-transform-text.ts
+++ b/src/main/orchestrators/usable-transform-text.ts
@@ -1,0 +1,7 @@
+// Where: src/main/orchestrators/usable-transform-text.ts
+// What: Shared helper for determining whether transformed model output is usable.
+// Why: Empty or whitespace-only transform results must be treated as failures by
+// capture and standalone transform pipelines instead of being emitted as success.
+
+export const hasUsableTransformText = (text: string | null | undefined): text is string =>
+  typeof text === 'string' && text.trim().length > 0


### PR DESCRIPTION
## Summary
- treat empty or whitespace-only batch transformation output as transformation_failed
- keep transcript fallback output and history intact when transformed text is unusable
- add focused capture pipeline regression coverage for empty and whitespace-only transform responses

## Testing
- pnpm vitest run src/main/orchestrators/capture-pipeline.test.ts
- pnpm typecheck

## Review
- Explorer sub-agent review: no findings
- Claude CLI review: attempted, but the CLI did not return output in this environment
