### PR TITLE
fix: preserve capture fallback destinations

### DIFF
--- a/src/main/orchestrators/capture-pipeline.test.ts
+++ b/src/main/orchestrators/capture-pipeline.test.ts
@@ -551,6 +551,75 @@ describe('createCaptureProcessor', () => {
     expect(deps.soundService!.play).toHaveBeenCalledWith('transformation_failed')
   })
 
+  it('preserves transformed-selected destinations when transcript text is used as fallback output', async () => {
+    const applyOutputWithDetail = vi.fn(async () => ({ status: 'succeeded' as TerminalJobStatus, message: null }))
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => ({
+          text: '',
+          model: 'gemini-2.5-flash' as const
+        }))
+      },
+      outputService: { applyOutputWithDetail }
+    })
+    const processor = createCaptureProcessor(deps)
+    const snapshot = buildCaptureRequestSnapshot({
+      transformationProfile: {
+        profileId: 'p1',
+        provider: 'google',
+        model: 'gemini-2.5-flash',
+        baseUrlOverride: null,
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      },
+      output: {
+        selectedTextSource: 'transformed',
+        transcript: { copyToClipboard: false, pasteAtCursor: true },
+        transformed: { copyToClipboard: true, pasteAtCursor: false }
+      }
+    })
+
+    const status = await processor(snapshot)
+
+    expect(status).toBe('transformation_failed')
+    expect(applyOutputWithDetail).toHaveBeenCalledWith('hello world', snapshot.output.transformed)
+    expect(applyOutputWithDetail).not.toHaveBeenCalledWith('hello world', snapshot.output.transcript)
+  })
+
+  it('preserves transformed-selected destinations when transformation throws before fallback output', async () => {
+    const applyOutputWithDetail = vi.fn(async () => ({ status: 'succeeded' as TerminalJobStatus, message: null }))
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => {
+          throw new Error('gemini failure')
+        })
+      },
+      outputService: { applyOutputWithDetail }
+    })
+    const processor = createCaptureProcessor(deps)
+    const snapshot = buildCaptureRequestSnapshot({
+      transformationProfile: {
+        profileId: 'p1',
+        provider: 'google',
+        model: 'gemini-2.5-flash',
+        baseUrlOverride: null,
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      },
+      output: {
+        selectedTextSource: 'transformed',
+        transcript: { copyToClipboard: false, pasteAtCursor: true },
+        transformed: { copyToClipboard: true, pasteAtCursor: false }
+      }
+    })
+
+    const status = await processor(snapshot)
+
+    expect(status).toBe('transformation_failed')
+    expect(applyOutputWithDetail).toHaveBeenCalledWith('hello world', snapshot.output.transformed)
+    expect(applyOutputWithDetail).not.toHaveBeenCalledWith('hello world', snapshot.output.transcript)
+  })
+
   it('returns output_failed_partial when output application fails', async () => {
     const deps = makeDeps({
       outputService: {

--- a/src/main/orchestrators/capture-pipeline.ts
+++ b/src/main/orchestrators/capture-pipeline.ts
@@ -18,7 +18,7 @@ import type { NetworkCompatibilityService } from '../services/network-compatibil
 import type { SoundService } from '../services/sound-service'
 import { checkSttPreflight, checkLlmPreflight, classifyAdapterError, NETWORK_SIGNATURE_PATTERN } from './preflight-guard'
 import { logStructured } from '../../shared/error-logging'
-import { selectCaptureOutput } from '../../shared/output-selection'
+import { getSelectedOutputDestinations } from '../../shared/output-selection'
 import { validateSafeUserPromptTemplate } from '../../shared/prompt-template-safety'
 import { applyDictionaryReplacement } from '../services/transcription/dictionary-replacement'
 import { hasUsableTransformText } from './usable-transform-text'
@@ -154,9 +154,14 @@ export function createCaptureProcessor(deps: CapturePipelineDeps): CaptureProces
       const preOutputStatus = terminalStatus
       let outputFailureDetail: string | null = null
       const outputStatus = await deps.outputCoordinator.submit(seq, async () => {
-        const selectedOutput = selectCaptureOutput(snapshot.output, transformedText !== null)
-        const outputText = selectedOutput.source === 'transformed' ? transformedText! : transcriptText!
-        const selectedOutputResult = await deps.outputService.applyOutputWithDetail(outputText, selectedOutput.rule)
+        const outputText =
+          snapshot.output.selectedTextSource === 'transformed' && hasUsableTransformText(transformedText)
+            ? transformedText
+            : transcriptText
+        const selectedOutputResult = await deps.outputService.applyOutputWithDetail(
+          outputText,
+          getSelectedOutputDestinations(snapshot.output)
+        )
         if (selectedOutputResult.status === 'output_failed_partial') {
           outputFailureDetail = normalizeOutputFailureDetail(selectedOutputResult.message)
         }

--- a/src/shared/output-selection.ts
+++ b/src/shared/output-selection.ts
@@ -1,29 +1,9 @@
 // Where: Shared module (main + renderer).
-// What: Helpers for output-source precedence and output-settings UI mapping.
+// What: Helpers for capture/output destination selection and output-settings UI mapping.
 // Why: #148 requires a single selected output text source for capture flows while
 // preserving existing transcript/transformed output rules used by other paths.
 
 import type { OutputRule, OutputSettings, OutputTextSource } from './domain'
-
-export interface CaptureOutputSelection {
-  source: OutputTextSource
-  rule: Readonly<OutputRule>
-}
-
-/**
- * Capture-flow precedence for #148:
- * - Use the selected transformed output when a transformed result exists.
- * - Otherwise fall back to transcript output (preserves existing transform-failure fallback behavior).
- */
-export const selectCaptureOutput = (
-  output: Readonly<OutputSettings>,
-  hasTransformedText: boolean
-): CaptureOutputSelection => {
-  if (output.selectedTextSource === 'transformed' && hasTransformedText) {
-    return { source: 'transformed', rule: output.transformed }
-  }
-  return { source: 'transcript', rule: output.transcript }
-}
 
 /**
  * Settings UI uses a single destination matrix shared by the selected text source. To keep


### PR DESCRIPTION
## Summary
- preserve transformed-selected destinations when capture falls back to transcript text
- remove the old helper that coupled text-source fallback with destination-rule selection
- add divergent-settings regression coverage for both empty-output and thrown transformation failure fallback paths

## Testing
- pnpm vitest run src/main/orchestrators/capture-pipeline.test.ts
- pnpm typecheck

## Review
- Explorer sub-agent review: one missing regression path found and fixed
- Claude CLI review: attempted, but the CLI did not return output in this environment
