### PR TITLE
docs: plan scratch cmd+k temporary model selection

### DIFF
--- a/docs/plans/001-scratch-space-cmd-k-temporary-model-selection.md
+++ b/docs/plans/001-scratch-space-cmd-k-temporary-model-selection.md
@@ -1,0 +1,407 @@
+---
+title: Implement scratch-space Cmd+K temporary model selection
+description: Add a scratch-local Change model Cmd+K action that applies a provider-plus-model override to the next scratch execution only, defaults to the selected profile model, and preserves the override across retry within the same scratch run.
+date: 2026-04-14
+status: active
+tags:
+  - plan
+  - scratch-space
+  - cmd-k
+  - llm
+  - renderer
+  - main-process
+---
+
+# Implement scratch-space Cmd+K temporary model selection
+
+## Goal
+
+Add a `Change model` item to scratch-space `Cmd+K` so the user can choose a temporary execution target for the next scratch transformation only. The default remains the selected transformation profile's provider/model, the override may cross providers, the override survives retry reopen for the same scratch run, and nothing persists to Settings.
+
+## Target branch
+
+- Base branch: `main`
+- Working branch: `feat/cmd-k-models`
+
+## Scope
+
+In scope:
+
+- scratch-space renderer `Cmd+K` menu changes
+- scratch-local temporary override state for `provider + model`
+- extending scratch-space IPC payload to carry a request-scoped override
+- main-process scratch execution changes so prompts still come from the selected profile while execution target may be overridden
+- filtering or disabling model choices so the menu only offers executable targets
+- unit and renderer coverage for new menu state, execution payload shape, retry behavior, and main-process resolution
+- doc updates required by the feature once implementation begins
+
+Out of scope:
+
+- persistent settings changes
+- profile editor changes
+- global picker changes outside scratch space
+- new providers beyond the existing Google, Ollama, and `openai-subscription` catalog
+- broad scratch-space redesign beyond what is needed to support the extra picker state
+
+## Non-goals
+
+- do not turn `Change model` into `Change profile`
+- do not store temporary overrides in `Settings`
+- do not change scratch-space success semantics from “override applies to the next execution only”
+- do not expose Codex models that the runtime cannot actually execute
+
+## Requirements captured from the clarified spec
+
+- `Cmd+K` keeps its current role as the scratch-local command entrypoint
+- a new top-level item `Change model` opens a second scratch-local picker
+- the picker may choose models across providers
+- selecting a model updates only the next scratch execution
+- after the next scratch execution is triggered, the temporary override resets
+- if execution fails and scratch reopens with `reason: 'retry'`, the temporary override is preserved for that retry cycle
+- when no override is active, execution uses the selected profile's `provider + model`
+- the selected profile continues to own prompts
+
+## Detailed approach
+
+The current architecture is preset-centric:
+
+- renderer sends `presetId`
+- main process resolves a full preset from persisted settings
+- scratch execution uses the preset's prompts and execution target
+
+To support a temporary cross-provider model selection without persisting anything, the implementation should add one new concept:
+
+- an ephemeral scratch override: `provider + model`, attached to the current scratch UI session and optionally sent with the execution request
+
+The implementation should keep the selected profile as the prompt source and treat `Change model` as a request-scoped execution-target override. That keeps the existing preset model honest:
+
+- profile selection still chooses prompt intent
+- model selection changes runtime target only
+
+Because the feature is “next execution only”, the renderer should own the override lifecycle. The main process should not become the long-term store of scratch session state; it only needs enough data on the execution request to resolve the effective target for that invocation.
+
+The one exception is retry behavior. Since retry reopen belongs to the same failed execution flow, the renderer must preserve the override across `onOpenScratchSpace({ reason: 'retry' })` rather than clearing it during the usual refresh path.
+
+## Relevant files and modules
+
+Primary implementation surfaces:
+
+- `src/renderer/scratch-space-app.tsx`
+  Owns `Cmd+K` mini menu state, scratch-local keyboard flow, selected preset state, and execution request payload assembly.
+- `src/renderer/scratch-space-app.test.tsx`
+  Renderer coverage for menu behavior, focus handling, execution payload shape, and retry semantics.
+- `src/shared/ipc.ts`
+  Shared scratch execution payload type must grow to represent an optional override.
+- `src/preload/index.ts`
+  Pass-through for the updated scratch execution payload.
+- `src/main/ipc/register-handlers.ts`
+  Scratch IPC handler signature must accept the extended payload.
+- `src/main/services/scratch-space-service.ts`
+  Resolve the effective provider/model for execution while leaving prompts on the selected profile.
+- `src/main/services/scratch-space-service.test.ts`
+  Main-process coverage for override resolution, next-run semantics, and retry preservation expectations where applicable.
+
+Supporting catalog and runtime surfaces:
+
+- `src/shared/llm.ts`
+  Shared provider/model catalog and labels for the picker.
+- `src/main/services/llm-provider-readiness-service.ts`
+  Existing availability truth for filtering or disabling picker choices.
+- `src/main/services/codex-cli-service.ts`
+  Current hard restriction to `gpt-5.4-mini`; this must inform what the scratch picker exposes.
+- `src/main/services/transformation-service.ts`
+  Existing provider/model allowlist validation seam.
+
+Docs and spec surfaces to update in the implementation change:
+
+- `specs/spec.md`
+- potentially a new ADR only if implementation forces a durable contract change broader than the current spec wording
+- `docs/e2e-playwright.md` if E2E coverage changes materially
+
+## Key design decisions already fixed for this plan
+
+- override scope: next execution only
+- cross-provider switching: allowed
+- retry reopen: keep the temporary override
+- `Cmd+K` UX: top-level `Change model` item opens a second picker
+
+## Risks and open questions
+
+## Risk 1: Codex catalog versus executable runtime mismatch
+
+Current code exposes many `openai-subscription` models in the shared catalog, but `CodexCliService.runTransformation(...)` currently only supports `gpt-5.4-mini`.
+
+Plan consequence:
+
+- implementation must not simply render every catalog entry as executable
+- task ordering should address executable-model filtering before the scratch picker ships
+
+Confidence:
+
+- 95/100 that this is a real blocker for “show all models as selectable”
+
+## Risk 2: scratch menu complexity
+
+The current mini menu is action-only. Adding a nested model picker increases keyboard-state complexity and focus management risk.
+
+Plan consequence:
+
+- write renderer tests before or alongside UI changes
+- keep the nested picker state explicit rather than overloading one flat selection index
+
+Confidence:
+
+- 90/100
+
+## Risk 3: override lifecycle bugs
+
+The feature depends on clearing the override after the next execution, but preserving it on retry. Those states are easy to mix up.
+
+Plan consequence:
+
+- implement the lifecycle explicitly in one small local state machine
+- test fresh open, next execution success, next execution failure with retry, and manual close
+
+Confidence:
+
+- 88/100
+
+## Recommended model exposure rule
+
+Use this rule unless product says otherwise:
+
+- show the union of currently supported execution targets across Google, Ollama, and Codex
+- disable models whose readiness says unavailable
+- additionally disable any Codex catalog entries the runtime cannot execute yet
+
+This keeps the UI aligned with real execution capability instead of catalog optimism.
+
+## Validation strategy
+
+Automated:
+
+- `pnpm test -- scratch-space-app.test.tsx scratch-space-service.test.ts`
+- targeted test runs for any updated shared or IPC types if needed
+- `pnpm docs:validate` after spec/doc changes
+
+Recommended broader regression checks before merge:
+
+- targeted `vitest` runs for:
+  - `src/renderer/scratch-space-app.test.tsx`
+  - `src/main/services/scratch-space-service.test.ts`
+  - `src/main/test-support/ipc-round-trip.test.ts` if IPC payload shape changes affect round-trip coverage
+- optional E2E extension if the scratch `Cmd+K` interaction already has Playwright coverage in this branch
+
+Manual verification:
+
+- open scratch space and confirm the selected profile still defines the default target
+- open `Cmd+K`, choose `Change model`, select a cross-provider target, then execute paste
+- confirm the override resets for the following fresh execution
+- force a failure, ensure retry reopen preserves the override, then retry successfully
+- confirm closing scratch clears the override
+- confirm unavailable models cannot be executed
+
+## Ordered tasks
+
+## Task 1: Define the executable override contract
+
+Goal:
+
+- lock down the exact override payload shape and executable model list before touching UI behavior
+
+Files:
+
+- `src/shared/ipc.ts`
+- `src/shared/llm.ts`
+- `src/main/services/codex-cli-service.ts`
+- `src/main/services/transformation-service.ts`
+- `src/main/test-support/ipc-round-trip.test.ts` if needed
+
+Changes:
+
+- add an optional scratch execution override type that represents `provider + model`
+- decide whether this should be a nested field like `runtimeOverride`
+- define or derive a single source of truth for “executable scratch targets”
+- make that executable-target truth account for the current Codex runtime restriction
+
+Implementation notes:
+
+- prefer a nested field over separate top-level override scalars so the request shape stays coherent
+- do not widen the public type without also updating the preload and handler signatures
+- if the current shared allowlists are kept broad, add a narrower executable-filter helper rather than mutating unrelated settings UI behavior
+
+Definition of done:
+
+- the shared contract can express “no override” and “provider/model override”
+- the codebase has one explicit source for scratch-executable targets
+- Codex non-executable models are either filtered out or clearly marked non-executable for scratch use
+
+## Task 2: Extend scratch IPC and main-process resolution
+
+Goal:
+
+- allow scratch execution requests to carry the override and resolve effective execution target in main process
+
+Files:
+
+- `src/preload/index.ts`
+- `src/main/ipc/register-handlers.ts`
+- `src/main/services/scratch-space-service.ts`
+- `src/main/services/scratch-space-service.test.ts`
+
+Changes:
+
+- extend preload pass-through and IPC handler types for the optional override payload
+- update `ScratchSpaceService.runTransformation(...)` input type
+- keep preset lookup unchanged for prompts
+- resolve effective provider/model as:
+  - override target when provided
+  - else selected preset target
+- keep all existing output, retry, and draft semantics unchanged
+
+Implementation notes:
+
+- keep prompt ownership on the preset to avoid mixing “profile intent” with “runtime target”
+- do not add persistent state to `ScratchSpaceService`
+- validate the override before dispatch so failures are explicit and actionable
+
+Definition of done:
+
+- main-process scratch execution accepts and uses the override when present
+- no behavior changes when the override is absent
+- tests cover success and failure paths for overridden execution
+
+## Task 3: Add renderer-local override state and menu substate
+
+Goal:
+
+- teach scratch space to select a temporary model target without executing immediately
+
+Files:
+
+- `src/renderer/scratch-space-app.tsx`
+- `src/renderer/scratch-space-app.test.tsx`
+
+Changes:
+
+- add renderer-local state for:
+  - current temporary override
+  - whether the `Cmd+K` surface is in top-level action mode or model-picker mode
+  - model-picker selection index
+- add `Change model` as the third top-level `Cmd+K` item
+- build a second picker state backed by executable target data
+- keep focus and Escape precedence explicit:
+  - model picker closes back to top-level `Cmd+K`
+  - top-level `Cmd+K` closes back to textarea
+  - scratch close remains last
+
+Implementation notes:
+
+- fetch readiness data only if the scratch renderer does not already have enough information at boot time
+- avoid duplicating settings-editor logic; scratch only needs a compact read-only target picker, not a full profile editor
+- show the active temporary target somewhere in the `Cmd+K` surface so the current override is visible
+
+Definition of done:
+
+- the scratch `Cmd+K` menu exposes `Change model`
+- choosing it opens a model picker instead of executing
+- model selection updates local override state only
+- the top-level action flow remains keyboard-first and predictable
+
+## Task 4: Implement override lifecycle rules exactly
+
+Goal:
+
+- make the next-run-only behavior unambiguous and testable
+
+Files:
+
+- `src/renderer/scratch-space-app.tsx`
+- `src/renderer/scratch-space-app.test.tsx`
+
+Changes:
+
+- when the user triggers execution, include the current override in the payload
+- clear the override after a successful or completed execution request cycle that should consume it
+- preserve the override when scratch reopens with `reason: 'retry'`
+- clear the override on:
+  - fresh reopen
+  - manual scratch close
+  - profile change, unless product later decides otherwise
+
+Implementation notes:
+
+- centralize lifecycle transitions in helper functions instead of scattering `setState(null)` calls
+- preserve current selected-preset retry behavior
+
+Definition of done:
+
+- tests prove:
+  - next execution consumes the override
+  - retry preserves it
+  - fresh reopen clears it
+  - manual close clears it
+
+## Task 5: Add targeted regression coverage
+
+Goal:
+
+- cover the new behavior where it is most likely to regress
+
+Files:
+
+- `src/renderer/scratch-space-app.test.tsx`
+- `src/main/services/scratch-space-service.test.ts`
+- `src/main/test-support/ipc-round-trip.test.ts` if payload shape coverage is needed
+
+Required test cases:
+
+- `Cmd+K` top-level menu contains `Change model`
+- `Enter` on `Change model` opens the picker and does not execute
+- selecting a cross-provider target updates the next execution payload
+- `Cmd+Enter` still forces paste from the action context
+- next execution clears the override
+- retry reopen keeps the override
+- fresh reopen clears the override
+- non-executable Codex models are not offered as runnable targets
+
+Definition of done:
+
+- targeted renderer and service tests pass
+- no pre-existing scratch tests regress
+
+## Task 6: Update durable docs with shipped behavior
+
+Goal:
+
+- make the durable contract reflect the implementation once it ships
+
+Files:
+
+- `specs/spec.md`
+- `docs/e2e-playwright.md` if E2E scope changes
+- a new ADR only if the implementation finalizes a broader durable interaction contract not already captured
+
+Changes:
+
+- update scratch-space sections to describe:
+  - the `Change model` item
+  - next-run-only override semantics
+  - retry preservation semantics
+  - any executable-model filtering behavior the user can observe
+
+Definition of done:
+
+- spec and tests describe the same shipped behavior
+- doc frontmatter validation passes
+
+## Suggested commit slices
+
+- Slice 1: shared contract and executable-target filtering
+- Slice 2: main-process scratch execution override path
+- Slice 3: renderer `Cmd+K` nested picker and lifecycle rules
+- Slice 4: doc updates and final regression cleanup
+
+## Handoff summary
+
+The feature should be implemented as a scratch-local, request-scoped `provider + model` override layered on top of the selected profile, not as a persistent settings change and not as a synthetic new profile. The critical sequencing constraint is to solve executable target truth first, because the current Codex runtime cannot execute every model the shared catalog exposes.

