### PR TITLE
docs: add local runtime installation research

### DIFF
--- a/docs/adr/0008-use-app-managed-uv-python-and-model-ownership-for-local-runtime-install.md
+++ b/docs/adr/0008-use-app-managed-uv-python-and-model-ownership-for-local-runtime-install.md
@@ -1,0 +1,190 @@
+---
+title: Use app-managed uv, Python, and model ownership for local runtime install
+description: Define the clean-slate WhisperLiveKit install architecture as app-owned bootstrap tooling, Python runtime, environment, and model storage outside userData.
+date: 2026-03-19
+status: accepted
+tags:
+  - architecture
+  - whisperlivekit
+  - installation
+  - uv
+  - python
+  - storage
+---
+
+<!--
+Where: docs/adr/0008-use-app-managed-uv-python-and-model-ownership-for-local-runtime-install.md
+What: Durable decision for how Dicta should own WhisperLiveKit installation and runtime payloads.
+Why: The local runtime already exists as an app-managed optional architecture, but the install stack still needed a durable end-state decision.
+-->
+
+# Context
+
+ADR-0003 chose WhisperLiveKit as an app-managed optional localhost runtime for local streaming STT.
+
+That earlier decision intentionally left one major implementation question open:
+
+- how much of the install stack should Dicta own directly
+
+The current implementation is an incremental design:
+
+- discover host Python
+- create a managed virtual environment
+- install the pinned package spec with `pip`
+- keep install state in app-managed storage
+
+That is workable, but it is not the cleanest long-term architecture if the goal is:
+
+- minimal hidden host coupling
+- explicit ownership of runtime payloads
+- deterministic support and reinstall behavior
+- lower long-term error surface
+- a codebase that does not preserve compatibility paths indefinitely
+
+The most important upstream fact is that WhisperLiveKit installation is not one thing. It has at least four layers:
+
+1. Python runtime exists.
+2. WhisperLiveKit package and extras are installed.
+3. Model weights are available locally.
+4. The local service can start and prove readiness.
+
+The package layer alone is not enough to declare the runtime ready.
+
+# Decision
+
+Dicta will treat the WhisperLiveKit local runtime as a fully app-managed install stack.
+
+Specifically:
+
+- Dicta will own a pinned `uv` binary and will not rely on user-installed `uv` or `uvx`.
+- Dicta will own the Python runtime used for the local WhisperLiveKit environment and will not rely on host Python as the durable end-state contract.
+- Dicta will own the WhisperLiveKit environment and install the pinned package and required extras inside an app-managed runtime root.
+- Dicta will own model storage policy and will not treat default global caches as the primary product contract.
+- Dicta will store heavyweight runtime payloads outside Electron `userData`.
+- Dicta will keep only small install metadata and renderer-visible state in `userData`.
+- Dicta will not declare the runtime `ready` until package install, model availability, and runtime verification all succeed.
+- Dicta will prefer reinstall-oriented recovery for invalid or mismatched runtime state rather than preserving legacy compatibility branches indefinitely.
+
+# Why this was chosen
+
+This decision gives Dicta one clear owner for the full runnable runtime:
+
+- bootstrap toolchain
+- Python
+- package environment
+- model assets
+- install state
+- verification
+- uninstall and update behavior
+
+That ownership model is stronger than the alternatives.
+
+It avoids the two weakest patterns:
+
+- user-managed `uv` or `uvx`, which introduces version drift and environment-sensitive behavior
+- host-Python-as-primary-contract, which keeps Python discovery and compatibility checking as a permanent support burden
+
+It also makes the runtime state model cleaner:
+
+- `installed` can mean environment and package are present
+- `ready` can mean the required model is available and the service passed verification
+
+This matches the product expectation better than lazy, hidden first-use downloads that surprise the user after installation has already been reported complete.
+
+# Alternatives considered
+
+## Keep host Python and pip as the long-term design
+
+Why it was attractive:
+
+- simpler to implement incrementally
+- no bootstrap binary to manage
+- preserves the current implementation shape
+
+Why it was not chosen:
+
+- host Python remains an uncontrolled dependency
+- Python discovery and version drift remain first-class failure modes
+- the app only partially owns the runtime stack
+
+This remains an acceptable bridge implementation, but not the preferred end state.
+
+## Rely on user-installed uv or uvx
+
+Why it was attractive:
+
+- less bootstrap work inside the app
+- can look simpler at first glance
+
+Why it was not chosen:
+
+- the user can have any `uv` version
+- cache behavior and install semantics can drift outside Dicta's control
+- support diagnostics become less deterministic
+- this weakens the app-managed runtime contract chosen in ADR-0003
+
+## Install the package in-app but let model ownership stay implicit
+
+Why it was attractive:
+
+- smaller initial implementation
+- lower up-front download cost
+
+Why it was not chosen:
+
+- package install and model install are separate lifecycle layers
+- readiness becomes ambiguous
+- uninstall and disk accounting become incomplete
+- first real use can still fail on hidden downloads or missing assets
+
+# Consequences
+
+Positive:
+
+- install behavior becomes deterministic across machines
+- the app owns the full runtime contract instead of only part of it
+- uninstall, update, and reinstall semantics become cleaner
+- support diagnostics can be more explicit about which phase failed
+- the runtime payload boundary becomes more intentional than storing everything in `userData`
+
+Negative:
+
+- the app must manage the `uv` binary lifecycle
+- the app must manage Python provisioning policy
+- implementation complexity increases relative to the current host-Python-plus-pip bridge
+- model storage ownership and verification become part of the product surface, not just package installation
+
+# Implementation notes
+
+This ADR defines the end-state architecture, not the migration sequence.
+
+Incremental migration may still happen in smaller steps, but those steps should converge toward this ownership model rather than entrenching host-managed or user-managed runtime behavior.
+
+The final install stack should include explicit phases for:
+
+- bootstrap tooling
+- environment creation
+- package installation
+- model acquisition or verification
+- runtime verification
+
+The final storage policy should separate:
+
+- small metadata in `userData`
+- heavyweight runtime payloads in a dedicated app-managed runtime location
+
+# Relationship to earlier decisions
+
+This ADR builds on ADR-0003.
+
+ADR-0003 chose the runtime family and ownership direction:
+
+- app-managed optional WhisperLiveKit localhost runtime
+
+This ADR narrows the install architecture inside that direction:
+
+- full app ownership of bootstrap tooling, Python, environment, and model storage policy
+
+# Verdict
+
+Use app-managed `uv`, app-managed Python, app-managed environment ownership, and app-managed model ownership for the WhisperLiveKit local runtime install path. Keep heavyweight runtime payloads outside `userData`, and treat runtime validity as reinstallable state rather than preserving compatibility logic indefinitely.

