### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicta",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "v1 macOS speech-to-text app",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary
- bump the app version from 0.1.1 to 0.1.2 before cutting the real release tag

## Verification
- confirmed package.json was the only tracked source of the app version string