--- a/docs/research/005-scratch-space-cmd-k-temporary-model-selection.md
+++ b/docs/research/005-scratch-space-cmd-k-temporary-model-selection.md
@@ -1,0 +1,678 @@
+---
+title: Scratch-space Cmd+K temporary model selection
+description: Research the current scratch-space Cmd+K flow and the design constraints for adding a request-scoped Change model action that temporarily overrides the selected profile model without persisting settings.
+date: 2026-04-14
+status: concluded
+tags:
+  - research
+  - scratch-space
+  - cmd-k
+  - llm
+  - models
+  - renderer
+  - main-process
+---
+
+# Scratch-space Cmd+K temporary model selection
+
+## Research goal
+
+Study the current scratch-space `Cmd+K` behavior in detail and determine what it would take to add a new `Change model` item to that menu with these requested properties:
+
+- the change applies only to the current scratch-space run
+- it does not persist to Settings
+- the default model remains the model attached to the currently selected transformation profile
+- the selectable model set should span the currently exposed model families across Google, Ollama, and Codex
+- the user flow should remain keyboard-first:
+  - open scratch space
+  - press `Cmd+K`
+  - choose a model-related option
+  - confirm with `Enter` or `Cmd+Enter`
+
+This document does not propose implementation code. It records the current architecture, the precise seams the feature would need to use, the hidden constraints, and the main design risks.
+
+## Executive summary
+
+The current scratch-space runtime has no concept of a temporary model override.
+
+Today, scratch-space execution is driven entirely by the selected transformation preset id. That preset contains the durable `provider + model + prompts` tuple, and `runScratchSpaceTransformation` receives only:
+
+- `text`
+- `presetId`
+- `executionMode`
+
+As a result:
+
+- scratch space can temporarily change the selected preset in renderer state
+- scratch space cannot temporarily change only the model for one run
+- any model change feature must introduce a new request-scoped override path somewhere between renderer state and the main-process execution call
+
+The cleanest mental model is:
+
+- selected profile remains the durable source of prompts and default provider/model
+- `Change model` creates an ephemeral runtime override for one scratch-space session or one scratch-space execution flow
+- execution resolves to `effective provider + effective model`, where the default is still the selected preset
+
+There is one important current mismatch in the codebase:
+
+- the shared model catalogs expose multiple Codex models
+- actual `CodexCliService` execution is currently hard-coded to support only `gpt-5.4-mini`
+
+That means a literal implementation of “show all Codex models in the scratch `Change model` menu” would currently expose options that the runtime cannot execute successfully.
+
+## Current shipped behavior
+
+## Scratch-space window and focus model
+
+Scratch space is a dedicated floating utility window controlled in main process by `ScratchSpaceWindowService`.
+
+Current durable behavior:
+
+- scratch opens as its own window, not inside the main Settings shell
+- on macOS it opens as an activating typing surface
+- the service captures the frontmost app bundle id before scratch opens
+- paste-mode execution later restores focus to that app before output is pasted
+
+Relevant sources:
+
+- `docs/adr/0014-scratch-space-focus-contract.md`
+- `docs/adr/0015-scratch-space-local-action-menu.md`
+- `src/main/services/scratch-space-window-service.ts`
+- `specs/spec.md`
+
+## Scratch-space renderer state
+
+`src/renderer/scratch-space-app.tsx` owns the scratch-local UI state.
+
+Important state fields today:
+
+- `selectedPresetId`
+- `isMiniMenuOpen`
+- `selectedMenuAction`
+- `isPresetMenuOpen`
+- `presetMenuIndex`
+- draft text and busy/error state
+
+There is no state for:
+
+- selected temporary model
+- selected temporary provider
+- selected runtime override
+- nested submenu or mode within the `Cmd+K` mini menu
+
+## Current `Cmd+K` mini menu
+
+The current scratch-local `Cmd+K` menu is a small renderer-only overlay.
+
+Current items:
+
+- `Copy transformed result`
+- `Paste at front app`
+
+Current keyboard behavior:
+
+- `Cmd+K` toggles the mini menu open and closed on macOS only
+- opening the menu resets selection to item 1
+- `ArrowUp` and `ArrowDown` move selection without wrapping
+- `Enter` executes the highlighted action
+- `Cmd+Enter` always executes paste mode, regardless of highlighted item
+- `Escape` closes the mini menu first
+- when the menu loses focus, it closes and textarea focus is restored
+
+Current tests explicitly cover these behaviors in `src/renderer/scratch-space-app.test.tsx`.
+
+## Current preset selection path
+
+Scratch space already supports temporary profile selection, but only at the preset level.
+
+There are two profile-selection surfaces:
+
+- the visible radio-list in the main scratch panel
+- the scratch-local preset menu opened from the global `pickTransformation` shortcut while scratch is visible
+
+Important existing semantics:
+
+- on fresh open, scratch selection resets to `settings.transformation.defaultPresetId`
+- on retry reopen after a failed execution, scratch preserves the previously selected preset
+- changing the selected preset in scratch does not persist any setting
+
+This is the closest existing precedent for temporary behavior. It proves the product already accepts request-local scratch overrides, but only for preset selection, not model selection.
+
+## Current execution path
+
+Scratch execution currently flows like this:
+
+1. Renderer calls `window.speechToTextApi.runScratchSpaceTransformation({ text, presetId, executionMode })`
+2. Main-process `ScratchSpaceService.runTransformation` loads the latest persisted settings
+3. `resolvePreset` finds:
+   - the requested preset id
+   - else the default preset id
+   - else the first available preset
+4. Scratch execution uses the resolved preset's:
+   - `provider`
+   - `model`
+   - `systemPrompt`
+   - `userPrompt`
+5. `executeTransformation(...)` runs preflight and dispatches through `TransformationService`
+6. successful output is always copied, and may also be pasted depending on execution mode
+7. draft is cleared only after success
+
+Important consequence:
+
+- there is no place in the current scratch IPC contract to supply a temporary model override
+
+## Current data contracts
+
+## Persistent settings shape
+
+`TransformationPresetSchema` in `src/shared/domain.ts` defines a durable preset as:
+
+- `id`
+- `name`
+- `provider`
+- `model`
+- `systemPrompt`
+- `userPrompt`
+- `shortcut`
+
+Scratch currently depends on the preset as the single durable execution source.
+
+The Settings schema contains:
+
+- `defaultPresetId`
+- `lastPickedPresetId`
+- `presets`
+
+It does not contain:
+
+- scratch-local override model
+- scratch-local override provider
+- last temporary scratch model
+
+That matches the requested non-persistent behavior.
+
+## Shared provider/model catalog
+
+`src/shared/llm.ts` is the catalog authority.
+
+Current provider ids:
+
+- `google`
+- `ollama`
+- `openai-subscription`
+
+Current user-facing labels:
+
+- `Google`
+- `Ollama`
+- `Codex CLI`
+
+This matters because the request says “google, ollama, codex”, while the code uses:
+
+- `openai-subscription` as the provider id
+- `Codex CLI` as the user-facing label
+
+Any research or implementation should treat “codex” in the feature description as the existing `openai-subscription` provider family rendered as `Codex CLI`.
+
+## Available models by provider
+
+Current allowlists expose:
+
+- Google:
+  - `gemini-2.5-flash`
+- Ollama:
+  - multiple curated models and quantized variants
+- Codex CLI:
+  - `gpt-5.4-mini`
+  - `gpt-5.4`
+  - `gpt-5.3-codex`
+  - `gpt-5.2-codex`
+  - `gpt-5.2`
+  - `gpt-5.1-codex-mini`
+
+This is the broadest current answer to “model options: all”.
+
+## Current readiness model
+
+The app already has provider readiness snapshots exposed to renderer via `getLlmProviderStatus()`.
+
+That snapshot includes:
+
+- provider credential state
+- readiness status
+- model availability list
+
+This is important because a `Change model` menu should not guess availability. The repo already has a runtime-readiness source of truth that distinguishes:
+
+- configured versus unconfigured cloud providers
+- local Ollama runtime availability
+- per-model availability
+- Codex CLI install/login status
+
+## Existing constraints that shape the feature
+
+## Constraint 1: scratch runtime executes by preset, not by model
+
+The current architecture is preset-centric.
+
+That is good for prompt integrity, because the prompt templates live on the preset. It also means a temporary model-selection feature must answer:
+
+- does it override only `model`
+- or `provider + model`
+
+In practice, it must resolve `provider + model`, not model alone, because:
+
+- models are allowlisted under providers
+- execution preflight is provider-specific
+- readiness is provider-specific
+- credentials are provider-specific
+
+The user-facing menu can still say `Change model`, but the runtime concept is really:
+
+- temporary execution target override
+
+## Constraint 2: the default comes from the selected profile
+
+The requested default behavior is already aligned with the current architecture:
+
+- selected profile owns the default provider/model pair
+
+That means the temporary override should almost certainly leave prompts attached to the selected profile and change only the execution target.
+
+This avoids turning `Change model` into `Change profile`.
+
+## Constraint 3: temporary means non-persistent across app settings
+
+The feature expectation is explicit:
+
+- no persistent change
+
+That means the override should not write to:
+
+- `settings.transformation.presets[*].model`
+- `settings.transformation.presets[*].provider`
+- `settings.transformation.defaultPresetId`
+- `settings.transformation.lastPickedPresetId`
+
+The existing scratch profile-selection behavior already proves this is acceptable product behavior.
+
+## Constraint 4: the current `Cmd+K` menu is action-oriented, not selection-oriented
+
+Today the `Cmd+K` menu only chooses execution action:
+
+- copy
+- paste
+
+Adding `Change model` introduces a second responsibility:
+
+- action selection
+- runtime target selection
+
+That means the menu can no longer remain a flat “execute now” surface unless the new item opens a second surface.
+
+This is the biggest interaction-design consequence in the feature.
+
+## Constraint 5: `Cmd+Enter` currently means paste immediately
+
+The current contract says:
+
+- inside scratch generally, `Cmd+Enter` runs transform-and-paste
+- inside the mini menu, `Cmd+Enter` also forces paste
+
+If `Change model` is added, `Cmd+Enter` semantics must remain unambiguous.
+
+Most likely safe interpretation:
+
+- while the top-level `Cmd+K` menu is open, `Cmd+Enter` should still execute paste
+- once a model-picker substate is entered, `Enter` should confirm model selection, not execute transformation
+- after a model is selected, the user returns to the top-level action context and can then use `Enter` or `Cmd+Enter`
+
+Anything else would overload the shortcut too much.
+
+## Constraint 6: retry behavior currently preserves profile, not model override
+
+On retry reopen after a failed scratch execution, current behavior preserves:
+
+- draft
+- selected preset
+
+There is no current concept of preserving a temporary model override.
+
+This needs a product decision if the feature is implemented.
+
+Reasonable options:
+
+- retry clears the temporary model override and falls back to the selected profile model
+- retry preserves the temporary model override for the same scratch session
+
+Given the user expectation says “this run only”, preserving the override through retry is plausible if retry is considered part of the same run. But this is not yet defined in the current contract and should be chosen explicitly.
+
+## Constraint 7: Codex model exposure and Codex execution do not currently match
+
+This is the most important hidden engineering constraint.
+
+Shared allowlists and renderer UI expose multiple Codex models, but `CodexCliService.runTransformation(...)` currently rejects any model other than `gpt-5.4-mini`.
+
+That means there are two different truths in the codebase:
+
+- catalog truth: multiple Codex models exist
+- execution truth: only `gpt-5.4-mini` actually runs
+
+If scratch `Change model` blindly uses the shared model catalog, Codex selections other than `gpt-5.4-mini` will fail at execution time.
+
+This should be treated as a real product/design constraint, not an implementation detail.
+
+## Likely product interpretation of the requested feature
+
+The request says:
+
+- “add change model item in cmd+k items”
+- “default model: model attached to the selected transformation profile”
+- “change a model option can change a model in this run only”
+- “model options: all (google, ollama, codex)”
+
+The closest coherent interpretation is:
+
+1. scratch keeps its selected profile as the durable prompt source
+2. `Cmd+K` gains a `Change model` item
+3. selecting `Change model` opens a second, scratch-local model picker
+4. that picker lets the user choose an effective model from the shared provider/model catalog
+5. execution uses:
+   - selected preset prompts
+   - selected preset default target unless overridden
+   - overridden provider/model when present
+6. the override is cleared when the scratch run ends, or when scratch is closed
+
+This interpretation preserves the existing meaning of profiles while satisfying the request for temporary model switching.
+
+## Interaction model options
+
+## Option A: flat top-level menu with a third item
+
+Top-level items would become:
+
+- `Copy transformed result`
+- `Paste at front app`
+- `Change model`
+
+Pros:
+
+- smallest conceptual diff from the current menu
+- directly matches the user wording
+
+Cons:
+
+- `Enter` on `Change model` cannot execute a transformation, so menu semantics become mixed
+- requires a second nested surface anyway
+- current `Cmd+Enter` behavior becomes harder to explain when the highlighted item is not an execution action
+
+Assessment:
+
+- workable, but only if `Change model` opens a second selection state rather than trying to execute from the same row
+
+## Option B: convert the `Cmd+K` surface into a true command palette
+
+The overlay would become a slightly richer scratch-local palette that can host:
+
+- execution actions
+- model-changing action
+- current effective model summary
+
+Pros:
+
+- more honest information architecture
+- easier to explain mixed actions and configuration
+- easier to show the currently effective runtime target
+
+Cons:
+
+- larger UI change
+- may exceed the intentionally compact current mini-menu contract
+
+Assessment:
+
+- architecturally cleaner, but larger than the request strictly needs
+
+## Option C: keep `Cmd+K` for actions and introduce a separate model shortcut
+
+Pros:
+
+- preserves the current action-only semantics
+
+Cons:
+
+- does not match the request
+- adds another shortcut and another concept
+
+Assessment:
+
+- not aligned with the stated feature
+
+## Recommended interaction direction for future implementation
+
+If the feature is implemented, Option A with an explicit second-step picker is the smallest coherent design:
+
+- top-level `Cmd+K` remains the action entrypoint
+- `Change model` enters a model-picker substate
+- model-picker confirms override selection with `Enter`
+- execution still happens only from the action context using `Enter` or `Cmd+Enter`
+
+That keeps the mental model clear:
+
+- step 1: optionally change runtime target
+- step 2: execute copy or paste
+
+## Data-flow options for future implementation
+
+## Option 1: renderer-only override state plus extended scratch IPC payload
+
+Scratch renderer stores an ephemeral override such as:
+
+- `temporaryModelOverride: { provider, model } | null`
+
+Then the IPC payload becomes something like:
+
+- `text`
+- `presetId`
+- `executionMode`
+- optional `providerOverride`
+- optional `modelOverride`
+
+Main process still resolves the preset for prompts, but resolves execution target as:
+
+- override provider/model when present
+- else preset provider/model
+
+Pros:
+
+- matches current layering
+- keeps the override request-scoped
+- avoids writing Settings
+
+Cons:
+
+- requires IPC contract expansion
+- requires new validation rules for override combinations
+
+Assessment:
+
+- this is the most direct fit for the current architecture
+
+## Option 2: synthesize a temporary preset in renderer
+
+Renderer could clone the selected preset and replace provider/model before execution.
+
+Pros:
+
+- reuses the existing preset execution mental model
+
+Cons:
+
+- fake preset ids are awkward
+- IPC still only accepts `presetId`
+- the main process resolves presets from persisted settings, so a synthetic preset cannot be looked up there without larger changes
+
+Assessment:
+
+- poor fit for current code
+
+## Option 3: store temporary override in main-process scratch service
+
+Main process could own scratch-session state for temporary model selection.
+
+Pros:
+
+- keeps execution state close to execution logic
+
+Cons:
+
+- introduces more main-process session state
+- scratch renderer still needs additional IPC for set/clear/query
+- more complex than needed
+
+Assessment:
+
+- possible, but heavier than the current architecture warrants
+
+## Recommendation on future data shape
+
+The least invasive design is:
+
+- keep preset id as the durable prompt source
+- add an optional request-scoped `provider + model` override to scratch execution
+
+That is the minimum change that actually represents the requested behavior honestly.
+
+## Availability and filtering rules the feature would need
+
+If the model list is meant to show “all” options, the implementation still needs clear filtering semantics.
+
+Possible list strategies:
+
+- show every allowlisted model for every provider
+- show only models whose readiness snapshot reports `available: true`
+- show all models, but disable unavailable ones with status context
+
+Given the existing repo patterns in profile editing and provider readiness, the third option is the best match:
+
+- users can see the whole supported catalog
+- unavailable models are visible but not selectable
+- the UI can stay aligned with readiness truth
+
+Provider-specific implications:
+
+- Google:
+  - straightforward because the catalog is currently one model
+- Ollama:
+  - model availability is dynamic and should use readiness snapshot data
+- Codex CLI:
+  - readiness can say provider is ready, but execution still currently supports only `gpt-5.4-mini`
+
+For Codex specifically, a future implementation should either:
+
+- expose only executable Codex models in scratch until runtime support broadens
+- or show the broader list disabled with explicit explanation
+
+It should not silently offer failing choices.
+
+## State lifecycle questions that need explicit product answers
+
+The current code does not answer these yet:
+
+1. When does the temporary model override clear?
+   - on successful execution
+   - on scratch close
+   - on fresh reopen
+   - on retry reopen
+
+2. Does changing the selected profile clear the temporary model override?
+   - probably yes, because the default runtime target changed underneath it
+
+3. Does the UI show the active override outside the `Cmd+K` menu?
+   - if not, the user may forget they changed the model
+
+4. If the user changes model to a different provider, do prompts remain unchanged?
+   - this is likely intended, but it changes execution behavior meaningfully
+
+5. What happens if the selected override becomes unavailable before execution?
+   - likely fail preflight with a clear message
+
+These are not blockers to research, but they are required before implementation can be called complete.
+
+## Risks and edge cases
+
+## Risk: profile prompts may not be provider-agnostic
+
+Profiles currently bundle prompts with provider/model. A temporary cross-provider model change assumes the profile prompts remain valid enough across providers.
+
+That is probably acceptable for a first pass because the app already treats transformation prompts as generic text templates, but it is still a behavior change worth documenting.
+
+## Risk: retry semantics become ambiguous
+
+Because retry already preserves the selected preset, users may reasonably expect retry to preserve the temporary override too. That needs explicit product treatment.
+
+## Risk: menu complexity may outgrow the current “mini menu”
+
+The current overlay is intentionally tiny and action-focused. Nested model selection may push it toward a fuller command palette.
+
+## Risk: Codex catalog may promise more than runtime can execute
+
+This is the strongest current concrete risk and should be resolved before implementation, not after.
+
+## Risk: settings refresh could invalidate a local override
+
+Scratch currently refreshes settings on `onSettingsUpdated`. A temporary model override would need a clear rule for what happens when provider readiness or settings change while scratch is open.
+
+## Suggested verification targets for the future implementation
+
+When implementation happens, the minimum high-value test areas would be:
+
+- renderer:
+  - `Cmd+K` top-level menu includes `Change model`
+  - selecting `Change model` opens the model-picker substate
+  - `Enter` confirms model selection without executing transformation
+  - `Cmd+Enter` still executes paste only in the action context
+  - active temporary override is cleared at the intended lifecycle boundary
+- IPC:
+  - scratch execution payload carries the override only when selected
+- main process:
+  - scratch execution uses preset prompts with overridden provider/model
+  - invalid override combinations fail clearly
+  - unavailable override models fail clearly
+  - retry behavior matches the chosen contract
+- provider/runtime:
+  - Codex non-`gpt-5.4-mini` options are not exposed as executable unless runtime support exists
+
+## Research conclusion
+
+Adding `Change model` to scratch-space `Cmd+K` is feasible, but it is not a trivial menu-row addition.
+
+The feature cuts across three layers:
+
+- renderer menu state
+- scratch IPC payload shape
+- main-process execution target resolution
+
+The current codebase already provides several strong foundations:
+
+- scratch-local temporary preset selection
+- shared provider/model catalogs
+- provider readiness snapshots
+- preset-based prompt ownership
+
+The main missing piece is an honest request-scoped execution override path.
+
+The most important implementation constraint discovered during research is the current Codex mismatch:
+
+- the catalog lists several Codex models
+- runtime execution currently supports only `gpt-5.4-mini`
+
+Because of that, the safest future implementation direction is:
+
+- keep selected profile as the durable prompt source
+- add `Change model` as a top-level `Cmd+K` item that opens a second-step picker
+- treat the selected value as a temporary `provider + model` override
+- never persist it to Settings
+- expose only executable models, or visibly disable non-executable ones
+
+That direction satisfies the requested feature while staying aligned with the current architecture and avoiding hidden persistence or misleading model choices.


### PR DESCRIPTION
## Summary
- add detailed research for scratch-space Cmd+K temporary model selection
- add an implementation-ready plan in docs/plans
- keep this PR docs-only with no code changes

## Validation
- pnpm docs:validate