--- a/docs/research/0004-local-runtime-storage-and-tooling-options.md
+++ b/docs/research/0004-local-runtime-storage-and-tooling-options.md
@@ -1,0 +1,242 @@
+---
+title: Evaluate local runtime storage and Python tooling options
+description: Study whether the WhisperLiveKit runtime should keep using pip in userData or move to a different installer and storage location.
+date: 2026-03-19
+status: concluded
+review_by: 2026-04-19
+links:
+  decision: ADR-0003
+tags:
+  - research
+  - whisperlivekit
+  - uv
+  - pip
+  - electron
+  - storage
+---
+
+<!--
+Where: docs/research/0004-local-runtime-storage-and-tooling-options.md
+What: Research note comparing runtime installer and storage options for the app-managed WhisperLiveKit runtime.
+Why: The current implementation uses pip inside userData, and we need an evidence-backed recommendation before changing it.
+-->
+
+# Local Runtime Storage and Tooling Research
+
+## Scope
+
+Study two questions in the current local WhisperLiveKit architecture:
+
+- should the app keep using `pip` for runtime installation, or switch to `uv`
+- should the app keep storing the managed runtime under Electron `userData`, or move the large runtime payload elsewhere
+
+This document is research only. It does not change code or the durable spec.
+
+## Relationship to later research
+
+This note answers the "what is the safest next step from the current implementation" question.
+
+Its recommendation is intentionally incremental:
+
+- keep `pip` for the next change
+- move the heavy runtime payload out of `userData` first
+- revisit `uv` after the storage policy is settled
+
+Later notes refine different questions:
+
+- [0005-whisperlivekit-install-ownership-tradeoffs.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0005-whisperlivekit-install-ownership-tradeoffs.md) studies install ownership and explains why Dicta should keep runtime ownership in-app
+- [0006-best-whisperlivekit-in-app-install-approach.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0006-best-whisperlivekit-in-app-install-approach.md) describes the strongest clean-slate end-state architecture if Dicta chooses to remove compatibility constraints rather than optimize for the next incremental migration step
+
+## Current implementation
+
+The merged implementation currently does this:
+
+- requires host Python `>=3.11 <3.14`
+- creates a staging virtual environment
+- upgrades `pip` inside that environment
+- installs the pinned package spec `whisperlivekit[voxtral-mlx]==0.2.20.post1`
+- atomically swaps the staging root into the committed runtime root on success
+- stores the runtime under `app.getPath('userData')/local-runtime/whisperlivekit`
+
+Current source references:
+
+- [src/shared/local-runtime.ts](/workspace/.worktrees/research-local-runtime-storage-tooling/src/shared/local-runtime.ts)
+- [src/main/services/local-runtime-install-manager.ts](/workspace/.worktrees/research-local-runtime-storage-tooling/src/main/services/local-runtime-install-manager.ts)
+- [specs/spec.md](/workspace/.worktrees/research-local-runtime-storage-tooling/specs/spec.md)
+
+## Verified external facts
+
+### Electron storage guidance
+
+Electron documents `userData` as the directory for app configuration and user data, and explicitly says it is not recommended for large files because some environments may back it up to cloud storage.
+
+Electron also documents `sessionData` as potentially very large and recommends moving it away from `userData` when large Chromium-managed data would otherwise pollute that directory.
+
+Primary source:
+
+- https://www.electronjs.org/docs/latest/api/app
+
+Implication:
+
+- the current runtime location under `userData` is stable and easy to reason about
+- but it is a poor fit for a Python virtualenv plus model/backend artifacts if the payload becomes large
+- the concern is not theoretical; Electron documents this exact category of risk
+
+### uv installation model
+
+`uv` is not part of the standard Python installation. It must itself be installed first, for example via:
+
+- Astral's standalone installer
+- `pipx install uv`
+- `pip install uv`
+- Homebrew or another package manager
+
+The `uv` docs also separate the project model from the `uv pip` compatibility interface and note that the `uv pip` interface expects a virtual environment by default.
+
+Primary sources:
+
+- https://docs.astral.sh/uv/getting-started/installation/
+- https://docs.astral.sh/uv/concepts/projects/
+- https://docs.astral.sh/uv/pip/environments/
+
+Implication:
+
+- switching this app from `pip` to `uv` is not just swapping one command string for another
+- the app would need a policy for how `uv` itself is provisioned, pinned, updated, and trusted
+
+## Why pip was the simpler first implementation
+
+There is no explicit ADR that says "`pip` was chosen because ...". This section is an inference from the current code.
+
+The current install manager only assumes:
+
+- a supported system Python exists
+- `venv` is available from that Python
+- `pip` can run inside the created environment
+
+That keeps the bootstrap surface narrow:
+
+- no second tool must be installed before runtime installation starts
+- no extra binary version needs to be pinned or updated
+- the app can drive install with three predictable commands:
+  - `python -m venv ...`
+  - `<venv-python> -m pip install --upgrade pip`
+  - `<venv-python> -m pip install --upgrade <pinned-package-spec>`
+
+For the current case, the package workload is also simple:
+
+- one pinned package spec
+- one backend extra
+- one app-managed environment
+- no `pyproject.toml`-style project workspace
+
+That makes `pip` a reasonable first bootstrap choice even if `uv` is attractive long-term.
+
+## uv advantages if we choose to pay the bootstrap cost
+
+If the app were willing to manage `uv` itself, `uv` would bring real benefits:
+
+- faster dependency resolution and install
+- a stronger path toward reproducible lock-driven environments
+- unified Python acquisition and environment management if we later decide the app should provision Python too
+- a cleaner future if the runtime grows beyond one pinned package spec
+
+These are real benefits, but they only pay off once we accept the extra lifecycle surface:
+
+- how `uv` is installed
+- where its binary lives
+- how its version is pinned
+- whether the app allows `uv` to download Python
+- how support diagnostics distinguish `uv` bootstrap failures from runtime package failures
+
+## Storage options
+
+### Option A: Keep the runtime under userData
+
+Benefits:
+
+- simplest implementation
+- path is already app-managed and stable
+- no new platform-specific directory policy
+- no migration work
+
+Costs:
+
+- Electron explicitly warns against large files here
+- virtualenv plus backend/model payload may bloat a directory that some platforms back up
+- config/state and heavyweight runtime assets stay mixed together
+
+Assessment:
+
+- acceptable as a first shipped implementation
+- weak as a durable storage choice if the runtime grows or if backup pollution matters
+
+### Option B: Keep metadata in userData, move runtime payload to a dedicated app-managed data/cache location
+
+Benefits:
+
+- aligns better with Electron's warning about large files
+- keeps configuration/state separate from heavyweight install artifacts
+- makes future cleanup and migrations easier
+
+Costs:
+
+- Electron does not provide one perfect cross-platform "large app-managed runtime" path for this exact use case
+- we would need an explicit path policy per platform
+- migration logic is required for existing installs
+- release/support docs must define whether the runtime is treated as cache-like, durable app data, or user-removable auxiliary data
+
+Assessment:
+
+- strongest direction if we want to harden this architecture
+- should be chosen deliberately, not casually, because it becomes product policy
+
+### Option C: Move to uv and move storage at the same time
+
+Benefits:
+
+- one migration event instead of two
+- can redesign runtime management more holistically
+
+Costs:
+
+- conflates two independent variables
+- makes failures harder to isolate
+- raises risk substantially for a feature that already has meaningful lifecycle complexity
+
+Assessment:
+
+- not recommended as the next step
+
+## Recommendation
+
+Do not change both variables at once.
+
+Recommended order:
+
+1. Keep `pip` for now.
+2. Move the runtime payload out of `userData` first, while keeping install semantics otherwise the same.
+3. Re-evaluate `uv` only after the storage policy is settled and migration is proven.
+
+Why this order is better:
+
+- the storage concern is directly supported by Electron's official guidance
+- the `pip` concern is more about engineering preference and future ergonomics than a present correctness problem
+- changing storage alone isolates the more concrete risk
+- changing both tooling and storage together would create unnecessary diagnostic ambiguity
+
+## Suggested follow-up decision
+
+If implementation proceeds, the next design step should be an ADR or focused plan that answers:
+
+- what exact path should hold the managed runtime on each supported platform
+- which parts remain in `userData` versus move out
+- whether the runtime is considered cache-like or durable app data
+- how existing `userData/local-runtime/whisperlivekit` installs are migrated safely
+- whether uninstall removes only the runtime payload or also associated metadata
+
+## Bottom line
+
+The current `pip` choice is understandable for first bootstrap simplicity.
+
+The current `userData` storage choice is the weaker part of the design. Electron's own docs make that concern credible, so if we change one thing next, storage location should move before installer tooling.

