### PR TITLE
fix: reject empty standalone transform output

### DIFF
--- a/src/main/orchestrators/transform-pipeline.test.ts
+++ b/src/main/orchestrators/transform-pipeline.test.ts
@@ -148,6 +148,46 @@ describe('createTransformProcessor', () => {
     expect(result.failureCategory).toBe('unknown')
   })
 
+  it('returns error with failureCategory=unknown when transformation returns empty text', async () => {
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => ({
+          text: '',
+          model: 'gemini-2.5-flash' as const
+        }))
+      }
+    })
+    const processor = createTransformProcessor(deps)
+    const snapshot = buildTransformationRequestSnapshot()
+
+    const result = await processor(snapshot)
+
+    expect(result.status).toBe('error')
+    expect(result.message).toContain('Transformation returned empty text')
+    expect(result.failureCategory).toBe('unknown')
+    expect(deps.outputService.applyOutputWithDetail).not.toHaveBeenCalled()
+  })
+
+  it('returns error with failureCategory=unknown when transformation returns whitespace-only text', async () => {
+    const deps = makeDeps({
+      transformationService: {
+        transform: vi.fn(async () => ({
+          text: '   \n\t',
+          model: 'gemini-2.5-flash' as const
+        }))
+      }
+    })
+    const processor = createTransformProcessor(deps)
+    const snapshot = buildTransformationRequestSnapshot()
+
+    const result = await processor(snapshot)
+
+    expect(result.status).toBe('error')
+    expect(result.message).toContain('Transformation returned empty text')
+    expect(result.failureCategory).toBe('unknown')
+    expect(deps.outputService.applyOutputWithDetail).not.toHaveBeenCalled()
+  })
+
   it('returns error without failureCategory when output application throws', async () => {
     const deps = makeDeps({
       outputService: {

--- a/src/main/orchestrators/transform-pipeline.ts
+++ b/src/main/orchestrators/transform-pipeline.ts
@@ -12,6 +12,7 @@ import type { OutputService } from '../services/output-service'
 import { checkLlmPreflight, classifyAdapterError } from './preflight-guard'
 import { logStructured } from '../../shared/error-logging'
 import { validateSafeUserPromptTemplate } from '../../shared/prompt-template-safety'
+import { hasUsableTransformText } from './usable-transform-text'
 
 export interface TransformPipelineDeps {
   secretStore: Pick<SecretStore, 'getApiKey'>
@@ -55,6 +56,13 @@ export function createTransformProcessor(deps: TransformPipelineDeps): Transform
           userPrompt: snapshot.userPrompt
         }
       })
+      if (!hasUsableTransformText(result.text)) {
+        return {
+          status: 'error',
+          message: 'Transformation failed: Transformation returned empty text.',
+          failureCategory: 'unknown'
+        }
+      }
       transformedText = result.text
     } catch (error) {
       const detail = error instanceof Error && error.message.trim().length > 0


### PR DESCRIPTION
## Summary
- reject empty or whitespace-only standalone transform results before any output side effects run
- reuse the shared usable-transform-text helper introduced in the earlier batch capture fix
- add focused transform pipeline regression coverage for empty and whitespace-only model responses

## Testing
- pnpm vitest run src/main/orchestrators/transform-pipeline.test.ts
- pnpm typecheck

## Review
- Explorer sub-agent review: no findings
- Claude CLI review: attempted, but the CLI did not return output in this environment
