### PR TITLE
fix: stabilize scratch-space popup e2e boot

### DIFF
--- a/docs/e2e-playwright.md
+++ b/docs/e2e-playwright.md
@@ -46,6 +46,10 @@ Artifacts are uploaded on every run:
 - `playwright-report/`
 - `test-results/`
 
+## Fixture contract rule
+- Keep any custom preload used by popup E2E flows aligned with the production `IpcApi` methods that the target renderer boot path calls.
+- For scratch-space coverage specifically, the E2E preload must continue to expose `notifyScratchSpaceReady` and `onOpenScratchSpacePresetMenu` in addition to the mocked transformation hooks; otherwise the popup can open but never finish rendering on CI.
+
 ## Coverage included
 - App launch smoke test (Home/Settings navigation).
 - Settings save flow behavior assertion.

--- a/e2e/electron-ui.e2e.ts
+++ b/e2e/electron-ui.e2e.ts
@@ -115,6 +115,7 @@ const openScratchSpaceWindow = async (electronApp: ElectronApplication, mainPage
   }, { preloadPath, scratchWindowUrl: scratchWindowUrl.toString() })
 
   const scratchWindow = await scratchWindowPromise
+  await scratchWindow.waitForLoadState('domcontentloaded')
   await scratchWindow.waitForSelector('#scratch-space-draft')
   await scratchWindow.bringToFront()
   return scratchWindow

--- a/e2e/fixtures/scratch-space-e2e-preload.cjs
+++ b/e2e/fixtures/scratch-space-e2e-preload.cjs
@@ -11,9 +11,11 @@ const IPC_CHANNELS = {
   getSettings: 'settings:get',
   getScratchSpaceDraft: 'scratch-space:get-draft',
   setScratchSpaceDraft: 'scratch-space:set-draft',
+  notifyScratchSpaceReady: 'scratch-space:renderer-ready',
   hideScratchSpaceWindow: 'scratch-space:hide-window',
   onSettingsUpdated: 'settings:on-updated',
-  onOpenScratchSpace: 'scratch-space:open'
+  onOpenScratchSpace: 'scratch-space:open',
+  onOpenScratchSpacePresetMenu: 'scratch-space:open-preset-menu'
 }
 
 const transformCalls = []
@@ -22,6 +24,7 @@ contextBridge.exposeInMainWorld('speechToTextApi', {
   getSettings: async () => ipcRenderer.invoke(IPC_CHANNELS.getSettings),
   getScratchSpaceDraft: async () => ipcRenderer.invoke(IPC_CHANNELS.getScratchSpaceDraft),
   setScratchSpaceDraft: async (draft) => ipcRenderer.invoke(IPC_CHANNELS.setScratchSpaceDraft, draft),
+  notifyScratchSpaceReady: async () => ipcRenderer.invoke(IPC_CHANNELS.notifyScratchSpaceReady),
   runScratchSpaceTransformation: async (payload) => {
     transformCalls.push({ ...payload })
     return {
@@ -43,6 +46,13 @@ contextBridge.exposeInMainWorld('speechToTextApi', {
     ipcRenderer.on(IPC_CHANNELS.onOpenScratchSpace, handler)
     return () => {
       ipcRenderer.removeListener(IPC_CHANNELS.onOpenScratchSpace, handler)
+    }
+  },
+  onOpenScratchSpacePresetMenu: (listener) => {
+    const handler = () => listener()
+    ipcRenderer.on(IPC_CHANNELS.onOpenScratchSpacePresetMenu, handler)
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.onOpenScratchSpacePresetMenu, handler)
     }
   }
 })

--- a/e2e/fixtures/scratch-space-e2e-preload.test.ts
+++ b/e2e/fixtures/scratch-space-e2e-preload.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Where: e2e/fixtures/scratch-space-e2e-preload.test.ts
+ * What:  Regression tests for the scratch-space E2E preload fixture contract.
+ * Why:   The popup smoke test depends on this test preload matching the production
+ *        scratch-space renderer API surface closely enough to boot reliably.
+ */
+
+import path from 'node:path'
+import fs from 'node:fs'
+import vm from 'node:vm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const exposedValues = new Map<string, unknown>()
+const invoke = vi.fn(async () => {})
+const on = vi.fn()
+const removeListener = vi.fn()
+
+describe('scratch-space-e2e-preload fixture', () => {
+  afterEach(() => {
+    exposedValues.clear()
+    invoke.mockClear()
+    on.mockClear()
+    removeListener.mockClear()
+  })
+
+  it('exposes the scratch-space bootstrap methods required by the renderer', async () => {
+    const fixturePath = path.resolve(process.cwd(), 'e2e/fixtures/scratch-space-e2e-preload.cjs')
+    const fixtureSource = fs.readFileSync(fixturePath, 'utf8')
+    const context = {
+      module: { exports: {} },
+      exports: {},
+      require: (specifier: string) => {
+        if (specifier === 'electron') {
+          return {
+            contextBridge: {
+              exposeInMainWorld: (key: string, value: unknown) => {
+                exposedValues.set(key, value)
+              }
+            },
+            ipcRenderer: {
+              invoke,
+              on,
+              removeListener
+            }
+          }
+        }
+
+        throw new Error(`Unexpected fixture dependency: ${specifier}`)
+      }
+    }
+
+    vm.runInNewContext(fixtureSource, context, { filename: fixturePath })
+
+    const api = exposedValues.get('speechToTextApi') as {
+      notifyScratchSpaceReady?: () => Promise<void>
+      onOpenScratchSpacePresetMenu?: (listener: () => void) => () => void
+    }
+
+    expect(api.notifyScratchSpaceReady).toBeTypeOf('function')
+    expect(api.onOpenScratchSpacePresetMenu).toBeTypeOf('function')
+
+    await api.notifyScratchSpaceReady?.()
+    expect(invoke).toHaveBeenCalledWith('scratch-space:renderer-ready')
+
+    const cleanup = api.onOpenScratchSpacePresetMenu?.(() => {})
+    expect(on).toHaveBeenCalledWith('scratch-space:open-preset-menu', expect.any(Function))
+    cleanup?.()
+    expect(removeListener).toHaveBeenCalledWith('scratch-space:open-preset-menu', expect.any(Function))
+  })
+})


### PR DESCRIPTION
## Summary
- restore the scratch-space E2E preload methods that the popup renderer now requires during boot
- wait for the popup document to reach `domcontentloaded` before asserting on `#scratch-space-draft`
- add a regression test for the CommonJS preload fixture contract and document the fixture-sync rule

## Root cause
The failing macOS run #866 timed out in `routes scratch-space mini menu shortcuts to the expected actions @macos` while waiting for `#scratch-space-draft`.
The scratch-space E2E preload had drifted behind the production `IpcApi` contract and no longer exposed `notifyScratchSpaceReady` or `onOpenScratchSpacePresetMenu`, so the popup renderer could open without completing its expected boot path.

## Verification
- `pnpm exec vitest run e2e/fixtures/scratch-space-e2e-preload.test.ts`
- `pnpm exec playwright test e2e/electron-ui.e2e.ts -g "routes scratch-space mini menu shortcuts to the expected actions"` timed out on this Linux worker under `xvfb-run`, so I relied on the captured macOS artifact/trace plus the new regression test for verification.