--- a/docs/research/0005-whisperlivekit-install-ownership-tradeoffs.md
+++ b/docs/research/0005-whisperlivekit-install-ownership-tradeoffs.md
@@ -1,0 +1,563 @@
+---
+title: Study WhisperLiveKit install ownership trade-offs
+description: Analyze how WhisperLiveKit installation actually works and compare app-managed installation against assuming the runtime and model are already installed.
+date: 2026-03-19
+status: concluded
+review_by: 2026-04-19
+links:
+  decision: ADR-0003
+tags:
+  - research
+  - whisperlivekit
+  - installation
+  - runtime
+  - models
+  - huggingface
+---
+
+<!--
+Where: docs/research/0005-whisperlivekit-install-ownership-tradeoffs.md
+What: Research note about WhisperLiveKit package/runtime/model installation ownership and its implications for this app.
+Why: The app must choose whether to own installation end-to-end or assume the runtime/model already exists, and that choice changes UX, support, security, and operational complexity.
+-->
+
+# WhisperLiveKit Install Ownership Trade-offs
+
+## Scope
+
+Study this product and architecture question in detail:
+
+- should the app install and manage WhisperLiveKit itself
+- or should the app assume the local WhisperLiveKit runtime and model are already installed
+
+This note covers how WhisperLiveKit installation actually works upstream, what "installed" means at each layer, and how those facts change the trade-off for this repo.
+
+This is research only. No implementation is included in this change.
+
+## Relationship to adjacent research
+
+This note sits between two narrower questions:
+
+- [0004-local-runtime-storage-and-tooling-options.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0004-local-runtime-storage-and-tooling-options.md) asks what the safest next incremental migration step is from the current implementation
+- [0006-best-whisperlivekit-in-app-install-approach.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0006-best-whisperlivekit-in-app-install-approach.md) asks what the strongest clean-slate end-state in-app install architecture would be if compatibility constraints are intentionally relaxed
+
+This note answers the broader ownership question that informs both.
+
+## Executive summary
+
+The key fact is that "WhisperLiveKit installed" is not one thing. It is at least four separate layers:
+
+1. Python runtime exists.
+2. WhisperLiveKit package plus required extras are installed.
+3. Model weights are available locally.
+4. The local service can start and answer requests successfully.
+
+For the current Dicta architecture, app-managed install is the stronger primary approach.
+
+Why:
+
+- the current ADR and spec already assume app-owned installation, version pinning, supervision, and uninstall
+- WhisperLiveKit package installation does not guarantee model availability
+- assuming a user-managed installation creates version drift, cache-location ambiguity, weaker observability, weaker uninstall/update semantics, and more support burden
+
+The strongest product posture is:
+
+- app owns installation of the Python environment and WhisperLiveKit package
+- app owns or constrains the model cache location
+- app verifies both package and model readiness before reporting the runtime ready
+- "assume already installed" remains at most an expert or development override, not the main product path
+
+## Current Dicta baseline
+
+The current merged Dicta code and spec already define the local path as an app-managed runtime:
+
+- [docs/adr/0003-use-whisperlivekit-managed-localhost-runtime-for-local-streaming.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/adr/0003-use-whisperlivekit-managed-localhost-runtime-for-local-streaming.md)
+- [specs/spec.md](/workspace/.worktrees/research-local-runtime-storage-tooling/specs/spec.md)
+- [src/shared/local-runtime.ts](/workspace/.worktrees/research-local-runtime-storage-tooling/src/shared/local-runtime.ts)
+- [src/main/services/local-runtime-install-manager.ts](/workspace/.worktrees/research-local-runtime-storage-tooling/src/main/services/local-runtime-install-manager.ts)
+
+The current implementation assumptions are:
+
+- Python `>=3.11 <3.14`
+- app-managed staging environment
+- pinned package spec `whisperlivekit[voxtral-mlx]==0.2.20.post1`
+- app-managed install state machine
+- app-managed uninstall and update semantics
+
+This matters because "assume already installed" is not just an implementation variation. It would change the ownership model already accepted in ADR-0003.
+
+## What WhisperLiveKit installation actually consists of
+
+WhisperLiveKit installation splits into multiple layers that can succeed or fail independently.
+
+### Layer 1: Python runtime
+
+From the pinned upstream package metadata:
+
+- `requires-python = ">=3.11, <3.14"`
+
+That matches Dicta's current manifest.
+
+Primary source:
+
+- vendored source archive `pyproject.toml` in `resources/references/whisperlivekit-0.2.20.post1-pypi-source.zip`
+
+### Layer 2: WhisperLiveKit package plus extras
+
+The base package includes the server and shared dependencies such as:
+
+- `fastapi`
+- `uvicorn`
+- `huggingface-hub`
+- `faster-whisper`
+- `torch`
+- `torchaudio`
+
+Optional extras add backend-specific capabilities. Relevant ones include:
+
+- `voxtral-mlx`
+- `voxtral-hf`
+- `mlx-whisper`
+- `cpu`
+- `cu129`
+- `translation`
+- diarization extras
+
+For Dicta's current local provider, the relevant pinned spec is:
+
+```text
+whisperlivekit[voxtral-mlx]==0.2.20.post1
+```
+
+Important consequence:
+
+- installing the Python package plus extras does not mean the Voxtral model weights are already present on disk
+
+### Layer 3: model weights and backend assets
+
+Upstream exposes model management through the `wlk` CLI:
+
+- `wlk models`
+- `wlk pull <model>`
+- `wlk rm <model>`
+- `wlk run <model>`
+
+The CLI maps high-level names to model repositories. Relevant examples in the pinned source:
+
+- `voxtral-mlx` → `mlx-community/Voxtral-Mini-4B-Realtime-6bit`
+- `voxtral` → `mistralai/Voxtral-Mini-4B-Realtime-2602`
+- Whisper-family models map to Hugging Face repos or native Whisper cache files
+
+The `wlk pull` command uses `huggingface_hub.snapshot_download(repo_id)`.
+
+Important consequence:
+
+- package installation and model download are separate lifecycle steps
+- a runtime can be "installed" at the package level while still not having the needed model available locally
+
+### Layer 4: server process and readiness
+
+Even after package and model installation succeed, WhisperLiveKit still has to:
+
+- choose a backend
+- load or resolve the model
+- initialize the server
+- bind a host and port
+- answer health or websocket requests
+
+So there is a final operational boundary:
+
+- "installed" is not the same as "ready to transcribe"
+
+That distinction is already reflected in Dicta's design, where install management and service supervision are different responsibilities.
+
+## What the upstream CLI reveals
+
+The pinned WhisperLiveKit CLI is extremely informative for this decision.
+
+### `wlk run` already assumes a cache-aware lifecycle
+
+`wlk run <model>`:
+
+- resolves the model spec
+- scans for already-downloaded models
+- auto-pulls the model if not found
+- then starts the server
+
+That means upstream itself does not treat package install as enough. It treats package install plus model presence as the minimum usable unit.
+
+### `wlk models` and `_scan_downloaded_models()` reveal cache ownership
+
+The pinned source scans:
+
+- Hugging Face cache via `huggingface_hub.scan_cache_dir()`
+- native Whisper cache in `~/.cache/whisper`
+
+This is critical.
+
+By default, WhisperLiveKit's notion of "downloaded model" is based on global user cache locations, not an app-owned model root.
+
+Implication:
+
+- if Dicta simply installs WhisperLiveKit and lets it use defaults, downloaded models may live in global caches outside Dicta's owned runtime root
+- uninstall, disk accounting, backup policy, and support diagnostics become less explicit
+
+### `--model-path` supports multiple ownership modes
+
+Upstream documents:
+
+- `--model-path` can point to a local file or directory
+- `--model-path` can also be a Hugging Face repo ID
+
+This makes three practical modes possible:
+
+1. model selected by name, resolved through default caches
+2. explicit local model path chosen by the caller
+3. repo-id-driven lazy or managed fetch
+
+That flexibility is useful, but it also means that "assume the model is installed" can hide multiple different operational contracts.
+
+## Model storage facts relevant to this decision
+
+### WhisperLiveKit model pulls default to Hugging Face cache
+
+`snapshot_download()` downloads into the Hugging Face local cache by default.
+
+Per Hugging Face's official docs:
+
+- default Hub cache is under `~/.cache/huggingface/hub`
+- cache location can be changed via `cache_dir`, `HF_HOME`, or `HF_HUB_CACHE`
+
+Primary sources:
+
+- https://huggingface.co/docs/huggingface_hub/guides/download
+- https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+
+Implication:
+
+- if Dicta wants app-owned model storage, it cannot just rely on WhisperLiveKit defaults
+- Dicta must explicitly control the Hugging Face cache location or download destination
+
+### Native Whisper cache is a second independent cache
+
+The pinned CLI also scans `~/.cache/whisper` for native Whisper `.pt` files.
+
+Implication:
+
+- "already installed locally" may mean different caches depending on backend
+- support and cleanup logic become backend-sensitive if ownership is not centralized
+
+## Two candidate approaches
+
+There are two main product postures.
+
+### Approach A: app-managed in-app install
+
+The app owns:
+
+- Python environment bootstrap
+- package install with pinned extras
+- model download or cache placement
+- runtime verification
+- service startup and readiness checks
+- uninstall and update semantics
+
+User experience:
+
+- user opts in once
+- app performs installation
+- app can show progress, failures, retries, cancel, and uninstall
+- app can say "runtime ready" only after package and model are both in place
+
+### Approach B: assume local runtime or model is already installed
+
+There are actually several subvariants:
+
+1. app assumes package and model already exist globally
+2. app installs package, but assumes model is already cached
+3. app assumes the user supplies an env path, executable path, or model path
+4. app assumes a local service is already running elsewhere
+
+These are materially different contracts, but all share one property:
+
+- ownership shifts away from the app and toward user-managed or environment-managed state
+
+## How Approach A works in practice
+
+For Dicta, a robust in-app install path would mean:
+
+1. user explicitly approves local runtime installation
+2. app creates or acquires a managed Python environment
+3. app installs the pinned WhisperLiveKit package spec with required extras
+4. app pre-pulls or otherwise verifies the required model/backend assets
+5. app stores install metadata
+6. app launches the localhost service with controlled env and cache settings
+7. app proves readiness through authenticated probes before exposing the runtime as usable
+
+Important nuance:
+
+- if the app only installs `whisperlivekit[voxtral-mlx]` and waits for first run to pull the model lazily, install completion and first transcription readiness become different product states
+- if the app wants a clean UX, it should either pre-pull the required model or represent "package installed, model pending" as an explicit intermediate state
+
+## How Approach B works in practice
+
+If the app assumes the runtime or model is already installed, it still has to answer these questions:
+
+- where is the Python executable
+- where is the WhisperLiveKit package installed
+- which extras are present
+- which backend is actually usable
+- where are the model weights stored
+- which model revision is cached
+- what should happen if the expected model is missing
+- what should happen if the model exists but the package version or backend support is incompatible
+
+That means this approach removes install ownership but does not remove validation complexity.
+
+It mostly relocates failure from a managed install step into first-use diagnostics.
+
+## Trade-off analysis
+
+### Product UX
+
+App-managed install is stronger.
+
+Why:
+
+- the app can present one coherent opt-in flow
+- the app can show progress and phase information
+- the app can make "ready" mean something concrete
+
+Assume-installed is weaker.
+
+Why:
+
+- first use becomes a discovery exercise
+- user has to understand Python, extras, models, or caches
+- failure messages become more technical and less actionable
+
+### Version control
+
+App-managed install is stronger.
+
+Why:
+
+- app pins exact package version and extras
+- app can define upgrade policy
+- app can reinstall deterministically
+
+Assume-installed is weaker.
+
+Why:
+
+- the app inherits package drift
+- the app may see old caches or incompatible revisions
+- package and model versions may not align
+
+### Model ownership
+
+App-managed install is stronger only if the app also owns the model cache path.
+
+Why:
+
+- package install alone is not enough
+- without cache control, model assets can still escape into generic user caches
+
+This is the single most important operational nuance in the whole decision.
+
+### Failure handling
+
+App-managed install is stronger.
+
+Why:
+
+- failures can be localized to explicit install phases
+- rollback and cancel semantics can be defined
+- corrupted runtime roots can be replaced atomically
+
+Assume-installed is weaker.
+
+Why:
+
+- many failures collapse into "it doesn't work on this machine"
+- diagnosis often requires inspecting external state the app does not own
+
+### Observability
+
+App-managed install is stronger.
+
+Why:
+
+- the app can log the exact package version, backend, model repo, cache root, and runtime root
+- the app can explain which phase failed
+
+Assume-installed is weaker.
+
+Why:
+
+- failures depend on global caches and user environment state
+- support diagnostics become more open-ended
+
+### Security and trust surface
+
+Neither approach is free.
+
+App-managed install adds:
+
+- package download and model download logic inside the app
+- stronger responsibility for integrity checks and storage policy
+
+Assume-installed adds:
+
+- weaker control over what code and models are actually being executed
+- more trust in user environment drift
+
+For Dicta's current security posture, app-managed install is still the stronger fit because it reduces ambiguity even though it increases responsibility.
+
+### Uninstall and disk accounting
+
+App-managed install is stronger if and only if all payloads live under app-owned roots.
+
+If WhisperLiveKit uses default global caches, uninstall becomes partial:
+
+- the app can remove its virtualenv
+- but not necessarily all downloaded models
+
+That would be a leaky contract.
+
+Therefore:
+
+- app-managed install should include app-managed cache configuration if it wants clean uninstall semantics
+
+### Change cost
+
+App-managed install has higher initial implementation cost.
+
+Assume-installed has higher long-term support and product cost.
+
+For a developer tool or expert utility, assume-installed can be acceptable.
+For a consumer-facing desktop app with guided setup expectations, it is usually the worse long-term trade.
+
+## The most important ambiguity to avoid
+
+"Install WhisperLiveKit in-app" can still be implemented badly if it only installs the package and leaves model ownership implicit.
+
+That creates a misleading state model:
+
+- package installed
+- model maybe present somewhere
+- service maybe warmable
+- first user recording still triggers hidden downloads or fails on missing assets
+
+So the real decision is not simply:
+
+- app installs package
+
+The real decision is:
+
+- does the app own the full runnable runtime, including model assets and their storage location
+
+## What "assume the local model is already installed" actually means
+
+This phrase needs to be decomposed before any implementation starts.
+
+Possible meanings:
+
+1. the package is installed and the correct Hugging Face repo is already cached in the default HF cache
+2. the package is installed and the app is given an explicit model path
+3. the user already has a working `wlk` environment on the machine
+4. a WhisperLiveKit service is already running and the app only needs an endpoint
+
+These are not equivalent.
+
+Each one changes:
+
+- ownership
+- update semantics
+- uninstall semantics
+- error messaging
+- documentation burden
+
+If this path were ever chosen, the app would need to narrow it to one explicit contract, not leave it ambiguous.
+
+## Compatibility with current Dicta architecture
+
+Approach A aligns with the current accepted architecture.
+
+Approach B conflicts with existing durable decisions.
+
+Specifically, Dicta has already accepted:
+
+- app-managed optional install
+- app-managed version pinning
+- app-managed runtime supervision
+- explicit install state published to the renderer
+- rejection of user-managed runtime installation as the primary product path
+
+So choosing assume-installed would not be a mere implementation tweak.
+It would require revisiting the existing ADR and spec.
+
+## Comparison to reference products
+
+The recent reference study also helps frame this choice.
+
+### WhiskrIO pattern
+
+WhiskrIO shells out to `uvx` and delegates model installation and caching to external tooling.
+
+That is effectively an assume-installed or tool-managed posture.
+
+It reduces app-owned install code but weakens:
+
+- version control
+- cache ownership
+- uninstall semantics
+- cross-machine determinism
+
+### Epicenter Whispering pattern
+
+Epicenter Whispering downloads and owns model files itself inside app-managed directories.
+
+That is much closer to the ownership model Dicta wants.
+
+However, Dicta still needs to be stricter about storage policy than blindly copying that path choice, because Electron's `userData` warning makes large-file placement more sensitive here.
+
+## Recommendation
+
+For Dicta, the best primary product path remains:
+
+- app-managed WhisperLiveKit installation
+- app-managed model ownership
+- app-managed readiness checks
+
+Not just:
+
+- install the package
+
+But:
+
+- own the full runnable runtime, including model storage policy
+
+The strongest operational contract is:
+
+1. app installs the pinned WhisperLiveKit package and extras
+2. app explicitly prefetches or verifies the required Voxtral model assets
+3. app controls the Hugging Face cache or model destination so payload ownership is explicit
+4. app reports ready only after both package and model are usable
+
+The "assume already installed" path should be treated, at most, as:
+
+- a developer override
+- an expert-mode escape hatch
+- or a future advanced integration surface
+
+It should not be the default product contract.
+
+## Bottom line
+
+WhisperLiveKit package installation and model installation are separate concerns.
+
+That single fact is the core of this decision.
+
+If Dicta owns installation, it should own both layers and the storage policy around them.
+If Dicta assumes the model is already installed, it inherits ambiguity in caches, versions, support, and readiness that conflicts with the architecture this repo has already chosen.

