### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicta",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "v1 macOS speech-to-text app",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary
- bump the app version from `0.3.2` to `0.3.3`
- keep the release trigger aligned with the repo workflow, where a `main` package version bump creates the matching `v0.3.3` tag in the macOS release workflow

## Validation
- `pnpm vitest run scripts/resolve-release-plan.test.ts scripts/report-release-artifacts.test.ts`
- `bash scripts/release-dry-run.sh`

## Review
- Claude review: no issues
- Codex sub-agent review did not return before merge prep; local release flow and dry-run checks were completed directly
