### PR TITLE
fix: concatenate gemini multipart transform output

### DIFF
--- a/src/main/services/transformation/gemini-transformation-adapter.test.ts
+++ b/src/main/services/transformation/gemini-transformation-adapter.test.ts
@@ -188,6 +188,74 @@ describe('GeminiTransformationAdapter', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('concatenates multipart text responses from the first candidate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'first ' },
+                { text: 'second' },
+                {},
+                { text: ' third' }
+              ]
+            }
+          }
+        ]
+      })
+    } as Response)
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const adapter = new GeminiTransformationAdapter()
+    const result = await adapter.transform({
+      text: 'input text',
+      apiKey: 'g-key',
+      model: 'gemini-2.5-flash',
+      prompt: {
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      }
+    })
+
+    expect(result.text).toBe('first second third')
+  })
+
+  it('does not drop later text parts when the first part is empty', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: '' },
+                { text: 'usable output' }
+              ]
+            }
+          }
+        ]
+      })
+    } as Response)
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const adapter = new GeminiTransformationAdapter()
+    const result = await adapter.transform({
+      text: 'input text',
+      apiKey: 'g-key',
+      model: 'gemini-2.5-flash',
+      prompt: {
+        systemPrompt: '',
+        userPrompt: '<input_text>{{text}}</input_text>'
+      }
+    })
+
+    expect(result.text).toBe('usable output')
+  })
+
   it('omits system_instruction when system prompt is blank', async () => {
     const fetchMock = vi.fn(async () => {
       return {

--- a/src/main/services/transformation/gemini-transformation-adapter.ts
+++ b/src/main/services/transformation/gemini-transformation-adapter.ts
@@ -47,7 +47,9 @@ export class GeminiTransformationAdapter implements TransformationAdapter {
     }
 
     const data = (await response.json()) as GeminiResponse
-    const transformedText = data.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+    const transformedText = (data.candidates?.[0]?.content?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('')
     return {
       text: transformedText,
       model: input.model


### PR DESCRIPTION
## Summary
- concatenate all text parts from Gemini's first response candidate instead of truncating at parts[0]
- preserve raw part ordering without injecting separators
- add multipart and empty-first-part regression coverage

## Testing
- pnpm vitest run src/main/services/transformation/gemini-transformation-adapter.test.ts src/main/orchestrators/capture-pipeline.test.ts src/main/orchestrators/transform-pipeline.test.ts
- pnpm typecheck

## Review
- Explorer sub-agent review: no findings reported before commit
- Claude CLI review: attempted, but the CLI did not return output in this environment