--- a/docs/research/0006-best-whisperlivekit-in-app-install-approach.md
+++ b/docs/research/0006-best-whisperlivekit-in-app-install-approach.md
@@ -1,0 +1,460 @@
+---
+title: Recommend the best WhisperLiveKit in-app install approach
+description: Define the recommended app-managed installation architecture for WhisperLiveKit, including toolchain ownership, model ownership, storage policy, readiness, and failure handling.
+date: 2026-03-19
+status: concluded
+review_by: 2026-04-19
+links:
+  decision: ADR-0003
+tags:
+  - research
+  - whisperlivekit
+  - installation
+  - uv
+  - python
+  - runtime
+---
+
+<!--
+Where: docs/research/0006-best-whisperlivekit-in-app-install-approach.md
+What: Research note recommending the concrete in-app installation design for WhisperLiveKit in Dicta.
+Why: High-level ownership trade-offs are not enough to implement safely; the app needs one explicit install architecture with named boundaries and failure semantics.
+-->
+
+# Best WhisperLiveKit In-App Install Approach
+
+## Scope
+
+Recommend the best concrete in-app install architecture for WhisperLiveKit in Dicta.
+
+This is narrower than the earlier ownership question. It assumes Dicta will own installation and answers:
+
+- what toolchain should the app own
+- where should the runtime payload live
+- when should model weights be downloaded
+- what should count as "installed" versus "ready"
+- how should update, uninstall, retry, and corruption recovery work
+
+This is research only. No implementation is included in this change.
+
+## Relationship to earlier research
+
+This note describes the strongest clean-slate end-state architecture, not the lowest-risk next incremental change from the current codebase.
+
+That distinction matters:
+
+- [0004-local-runtime-storage-and-tooling-options.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0004-local-runtime-storage-and-tooling-options.md) recommends keeping `pip` and moving storage first as the safer next step from today's implementation
+- [0005-whisperlivekit-install-ownership-tradeoffs.md](/workspace/.worktrees/research-local-runtime-storage-tooling/docs/research/0005-whisperlivekit-install-ownership-tradeoffs.md) explains why Dicta should own the install path rather than assume the runtime or model is already installed
+
+This note answers a different question:
+
+- if Dicta intentionally optimizes for the cleanest long-term architecture and is willing to remove compatibility constraints, what should the end-state install design be
+
+## Short answer
+
+The best in-app install approach is:
+
+- Dicta owns the bootstrap toolchain completely
+- Dicta owns one dedicated runtime root outside Electron `userData`
+- Dicta keeps only small install metadata and UI state in `userData`
+- Dicta installs a pinned Python toolchain and a pinned WhisperLiveKit environment under that runtime root
+- Dicta explicitly downloads or verifies the required model assets during install, instead of treating first-run lazy fetch as "ready"
+- Dicta reports `ready` only after package, model, and service-readiness checks all pass
+- Dicta treats version mismatch or corruption as reinstallable state, not as something to patch in place indefinitely
+
+For a clean-slate architecture, the strongest long-term toolchain owner is app-managed `uv`, not user-managed `uv`, and not host-Python-plus-pip.
+
+## Why this note recommends a stronger design than the current implementation
+
+The current Dicta implementation is a reasonable first pass:
+
+- host Python is discovered
+- a managed venv is created
+- `pip` installs the pinned package spec
+- install occurs into a staging root and is atomically committed
+
+That is acceptable as an incremental implementation.
+
+But if the goal is the best long-term in-app install architecture with minimal hidden coupling and reduced error surface, it is not the best final shape.
+
+The two biggest weaknesses in the current approach are:
+
+1. bootstrap depends on host Python availability and version compatibility
+2. the implementation currently treats package install as the center of ownership, while model ownership still needs to be made explicit
+
+## Design axes that matter
+
+There are five design axes that determine whether the install architecture stays clean.
+
+### 1. Toolchain ownership
+
+Choices:
+
+- host Python plus `pip`
+- app-managed `uv`
+- user-managed `uv` or `uvx`
+
+### 2. Model ownership
+
+Choices:
+
+- rely on WhisperLiveKit default global caches
+- explicitly control the model cache path
+- ask the user for a model path
+
+### 3. Storage policy
+
+Choices:
+
+- keep everything under `userData`
+- split metadata and payload
+- put payload in a dedicated app-managed runtime directory
+
+### 4. Readiness semantics
+
+Choices:
+
+- package installed means ready
+- package installed means partially ready
+- ready means package + model + successful runtime probe
+
+### 5. Recovery policy
+
+Choices:
+
+- try to preserve and patch every old state forever
+- keep migration minimal and prefer explicit reinstall when the state is invalid
+
+These axes are interdependent. The best design is the one that keeps all five coherent at once.
+
+## Candidate in-app install architectures
+
+### Option A: host Python + pip + app-owned venv + default Hugging Face cache
+
+How it works:
+
+- detect Python on host
+- create venv
+- install pinned package spec with `pip`
+- let WhisperLiveKit use default model cache behavior
+
+Benefits:
+
+- smallest bootstrap implementation
+- no extra bootstrap binary
+- easy incremental path from current implementation
+
+Costs:
+
+- depends on host Python being present and acceptable
+- model assets may escape to global caches
+- uninstall semantics are incomplete
+- "ready" can still hide first-run model fetches
+
+Assessment:
+
+- good first implementation
+- not the best final architecture
+
+### Option B: host Python + pip + app-owned venv + app-owned model cache
+
+How it works:
+
+- same as Option A
+- but Dicta explicitly controls Hugging Face cache location or model destination
+
+Benefits:
+
+- removes the biggest ownership leak from Option A
+- preserves simpler bootstrap
+- improves uninstall, disk accounting, and observability
+
+Costs:
+
+- still depends on host Python
+- still inherits host Python drift and missing-tool failures
+
+Assessment:
+
+- stronger than current implementation
+- still not the cleanest end state
+
+### Option C: app-managed `uv` + app-managed Python + app-owned runtime and model cache
+
+How it works:
+
+- Dicta acquires a pinned `uv` binary itself
+- Dicta uses that exact `uv` to provision the Python runtime and environment it wants
+- Dicta installs WhisperLiveKit and extras under one app-owned runtime root
+- Dicta controls model cache location under that same ownership domain
+- Dicta verifies package and model readiness before exposing the runtime as ready
+
+Benefits:
+
+- app owns the entire bootstrap stack
+- no dependency on user-installed Python or `uv`
+- deterministic across machines
+- cleaner upgrade and reinstall semantics
+- fewer host-environment branches
+
+Costs:
+
+- more implementation work up front
+- app must manage the `uv` binary lifecycle too
+- Python provisioning policy becomes part of the product
+
+Assessment:
+
+- best long-term architecture if Dicta is serious about owning the runtime cleanly
+
+### Option D: app-managed package install but lazy model pull on first use
+
+How it works:
+
+- package install completes first
+- model download happens only when user first records
+
+Benefits:
+
+- lower install-time payload
+- faster initial install flow
+
+Costs:
+
+- "installed" and "ready" diverge in a confusing way
+- first real use becomes a surprise dependency download
+- harder to distinguish install success from first-run operational failure
+
+Assessment:
+
+- acceptable only if the product exposes "runtime installed, model pending" as a distinct state
+- not the best default for a polished desktop flow
+
+## Recommended architecture
+
+### Recommendation
+
+Choose Option C.
+
+More precisely:
+
+- app-managed `uv`
+- app-managed Python
+- app-managed WhisperLiveKit environment
+- app-managed model cache location
+- app-managed runtime root outside `userData`
+- explicit model prefetch or verification before `ready`
+
+This is the cleanest design when judged on responsibility, coupling, changeability, failure handling, observability, and explicit state.
+
+## What "app-managed uv" means
+
+This point needs to stay explicit because it is easy to get wrong.
+
+It does **not** mean:
+
+- call `uv` or `uvx` from `PATH`
+- rely on whichever version the user has installed
+- inherit user-specific `uv` behavior or cache policy
+
+It **does** mean:
+
+- Dicta pins one exact `uv` version
+- Dicta bundles or downloads that exact binary itself
+- Dicta invokes it by absolute path
+- Dicta ignores the user's `uv`
+
+That turns `uv` into an internal implementation detail of Dicta's runtime manager, not an external prerequisite.
+
+## Recommended runtime layout
+
+The runtime layout should separate small metadata from heavyweight payload.
+
+### `userData` should contain
+
+- install state visible to the renderer
+- install metadata for the current committed runtime
+- user-facing summary/detail strings if persisted
+- small logs or references if needed
+
+### dedicated runtime payload root should contain
+
+- bootstrap tool binaries if downloaded on demand
+- managed Python runtime if app-owned
+- WhisperLiveKit environment
+- model cache or model files
+- staging root
+- current committed root
+- backup root only during atomic replacement
+
+### Why split storage
+
+Electron documents `userData` as a poor place for large files. The runtime payload is exactly the kind of heavy asset set that should not be mixed into settings and small app state.
+
+## Recommended install phases
+
+The install state machine should distinguish these phases explicitly.
+
+1. `bootstrap`
+2. `environment`
+3. `package`
+4. `model`
+5. `verify`
+6. `ready`
+
+Recommended meanings:
+
+- `bootstrap`: acquire or validate Dicta-owned `uv`
+- `environment`: create or repair the app-owned Python environment
+- `package`: install pinned WhisperLiveKit package and extras
+- `model`: download or verify required model assets
+- `verify`: launch a short-lived runtime probe and confirm readiness semantics
+- `ready`: all prior phases succeeded
+
+The current Dicta install phases are too package-centric for the ideal end state. The best architecture should make model acquisition and runtime verification first-class phases.
+
+## Recommended readiness contract
+
+The app should never treat "package installed" as "runtime ready".
+
+The recommended contract is:
+
+- `installed`: environment exists and package install succeeded
+- `ready`: required model assets are present and a runtime probe succeeds
+
+This distinction matters because WhisperLiveKit's own CLI reveals that model pull is a separate lifecycle concern and that backend readiness depends on more than just package presence.
+
+## Recommended model strategy
+
+The best in-app install path should make one deliberate choice:
+
+- prefetch the required model during install
+
+Why:
+
+- it makes disk cost explicit
+- it makes progress reporting honest
+- it allows a meaningful `ready` state
+- it avoids surprising first-use downloads
+- it allows deterministic verification
+
+The alternative is only acceptable if the app exposes a separate "model pending" state and intentionally accepts that first use is part of installation.
+
+For Dicta's UX goals, prefetch is the better default.
+
+## Recommended verification strategy
+
+Install should not stop at files-on-disk checks.
+
+The app should verify:
+
+- the package and expected extras are importable in the managed environment
+- the model assets are present at the controlled location
+- the local service starts with the intended backend
+- the service responds to an authenticated health or control-plane probe
+
+For a stronger contract, the app may optionally perform a minimal warmup or session-creation check before declaring the runtime ready.
+
+## Recommended update strategy
+
+Update should remain app-managed and session-aware.
+
+The best policy is:
+
+- never update while a local session is active
+- install updates into a staging root
+- verify the staged runtime fully
+- atomically promote staged to current
+- keep rollback minimal and mechanical
+
+Version mismatch should not trigger ad hoc repair logic spread across multiple components. It should resolve through one owner:
+
+- install manager decides whether to reuse, replace, or reinstall the runtime root
+
+## Recommended uninstall strategy
+
+Uninstall should remove:
+
+- the committed runtime root
+- staged remnants
+- model payload owned by the runtime root or runtime cache policy
+
+It should not leave heavyweight model residue behind if the product claims to manage the runtime.
+
+Small metadata in `userData` may remain only if it is useful to preserve state history, but the product contract should be explicit about that.
+
+## Recovery and corruption policy
+
+The cleanest recovery policy is not endless compatibility preservation.
+
+Recommended policy:
+
+- if metadata is invalid, state becomes reinstallable
+- if package integrity or runtime verification fails, state becomes reinstallable
+- if model assets are missing or incompatible, state becomes reinstallable
+- if current root is irreparably inconsistent, remove and reinstall
+
+This is cleaner than accumulating repair branches for every historical install shape.
+
+## Why not rely on user-installed Python
+
+Host Python looks simpler, but it keeps hidden complexity alive:
+
+- Python may be missing
+- version may be unsupported
+- `venv` behavior may vary
+- system configuration may be surprising
+- support burden increases
+
+That makes host Python acceptable as an incremental bridge, but not the best clean in-app install architecture.
+
+## Why not rely on user-installed uv
+
+User-installed `uv` or `uvx` is worse than app-owned `uv`.
+
+Why:
+
+- version drift
+- unpredictable behavior changes
+- cache path ambiguity
+- more environment-sensitive bugs
+- weaker determinism
+
+If `uv` is chosen, the app must own it.
+
+## Trade-off summary
+
+### Why this approach is best
+
+- strongest ownership boundaries
+- least hidden host coupling
+- best observability
+- cleanest uninstall and update story
+- clearest meaning of `ready`
+- lowest long-term support ambiguity
+
+### What it costs
+
+- more implementation work than the current `pip` path
+- more bootstrap responsibility
+- a larger architecture decision surface
+
+### Why it is still worth it
+
+Because WhisperLiveKit is not just a library dependency. It is an optional app-managed runtime with separate package, model, and service lifecycles. Half-owning that stack leads to ambiguity. Fully owning it leads to a cleaner system.
+
+## Final recommendation
+
+The best in-app install approach for Dicta is:
+
+- app-owned `uv`
+- app-owned Python runtime
+- app-owned WhisperLiveKit environment
+- app-owned model cache or model directory
+- heavy payload outside `userData`
+- small metadata in `userData`
+- explicit install phases for package, model, and verification
+- `ready` only after service-level verification
+- reinstall-oriented recovery instead of growing compatibility code forever
+
+If Dicta wants the cleanest long-term local-runtime architecture, this is the design to implement.


### PR DESCRIPTION
## Summary
- add research on local runtime storage and tooling trade-offs
- add detailed WhisperLiveKit install ownership analysis
- add a recommended in-app install end-state architecture for Dicta

## Verification
- pnpm docs:validate
- explorer review after consistency fix: no findings
- claude review after consistency fix: no findings