### PR TITLE
Use installed Ollama models instead of a hardcoded catalog

### DIFF
--- a/docs/adr/0016-use-installed-ollama-model-ids.md
+++ b/docs/adr/0016-use-installed-ollama-model-ids.md
@@ -1,0 +1,80 @@
+---
+title: Use installed Ollama model ids directly
+description: Stop hardcoding Ollama transformation models and use the installed model ids reported by Ollama readiness instead.
+date: 2026-04-14
+status: accepted
+tags:
+  - architecture
+  - ollama
+---
+
+# Use installed Ollama model ids directly
+
+## Context
+
+Dicta originally modeled Ollama through a curated allowlist shared across settings validation, readiness, and transformation dispatch.
+
+That design now conflicts with the actual runtime contract:
+
+- Ollama reports installed local models dynamically.
+- users can install any compatible model without changing Dicta code
+- a hardcoded allowlist blocks valid local setups and forces product releases for simple model changes
+
+The current code also leaks the curated assumption into multiple layers:
+
+- settings schema validation rejects unknown Ollama model ids
+- readiness returns disabled rows for models that are not installed
+- transformation dispatch rejects installed models that are not in the shipped list
+
+## Decision
+
+Dicta will treat Ollama model ids as runtime-discovered values rather than a shipped enum.
+
+Specifically:
+
+- Ollama readiness will return the installed model ids reported by the local runtime
+- transformation presets will accept any non-empty Ollama model id
+- the profile editor and settings diagnostics will show only installed Ollama models
+- Google and Codex model validation will remain allowlisted and static
+
+## Options Considered
+
+### Option 1: Keep the curated allowlist
+
+Pros:
+
+- strong compile-time exhaustiveness
+- easy to attach bespoke labels or metadata to known models
+
+Cons:
+
+- rejects valid installed models
+- requires code changes for normal user configuration changes
+- diverges from Ollama's dynamic model discovery behavior
+
+### Option 2: Allow installed model ids directly
+
+Pros:
+
+- matches the Ollama runtime contract
+- removes unnecessary release coupling
+- keeps readiness, selection, and execution aligned on one source of truth
+
+Cons:
+
+- loses compile-time enumeration for Ollama model ids
+- model-specific metadata must be added separately if ever needed again
+
+## Consequences
+
+Positive:
+
+- users can use any installed Ollama model immediately
+- readiness and execution now agree on what is selectable
+- persisted presets survive model catalog drift as long as the model id remains valid
+
+Negative:
+
+- Ollama model ids are now validated at runtime as non-empty strings instead of compile-time enum members
+- special-case UI labels or per-model execution flags are no longer implied by the shared contract
+

--- a/docs/e2e-playwright.md
+++ b/docs/e2e-playwright.md
@@ -54,7 +54,7 @@ Artifacts are uploaded on every run:
 - App launch smoke test (Home/Settings navigation).
 - Settings save flow behavior assertion.
 - Provider API key input visibility in Settings.
-- LLM settings smoke covering the shipped Codex, Gemini, and Ollama sections plus curated Ollama model availability handling against controlled fake readiness responses.
+- LLM settings smoke covering the shipped Codex, Gemini, and Ollama sections plus installed Ollama model availability handling against controlled fake readiness responses.
 - macOS-only provider API key positive save/status path (`@macos` tagged).
 - macOS fake microphone recording smoke using Chromium fake-media flags + fixture WAV (`@macos` tagged).
 - Deterministic recording flow using an in-page synthetic microphone stream (mocked `getUserMedia`) with strict success-path assertions (`@macos` tagged in current CI workflow).

--- a/docs/ui-design-guidelines.md
+++ b/docs/ui-design-guidelines.md
@@ -245,7 +245,7 @@ Current `settings` tab includes only:
 - `Gemini` mirrors the STT stacked `provider -> model -> API key` layout.
 - `Codex Integration` uses a green-accented top-level icon, removes the redundant provider selector, keeps model selection, and places generic Codex CLI readiness status beneath the `Codex CLI access` action row.
 - `Gemini` does not render a separate section title; the provider/model/API-key controls stand on their own.
-- `Ollama` removes the redundant provider selector, hides the status line when the runtime is healthy, and renders model availability inside a bordered, scrollable readiness list with summary counts for larger curated catalogs, including multiple quantized variants from one family when curated.
+- `Ollama` removes the redundant provider selector, hides the status line when the runtime is healthy, and renders installed model availability inside a bordered, scrollable readiness list driven by the model ids reported by Ollama.
 - Uses same delete confirmation modal component for the Google key.
 
 ## 6.10 API key delete confirmation (`ConfirmDeleteApiKeyDialogReact`)

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -42,7 +42,7 @@ v1 delivery scope:
 - platform: macOS.
 - STT providers: Groq and ElevenLabs.
 - LLM UI exposure: unified provider/model preset editing with implemented Google and Ollama transformation providers, plus provider-scoped readiness for Google, Ollama, and OpenAI Subscription.
-- Settings LLM cards: flat top-level `Codex Integration`, `Gemini`, and `Ollama` sections without a shared `LLM` eyebrow label; Codex Integration and Ollama omit redundant provider selectors, Gemini omits a standalone section title, Codex readiness messaging remains generic to CLI state rather than account entitlement, and Ollama model availability is presented as a scalable curated readiness list that may include multiple quantized variants from one curated family. Each Ollama row **MUST** present the curated display label without a secondary muted raw model-id line.
+- Settings LLM cards: flat top-level `Codex Integration`, `Gemini`, and `Ollama` sections without a shared `LLM` eyebrow label; Codex Integration and Ollama omit redundant provider selectors, Gemini omits a standalone section title, Codex readiness messaging remains generic to CLI state rather than account entitlement, and Ollama model availability is presented as the installed model list reported by the local runtime. Each Ollama row **MUST** present the installed model id with no secondary muted raw model-id line.
 
 Deferred beyond v1:
 - voice-activation recording mode.
@@ -330,13 +330,14 @@ Additional capture output rules:
 ### 4.6.1 Unified LLM settings and Ollama diagnostics
 
 - Persisted settings **MUST NOT** contain a standalone `cleanup` field.
-- Ollama readiness and curated-model availability **MUST** be surfaced through the shared LLM provider readiness contract rather than a separate cleanup-specific IPC channel.
+- Ollama readiness and installed-model availability **MUST** be surfaced through the shared LLM provider readiness contract rather than a separate cleanup-specific IPC channel.
 - Settings **MUST** present separate top-level LLM sections for `Gemini`, `OpenAI subscription`, and `Ollama`.
 - The Settings speech-to-text section heading **MUST** be labeled `Dictation`.
 - The `Gemini` section **MUST** follow the STT-style stacked `provider -> model -> API key` form.
 - The `OpenAI subscription` section **MUST** appear directly below `Gemini`, show the provider selection label as `Codex (subscription)`, and keep Codex CLI readiness guidance in its own dedicated section.
 - The `Ollama` section **MUST** appear as its own top-level section rather than inside a generic local-runtime card.
 - The `Ollama` section **MUST** show model availability as top-level readiness rows inside the Ollama section rather than inside an extra nested subsection card.
+- The `Ollama` section **MUST** show the model ids currently returned by Ollama's installed-model discovery, and **MUST NOT** synthesize additional disabled catalog rows for models that are not installed.
 - LLM model display labels **MUST** remain the exact model ids with no prettified display-name layer.
 
 ### 4.7 User dictionary (speech correction)
@@ -478,7 +479,7 @@ Implementation note:
 - The first shipped OpenAI subscription execution path **MUST** be pinned to `gpt-5.4-mini`.
 - OpenAI subscription models **MUST** become available when Codex CLI is installed, signed in, and the provider readiness snapshot reports `ready`.
 - Transformation preflight failures **MUST** use provider-specific product wording in user-facing errors rather than raw provider ids.
-- Implemented local-runtime providers **MUST** expose curated models in the profile editor even when unavailable, and unavailable models **MUST** remain visibly disabled.
+- Implemented local-runtime providers **MUST** expose the installed model ids reported by runtime readiness in the profile editor, and transformation presets **MUST** accept any non-empty Ollama model id so existing settings remain editable across model changes.
 - Main-process transformation execution for local-runtime providers **MUST** consult the same provider readiness snapshot before dispatch so renderer-disabled models are also blocked at preflight.
 - LLM provider configuration in v1 **MUST NOT** expose base URL override fields in Settings.
 - LLM requests **MUST** use provider default endpoints in v1 runtime settings flow.

--- a/specs/user-flow.md
+++ b/specs/user-flow.md
@@ -293,11 +293,11 @@ Steps:
 1. User opens the `Settings` tab.
 2. User opens or edits a transformation preset.
 3. User selects `Ollama` as the LLM provider.
-4. App shows curated Ollama models as readiness rows directly in the top-level `Ollama` section, using the curated display label without a secondary raw model-id line.
+4. App shows the installed Ollama models as readiness rows directly in the top-level `Ollama` section, using the installed model id without a secondary raw model-id line.
 4. If Ollama is not installed, app shows install guidance.
 5. If Ollama is installed but not running or otherwise unreachable, app shows start-or-refresh guidance.
-6. If Ollama is reachable but no curated supported model is installed, app shows a supported-model warning instead of implying the provider is ready.
-7. User selects an installed supported model.
+6. If Ollama is reachable but no models are installed, app shows an empty-state warning instead of implying the provider is ready.
+7. User selects an installed model.
 8. App autosaves the preset change.
 
 Flow result:

--- a/src/main/orchestrators/preflight-guard.test.ts
+++ b/src/main/orchestrators/preflight-guard.test.ts
@@ -118,7 +118,7 @@ describe('checkLlmPreflight', () => {
 
   it('allows Ollama presets without an API key lookup', () => {
     const secretStore = { getApiKey: vi.fn(() => 'valid-key') }
-    const result = checkLlmPreflight(secretStore, 'ollama', 'qwen3.5:4b')
+    const result = checkLlmPreflight(secretStore, 'ollama', 'llama3.2:latest')
 
     expect(result).toEqual({ ok: true, apiKey: '' })
     expect(secretStore.getApiKey).not.toHaveBeenCalled()

--- a/src/main/orchestrators/preflight-guard.ts
+++ b/src/main/orchestrators/preflight-guard.ts
@@ -5,7 +5,8 @@
 //        pre-network (preflight) vs post-network (api_auth/network) failures.
 
 import type { FailureCategory } from '../../shared/domain'
-import { STT_MODEL_ALLOWLIST, TRANSFORM_MODEL_ALLOWLIST, type SttModel, type SttProvider, type TransformModel, type TransformProvider } from '../../shared/domain'
+import { STT_MODEL_ALLOWLIST, TRANSFORM_MODEL_ALLOWLIST, type SttModel, type SttProvider, type TransformProvider } from '../../shared/domain'
+import { isAllowedImplementedTransformModel } from '../../shared/llm'
 import type { SecretStore } from '../services/secret-store'
 
 type ApiKeyProvider = Parameters<SecretStore['getApiKey']>[0]
@@ -111,8 +112,8 @@ const isSupportedSttModel = (provider: SttProvider, model: string): model is Stt
 const isSupportedLlmProvider = (provider: string): provider is TransformProvider =>
   provider in TRANSFORM_MODEL_ALLOWLIST
 
-const isSupportedLlmModel = (provider: TransformProvider, model: string): model is TransformModel =>
-  TRANSFORM_MODEL_ALLOWLIST[provider].includes(model as TransformModel)
+const isSupportedLlmModel = (provider: TransformProvider, model: string): boolean =>
+  isAllowedImplementedTransformModel(provider, model)
 
 // ---------------------------------------------------------------------------
 // Post-network error classification

--- a/src/main/services/llm-provider-readiness-service.test.ts
+++ b/src/main/services/llm-provider-readiness-service.test.ts
@@ -48,24 +48,24 @@ describe('LlmProviderReadinessService', () => {
     })
   })
 
-  it('reports Ollama as ready when a curated model is installed', async () => {
+  it('reports Ollama as ready when an installed model is discovered', async () => {
     const service = new LlmProviderReadinessService({
       secretStore: { getApiKey: vi.fn(() => null) } as any,
       localLlmRuntime: {
         healthcheck: vi.fn(async () => ({ ok: true as const })),
-        listModels: vi.fn(async () => [{ id: 'qwen3.5:2b', label: 'qwen3.5:2b' }])
+        listModels: vi.fn(async () => [{ id: 'llama3.2:latest', label: 'llama3.2:latest' }])
       } as any,
       codexCliService: createCodexCliService({ kind: 'cli_not_installed' }) as any
     })
 
     const snapshot = await service.getSnapshot()
     expect(snapshot.ollama.status).toEqual({ kind: 'ready', message: 'Ollama is available.' })
-    expect(snapshot.ollama.models.find((model) => model.id === 'qwen3.5:2b')?.available).toBe(true)
-    expect(snapshot.ollama.models.find((model) => model.id === 'qwen3.5:4b')?.available).toBe(false)
-    expect(snapshot.ollama.models.find((model) => model.id === 'mitmul/plamo-2-translate')?.available).toBe(false)
+    expect(snapshot.ollama.models).toEqual([
+      { id: 'llama3.2:latest', label: 'llama3.2:latest', available: true }
+    ])
   })
 
-  it('reports Ollama as no_supported_models when runtime is healthy but curated models are missing', async () => {
+  it('reports Ollama as no_supported_models when runtime is healthy but no models are installed', async () => {
     const service = new LlmProviderReadinessService({
       secretStore: { getApiKey: vi.fn(() => null) } as any,
       localLlmRuntime: {
@@ -78,9 +78,9 @@ describe('LlmProviderReadinessService', () => {
     const snapshot = await service.getSnapshot()
     expect(snapshot.ollama.status).toEqual({
       kind: 'no_supported_models',
-      message: 'No curated Ollama LLM model is installed yet.'
+      message: 'No Ollama models are installed yet.'
     })
-    expect(snapshot.ollama.models.every((model) => model.available === false)).toBe(true)
+    expect(snapshot.ollama.models).toEqual([])
   })
 
   it('reports OpenAI subscription as cli_not_installed until Codex CLI is installed', async () => {

--- a/src/main/services/llm-provider-readiness-service.ts
+++ b/src/main/services/llm-provider-readiness-service.ts
@@ -8,7 +8,7 @@ Why: Replace renderer-side assumptions with one provider-scoped readiness contra
 import type { LlmProviderStatusSnapshot } from '../../shared/ipc'
 import {
   LLM_MODEL_ALLOWLIST,
-  LLM_MODEL_LABELS,
+  getLlmModelLabel,
   type LlmProvider
 } from '../../shared/llm'
 import { SecretStore } from './secret-store'
@@ -54,7 +54,7 @@ export class LlmProviderReadinessService {
         : { kind: 'missing_credentials', message: 'Add a Google API key to enable Gemini transformation.' },
       models: LLM_MODEL_ALLOWLIST.google.map((id) => ({
         id,
-        label: LLM_MODEL_LABELS[id],
+        label: getLlmModelLabel(id),
         available: configured
       }))
     }
@@ -65,12 +65,6 @@ export class LlmProviderReadinessService {
       provider: 'ollama' as const,
       credential: { kind: 'local' as const }
     }
-    const curatedModels = LLM_MODEL_ALLOWLIST.ollama.map((id) => ({
-      id,
-      label: LLM_MODEL_LABELS[id],
-      available: false
-    }))
-
     try {
       const health = await this.localLlmRuntime.healthcheck()
       if (!health.ok) {
@@ -80,22 +74,20 @@ export class LlmProviderReadinessService {
             kind: mapLocalRuntimeStatus(health.code),
             message: health.message
           },
-          models: curatedModels
+          models: []
         }
       }
       const installedModels = await this.localLlmRuntime.listModels()
-      const installedIds = new Set<string>(installedModels.map((model) => model.id))
-      const models = LLM_MODEL_ALLOWLIST.ollama.map((id) => ({
-        id,
-        label: LLM_MODEL_LABELS[id],
-        available: installedIds.has(id)
+      const models = installedModels.map((model) => ({
+        id: model.id,
+        label: model.label,
+        available: true
       }))
-      const hasInstalledSupportedModel = models.some((model) => model.available)
       return {
         ...base,
-        status: hasInstalledSupportedModel
+        status: models.length > 0
           ? { kind: 'ready', message: 'Ollama is available.' }
-          : { kind: 'no_supported_models', message: 'No curated Ollama LLM model is installed yet.' },
+          : { kind: 'no_supported_models', message: 'No Ollama models are installed yet.' },
         models
       }
     } catch (error) {
@@ -105,7 +97,7 @@ export class LlmProviderReadinessService {
           kind: mapLocalRuntimeStatus(error),
           message: error instanceof Error ? error.message : 'Failed to query Ollama model availability.'
         },
-        models: curatedModels
+        models: []
       }
     }
   }
@@ -148,7 +140,7 @@ export class LlmProviderReadinessService {
       status,
       models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
         id,
-        label: LLM_MODEL_LABELS[id],
+        label: getLlmModelLabel(id),
         available: ready
       }))
     }

--- a/src/main/services/local-llm/ollama-local-llm-runtime.test.ts
+++ b/src/main/services/local-llm/ollama-local-llm-runtime.test.ts
@@ -1,5 +1,5 @@
 // Where: Main-process Ollama runtime tests.
-// What:  Verifies healthcheck, curated model discovery, and structured
+// What:  Verifies healthcheck, installed model discovery, and structured
 //        transformation execution against the Ollama adapter.
 // Why:   Keep the remaining local LLM path focused on transformation only.
 
@@ -59,21 +59,17 @@ describe('OllamaLocalLlmRuntime', () => {
     })
   })
 
-  it('filters runtime models through the curated supported catalog', async () => {
+  it('returns installed model ids directly from the Ollama tags response', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
           models: [
-            { model: 'qwen3.5:4b' },
-            { model: 'mitmul/plamo-2-translate' },
-            { model: 'mitmul/plamo-2-translate:Q4_K_M' },
-            { model: 'mitmul/plamo-2-translate:IQ2_S' },
-            { model: 'sorc/qwen3.5-instruct:0.8b' },
-            { model: 'gemma3' },
-            { name: 'qwen3.5:2b' },
-            { name: 'sorc/qwen3.5-instruct-uncensored:2b' }
+            { model: 'llama3.2:latest' },
+            { model: 'mistral:7b' },
+            { model: 'llama3.2:latest' },
+            { name: 'qwen2.5:3b' }
           ]
         })
       } as Response)
@@ -81,50 +77,10 @@ describe('OllamaLocalLlmRuntime', () => {
 
     const runtime = new OllamaLocalLlmRuntime()
     await expect(runtime.listModels()).resolves.toEqual([
-      expect.objectContaining({ id: 'qwen3.5:2b' }),
-      expect.objectContaining({ id: 'qwen3.5:4b' }),
-      expect.objectContaining({ id: 'mitmul/plamo-2-translate' }),
-      expect.objectContaining({ id: 'mitmul/plamo-2-translate:Q4_K_M' }),
-      expect.objectContaining({ id: 'mitmul/plamo-2-translate:IQ2_S' }),
-      expect.objectContaining({ id: 'sorc/qwen3.5-instruct:0.8b' }),
-      expect.objectContaining({ id: 'sorc/qwen3.5-instruct-uncensored:2b' })
+      { id: 'llama3.2:latest', label: 'llama3.2:latest' },
+      { id: 'mistral:7b', label: 'mistral:7b' },
+      { id: 'qwen2.5:3b', label: 'qwen2.5:3b' }
     ])
-  })
-
-  it('exposes both think and no-think variants when a gemma4 e2b ollamaId is installed', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [{ model: 'gemma4:e2b-it-q4_K_M' }]
-        })
-      } as Response)
-    )
-
-    const runtime = new OllamaLocalLlmRuntime()
-    const models = await runtime.listModels()
-    const ids = models.map((m) => m.id)
-    expect(ids).toContain('gemma4:e2b-it-q4_K_M:think')
-    expect(ids).toContain('gemma4:e2b-it-q4_K_M:no-think')
-  })
-
-  it('exposes both think and no-think variants when a gemma4 e4b ollamaId is installed', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [{ model: 'gemma4:e4b-it-q4_K_M' }]
-        })
-      } as Response)
-    )
-
-    const runtime = new OllamaLocalLlmRuntime()
-    const models = await runtime.listModels()
-    const ids = models.map((m) => m.id)
-    expect(ids).toContain('gemma4:e4b-it-q4_K_M:think')
-    expect(ids).toContain('gemma4:e4b-it-q4_K_M:no-think')
   })
 
   it('returns an empty model list when Ollama omits the models field', async () => {
@@ -158,12 +114,12 @@ describe('OllamaLocalLlmRuntime', () => {
         userPrompt: 'Transform this.\n<input_text>{{text}}</input_text>',
         timeoutMs: 1000
       },
-      'qwen3.5:2b'
+      'llama3.2:latest'
     )
 
     expect(result).toEqual({
       transformedText: 'transformed output',
-      modelId: 'qwen3.5:2b'
+      modelId: 'llama3.2:latest'
     })
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(String(init.body))
@@ -178,7 +134,7 @@ describe('OllamaLocalLlmRuntime', () => {
     })
   })
 
-  it('sends think:true and uses the ollamaId for the gemma4 thinking variant', async () => {
+  it('sends the selected model id directly to Ollama', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -191,79 +147,13 @@ describe('OllamaLocalLlmRuntime', () => {
     const runtime = new OllamaLocalLlmRuntime()
     await runtime.transform(
       { text: 'hello', systemPrompt: 'sys', userPrompt: '<input_text>{{text}}</input_text>', timeoutMs: 1000 },
-      'gemma4:e2b-it-q4_K_M:think'
+      'mistral:7b'
     )
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(String(init.body))
-    expect(body.model).toBe('gemma4:e2b-it-q4_K_M')
-    expect(body.think).toBe(true)
-  })
-
-  it('sends think:false and uses the ollamaId for the gemma4 no-think variant', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        response: JSON.stringify({ transformed_text: 'out' }),
-        done: true
-      })
-    } as Response)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const runtime = new OllamaLocalLlmRuntime()
-    await runtime.transform(
-      { text: 'hello', systemPrompt: 'sys', userPrompt: '<input_text>{{text}}</input_text>', timeoutMs: 1000 },
-      'gemma4:e4b-it-q4_K_M:no-think'
-    )
-
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    const body = JSON.parse(String(init.body))
-    expect(body.model).toBe('gemma4:e4b-it-q4_K_M')
-    expect(body.think).toBe(false)
-  })
-
-  it('sends think:false and uses the ollamaId for the gemma4 e2b no-think variant', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        response: JSON.stringify({ transformed_text: 'out' }),
-        done: true
-      })
-    } as Response)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const runtime = new OllamaLocalLlmRuntime()
-    await runtime.transform(
-      { text: 'hello', systemPrompt: 'sys', userPrompt: '<input_text>{{text}}</input_text>', timeoutMs: 1000 },
-      'gemma4:e2b-it-q4_K_M:no-think'
-    )
-
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    const body = JSON.parse(String(init.body))
-    expect(body.model).toBe('gemma4:e2b-it-q4_K_M')
-    expect(body.think).toBe(false)
-  })
-
-  it('sends think:true and uses the ollamaId for the gemma4 e4b thinking variant', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        response: JSON.stringify({ transformed_text: 'out' }),
-        done: true
-      })
-    } as Response)
-    vi.stubGlobal('fetch', fetchMock)
-
-    const runtime = new OllamaLocalLlmRuntime()
-    await runtime.transform(
-      { text: 'hello', systemPrompt: 'sys', userPrompt: '<input_text>{{text}}</input_text>', timeoutMs: 1000 },
-      'gemma4:e4b-it-q4_K_M:think'
-    )
-
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    const body = JSON.parse(String(init.body))
-    expect(body.model).toBe('gemma4:e4b-it-q4_K_M')
-    expect(body.think).toBe(true)
+    expect(body.model).toBe('mistral:7b')
+    expect(body.think).toBeUndefined()
   })
 
   it('accepts supported sorc model ids on the transformation request path', async () => {
@@ -364,7 +254,7 @@ describe('OllamaLocalLlmRuntime', () => {
     })
   })
 
-  it('throws unsupported_model before calling Ollama for an unsupported model id', async () => {
+  it('throws unsupported_model before calling Ollama for an empty model id', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 
@@ -377,7 +267,7 @@ describe('OllamaLocalLlmRuntime', () => {
           userPrompt: '<input_text>{{text}}</input_text>',
           timeoutMs: 1000
         },
-        'not-supported' as LocalLlmModelId
+        '   ' as LocalLlmModelId
       )
     ).rejects.toMatchObject({
       code: 'unsupported_model'

--- a/src/main/services/local-llm/ollama-local-llm-runtime.ts
+++ b/src/main/services/local-llm/ollama-local-llm-runtime.ts
@@ -6,10 +6,10 @@
 
 import { validateBaseUrlOverride } from '../endpoint-resolver'
 import type { LocalLlmModelId } from '../../../shared/local-llm'
-import { SUPPORTED_LOCAL_LLM_MODELS, type SupportedLocalLlmModel } from './catalog'
 import { LOCAL_LLM_DISCOVERY_TIMEOUT_MS } from './config'
 import { buildPromptBlocks } from '../transformation/prompt-format'
 import {
+  type LocalLlmDiscoveredModel,
   type LocalLlmFailureCode,
   LocalLlmRuntimeError,
   type LocalLlmHealthcheckResult,
@@ -79,40 +79,35 @@ export class OllamaLocalLlmRuntime implements LocalLlmRuntime {
     }
   }
 
-  async listModels(): Promise<readonly SupportedLocalLlmModel[]> {
+  async listModels(): Promise<readonly LocalLlmDiscoveredModel[]> {
     const response = await this.fetchJson<OllamaTagsResponse>(
       this.resolveUrl(OLLAMA_TAGS_PATH),
       { method: 'GET' },
       LOCAL_LLM_DISCOVERY_TIMEOUT_MS
     )
-    const installedModelIds = new Set(
-      (response.models ?? [])
-        .map((model) => model.model ?? model.name ?? '')
-        .filter((modelId) => modelId.length > 0)
+    const installedModelIds = Array.from(
+      new Set(
+        (response.models ?? [])
+          .map((model) => model.model ?? model.name ?? '')
+          .map((modelId) => modelId.trim())
+          .filter((modelId) => modelId.length > 0)
+      )
     )
 
-    // Match against ollamaId when present — think/no-think variants share
-    // the same underlying Ollama model name so both appear when one is installed.
-    return SUPPORTED_LOCAL_LLM_MODELS.filter((model) => installedModelIds.has(model.ollamaId ?? model.id))
+    return installedModelIds.map((modelId) => ({
+      id: modelId,
+      label: modelId
+    }))
   }
 
   async transform(
     request: LocalLlmTransformationRequest,
     modelId: LocalLlmModelId
   ): Promise<LocalLlmTransformationResponse> {
-    const catalogEntry = this.requireCatalogEntry(modelId)
-
-    // ollamaId may differ from the catalog id (e.g. think/no-think variants
-    // share the same underlying Ollama model name). Guard against empty strings
-    // which would reach Ollama and be misdiagnosed as model_missing.
-    if (catalogEntry.ollamaId !== undefined && catalogEntry.ollamaId.trim().length === 0) {
-      throw new LocalLlmRuntimeError('unsupported_model', `Catalog entry for ${modelId} has an empty ollamaId`)
+    const normalizedModelId = modelId.trim()
+    if (normalizedModelId.length === 0) {
+      throw new LocalLlmRuntimeError('unsupported_model', 'Ollama model id must not be empty')
     }
-    const ollamaModelId = catalogEntry.ollamaId ?? modelId
-
-    // think must be a top-level field — placing it inside `options` is
-    // silently ignored by /api/generate (Ollama issue #14793).
-    const thinkField = catalogEntry.think !== undefined ? { think: catalogEntry.think } : {}
 
     const response = await this.fetchJson<OllamaGenerateResponse>(
       this.resolveUrl(OLLAMA_GENERATE_PATH),
@@ -122,8 +117,7 @@ export class OllamaLocalLlmRuntime implements LocalLlmRuntime {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          model: ollamaModelId,
-          ...thinkField,
+          model: normalizedModelId,
           system: request.systemPrompt.trim(),
           prompt: buildPromptBlocks({
             sourceText: request.text,
@@ -155,20 +149,12 @@ export class OllamaLocalLlmRuntime implements LocalLlmRuntime {
 
     return {
       transformedText: payload.transformed_text,
-      modelId
+      modelId: normalizedModelId
     }
   }
 
   private resolveUrl(path: string): string {
     return `${this.baseUrl}${path}`
-  }
-
-  private requireCatalogEntry(modelId: LocalLlmModelId): (typeof SUPPORTED_LOCAL_LLM_MODELS)[number] {
-    const entry = SUPPORTED_LOCAL_LLM_MODELS.find((m) => m.id === modelId)
-    if (!entry) {
-      throw new LocalLlmRuntimeError('unsupported_model', `Model ${modelId} is not in the supported local catalog`)
-    }
-    return entry
   }
 
   private parseStructuredResponse<T extends object>(input: {

--- a/src/main/services/local-llm/types.ts
+++ b/src/main/services/local-llm/types.ts
@@ -4,7 +4,6 @@
 //        for future pipeline and UI integration work.
 
 import type { LocalLlmModelId, LocalLlmRuntimeId } from '../../../shared/local-llm'
-import type { SupportedLocalLlmModel } from './catalog'
 
 export type LocalLlmFailureCode =
   | 'runtime_unavailable'
@@ -30,6 +29,11 @@ export interface LocalLlmTransformationRequest {
   timeoutMs: number
 }
 
+export interface LocalLlmDiscoveredModel {
+  id: string
+  label: string
+}
+
 export interface LocalLlmTransformationResponse {
   transformedText: string
   modelId: LocalLlmModelId
@@ -38,7 +42,7 @@ export interface LocalLlmTransformationResponse {
 export interface LocalLlmRuntime {
   kind: LocalLlmRuntimeId
   healthcheck(): Promise<LocalLlmHealthcheckResult>
-  listModels(): Promise<readonly SupportedLocalLlmModel[]>
+  listModels(): Promise<readonly LocalLlmDiscoveredModel[]>
   transform(
     request: LocalLlmTransformationRequest,
     modelId: LocalLlmModelId

--- a/src/main/services/transformation-service.test.ts
+++ b/src/main/services/transformation-service.test.ts
@@ -110,7 +110,7 @@ describe('TransformationService', () => {
       transform: vi.fn(async () => ({
         text: 'local result',
         provider: 'ollama' as const,
-        model: 'qwen3.5:2b' as const
+        model: 'llama3.2:latest'
       }))
     }
 
@@ -119,7 +119,7 @@ describe('TransformationService', () => {
       text: 'hello',
       provider: 'ollama',
       credential: { kind: 'local' },
-      model: 'qwen3.5:2b',
+      model: 'llama3.2:latest',
       prompt: {
         systemPrompt: 's',
         userPrompt: 'u'
@@ -130,7 +130,7 @@ describe('TransformationService', () => {
       text: 'hello',
       provider: 'ollama',
       credential: { kind: 'local' },
-      model: 'qwen3.5:2b',
+      model: 'llama3.2:latest',
       prompt: {
         systemPrompt: 's',
         userPrompt: 'u'
@@ -139,7 +139,7 @@ describe('TransformationService', () => {
     expect(result).toEqual({
       text: 'local result',
       provider: 'ollama',
-      model: 'qwen3.5:2b'
+      model: 'llama3.2:latest'
     })
   })
 

--- a/src/main/services/transformation-service.ts
+++ b/src/main/services/transformation-service.ts
@@ -3,7 +3,7 @@
 // Why:   Keep allowlist validation and adapter lookup centralized behind one seam.
 
 import type { CodexCliService } from './codex-cli-service'
-import { TRANSFORM_MODEL_ALLOWLIST } from '../../shared/domain'
+import { isAllowedImplementedTransformModel } from '../../shared/llm'
 import type { TransformationInput, TransformationResult } from './transformation/types'
 import {
   createDefaultTransformationAdapterRegistry,
@@ -21,11 +21,7 @@ export class TransformationService {
   }
 
   async transform(input: TransformationInput): Promise<TransformationResult> {
-    const allowedModels = TRANSFORM_MODEL_ALLOWLIST[input.provider]
-    if (!allowedModels) {
-      throw new Error(`Unsupported LLM provider: ${input.provider}`)
-    }
-    if (!allowedModels.includes(input.model)) {
+    if (!isAllowedImplementedTransformModel(input.provider, input.model)) {
       throw new Error(`Unsupported LLM model ${input.model} for provider ${input.provider}`)
     }
 

--- a/src/renderer/profiles-panel-react.test.tsx
+++ b/src/renderer/profiles-panel-react.test.tsx
@@ -108,13 +108,7 @@ const buildLlmProviderStatus = (): LlmProviderStatusSnapshot => ({
     status: { kind: 'ready', message: 'Ollama is available.' },
     models: [
       { id: 'qwen3.5:2b', label: 'qwen3.5:2b', available: true },
-      { id: 'qwen3.5:4b', label: 'qwen3.5:4b', available: false },
-      { id: 'sorc/qwen3.5-instruct:0.8b', label: 'sorc/qwen3.5-instruct:0.8b', available: false },
-      {
-        id: 'sorc/qwen3.5-instruct-uncensored:2b',
-        label: 'sorc/qwen3.5-instruct-uncensored:2b',
-        available: false
-      }
+      { id: 'llama3.2:latest', label: 'llama3.2:latest', available: true }
     ]
   },
   'openai-subscription': {
@@ -1380,7 +1374,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
     expect(modelOptions).not.toContain('gpt-5.4-mini')
   })
 
-  it('shows curated Ollama models as unavailable when readiness marks them missing', async () => {
+  it('shows installed Ollama models from readiness in the model picker', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -1423,8 +1417,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
     }))
 
     expect(optionTexts).toContainEqual({ text: 'qwen3.5:2b', disabled: false })
-    expect(optionTexts).toContainEqual({ text: 'qwen3.5:4b (unavailable)', disabled: true })
-    expect(optionTexts).toContainEqual({ text: 'sorc/qwen3.5-instruct:0.8b (unavailable)', disabled: true })
+    expect(optionTexts).toContainEqual({ text: 'llama3.2:latest', disabled: false })
   })
 
   it('disables save when the selected Ollama model is unavailable', async () => {
@@ -1435,12 +1428,9 @@ describe('ProfilesPanelReact (STY-05)', () => {
     const llmProviderStatus = buildLlmProviderStatus()
     llmProviderStatus.ollama.status = {
       kind: 'no_supported_models',
-      message: 'No curated Ollama LLM model is installed yet.'
+      message: 'No Ollama models are installed yet.'
     }
-    llmProviderStatus.ollama.models = llmProviderStatus.ollama.models.map((model) => ({
-      ...model,
-      available: false
-    }))
+    llmProviderStatus.ollama.models = []
     const settings = buildSettings({
       presets: [
         {
@@ -1465,7 +1455,7 @@ describe('ProfilesPanelReact (STY-05)', () => {
     await flush()
 
     expect(host.querySelector('#profile-edit-model-status-preset-a')?.textContent).toContain(
-      'Unavailable: No curated Ollama LLM model is installed yet.'
+      'Unavailable: No Ollama models are installed yet.'
     )
     const saveButton = Array.from(host.querySelectorAll<HTMLButtonElement>('button')).find(
       (button) => button.textContent?.trim() === 'Save'

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -20,12 +20,11 @@ import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { Pencil, Plus, Star, Trash2 } from 'lucide-react'
 import type { Settings, TransformationPreset } from '../shared/domain'
 import {
-  IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST,
   IMPLEMENTED_TRANSFORM_PROVIDER_IDS,
   LLM_MODEL_ALLOWLIST,
-  LLM_MODEL_LABELS,
   LLM_PROVIDER_LABELS,
-  type ImplementedTransformModel,
+  getLlmModelLabel,
+  isAllowedImplementedTransformModel,
   type LlmModel,
   type LlmProvider
 } from '../shared/llm'
@@ -84,13 +83,13 @@ const DEFAULT_LLM_PROVIDER_STATUS: LlmProviderStatusSnapshot = {
     provider: 'google',
     credential: { kind: 'api_key', configured: false },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST.google.map((id) => ({ id, label: LLM_MODEL_LABELS[id], available: false }))
+    models: LLM_MODEL_ALLOWLIST.google.map((id) => ({ id, label: getLlmModelLabel(id), available: false }))
   },
   ollama: {
     provider: 'ollama',
     credential: { kind: 'local' },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST.ollama.map((id) => ({ id, label: LLM_MODEL_LABELS[id], available: false }))
+    models: []
   },
   'openai-subscription': {
     provider: 'openai-subscription',
@@ -98,7 +97,7 @@ const DEFAULT_LLM_PROVIDER_STATUS: LlmProviderStatusSnapshot = {
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
     models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
       id,
-      label: LLM_MODEL_LABELS[id],
+      label: getLlmModelLabel(id),
       available: false
     }))
   }
@@ -118,24 +117,24 @@ const toImplementedDraftInput = (draft: EditDraft): TransformationPresetDraftInp
         userPrompt: draft.userPrompt
       }
     case 'ollama':
-      if (!LLM_MODEL_ALLOWLIST.ollama.includes(draft.model)) {
+      if (!isAllowedImplementedTransformModel('ollama', draft.model)) {
         return null
       }
       return {
         name: draft.name,
         provider: 'ollama',
-        model: draft.model as TransformationPresetDraftInput['model'],
+        model: draft.model,
         systemPrompt: draft.systemPrompt,
         userPrompt: draft.userPrompt
       }
     case 'openai-subscription':
-      if (!IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription'].includes(draft.model as ImplementedTransformModel)) {
+      if (!isAllowedImplementedTransformModel('openai-subscription', draft.model)) {
         return null
       }
       return {
         name: draft.name,
         provider: 'openai-subscription',
-        model: draft.model as ImplementedTransformModel,
+        model: draft.model,
         systemPrompt: draft.systemPrompt,
         userPrompt: draft.userPrompt
       }
@@ -379,7 +378,8 @@ const ProfileEditForm = ({
             const readiness = llmProviderStatus[provider]
             const nextModel =
               readiness.models.find((model) => model.available)?.id ??
-              LLM_MODEL_ALLOWLIST[provider][0]
+              LLM_MODEL_ALLOWLIST[provider][0] ??
+              ''
             onChangeDraft({
               provider,
               model: nextModel
@@ -424,7 +424,7 @@ const ProfileEditForm = ({
                 disabled={!model.available}
                 className="font-mono"
               >
-                {LLM_MODEL_LABELS[model.id]}
+                {getLlmModelLabel(model.id)}
                 {!model.available ? ' (unavailable)' : ''}
               </SelectItem>
             ))}

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -14,7 +14,7 @@ This file is now the thin orchestration layer: boot, state, autosave, and render
 
 import { DEFAULT_SETTINGS, type OutputTextSource, type Settings } from '../shared/domain'
 import { logStructured } from '../shared/error-logging'
-import { LLM_MODEL_ALLOWLIST, LLM_MODEL_LABELS } from '../shared/llm'
+import { LLM_MODEL_ALLOWLIST, getLlmModelLabel } from '../shared/llm'
 import { buildOutputSettingsFromSelection } from '../shared/output-selection'
 import { COMPOSITE_TRANSFORM_ENQUEUED_MESSAGE } from '../shared/ipc'
 import { createRoot, type Root } from 'react-dom/client'
@@ -51,19 +51,19 @@ const createDefaultLlmProviderStatus = (): LlmProviderStatusSnapshot => ({
     provider: 'google',
     credential: { kind: 'api_key', configured: false },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST.google.map((id) => ({ id, label: LLM_MODEL_LABELS[id], available: false }))
+    models: LLM_MODEL_ALLOWLIST.google.map((id) => ({ id, label: getLlmModelLabel(id), available: false }))
   },
   ollama: {
     provider: 'ollama',
     credential: { kind: 'local' },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST.ollama.map((id) => ({ id, label: LLM_MODEL_LABELS[id], available: false }))
+    models: []
   },
   'openai-subscription': {
     provider: 'openai-subscription',
     credential: { kind: 'cli', installed: false },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({ id, label: LLM_MODEL_LABELS[id], available: false }))
+    models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({ id, label: getLlmModelLabel(id), available: false }))
   }
 })
 

--- a/src/renderer/settings-api-keys-react.test.tsx
+++ b/src/renderer/settings-api-keys-react.test.tsx
@@ -29,7 +29,7 @@ const baseLlmProviderStatus = (): LlmProviderStatusSnapshot => ({
     provider: 'ollama',
     credential: { kind: 'local' },
     status: { kind: 'runtime_unavailable', message: 'Ollama is not installed.' },
-    models: [{ id: 'qwen3.5:2b', label: 'qwen3.5:2b', available: false }]
+    models: []
   },
   'openai-subscription': {
     provider: 'openai-subscription',
@@ -414,7 +414,7 @@ describe('SettingsApiKeysReact', () => {
       status: { kind: 'ready', message: 'Ollama is available.' },
       models: [
         { id: 'qwen3.5:2b', label: 'qwen3.5:2b', available: true },
-        { id: 'sorc/qwen3.5-instruct:0.8b', label: 'sorc/qwen3.5-instruct:0.8b', available: false }
+        { id: 'llama3.2:latest', label: 'llama3.2:latest', available: true }
       ]
     }
 
@@ -433,15 +433,14 @@ describe('SettingsApiKeysReact', () => {
 
     const localSection = host.querySelector('#llm-settings-ollama')
     expect(localSection?.textContent).toContain('qwen3.5:2b')
-    expect(localSection?.textContent).toContain('sorc/qwen3.5-instruct:0.8b')
+    expect(localSection?.textContent).toContain('llama3.2:latest')
     expect(localSection?.textContent).toContain('Ready')
-    expect(localSection?.textContent).toContain('Not installed')
     expect(localSection?.textContent).not.toContain('Ollama is available.')
     expect(localSection?.textContent?.match(/qwen3\.5:2b/g)).toHaveLength(1)
-    expect(localSection?.textContent?.match(/sorc\/qwen3\.5-instruct:0\.8b/g)).toHaveLength(1)
+    expect(localSection?.textContent?.match(/llama3\.2:latest/g)).toHaveLength(1)
   })
 
-  it('shows an Ollama empty state when no curated models are currently detected', async () => {
+  it('shows an Ollama empty state when no installed models are currently detected', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
@@ -464,18 +463,18 @@ describe('SettingsApiKeysReact', () => {
       )
     })
 
-    expect(host.querySelector('#llm-settings-ollama')?.textContent).toContain('No supported Ollama models are detected yet.')
+    expect(host.querySelector('#llm-settings-ollama')?.textContent).toContain('No Ollama models are installed yet. Pull a model, then refresh readiness.')
   })
 
-  it('shows unavailable Ollama rows when curated models exist but none are installed', async () => {
+  it('keeps the empty state when Ollama is healthy but no installed models are found', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     root = createRoot(host)
     const llmProviderStatus = baseLlmProviderStatus()
     llmProviderStatus.ollama = {
       ...llmProviderStatus.ollama,
-      status: { kind: 'no_supported_models', message: 'No curated Ollama LLM model is installed yet.' },
-      models: [{ id: 'qwen3.5:2b', label: 'qwen3.5:2b', available: false }]
+      status: { kind: 'no_supported_models', message: 'No Ollama models are installed yet.' },
+      models: []
     }
 
     await act(async () => {
@@ -492,43 +491,6 @@ describe('SettingsApiKeysReact', () => {
     })
 
     const localSection = host.querySelector('#llm-settings-ollama')
-    expect(localSection?.textContent).toContain('qwen3.5:2b')
-    expect(localSection?.textContent).toContain('Not installed')
-    expect(localSection?.textContent).not.toContain('No supported Ollama models are detected yet.')
-  })
-
-  it('shows only the curated Ollama display label when it differs from the raw model id', async () => {
-    const host = document.createElement('div')
-    document.body.append(host)
-    root = createRoot(host)
-    const llmProviderStatus = baseLlmProviderStatus()
-    llmProviderStatus.ollama = {
-      ...llmProviderStatus.ollama,
-      status: { kind: 'ready', message: 'Ollama is available.' },
-      models: [
-        {
-          id: 'gemma4:e4b-it-q4_K_M:no-think',
-          label: 'Gemma 4 E4B Instruct (No Think)',
-          available: true
-        }
-      ]
-    }
-
-    await act(async () => {
-      root?.render(
-        <SettingsApiKeysReact
-          llmProviderStatus={llmProviderStatus}
-          apiKeySaveStatus={{ groq: '', elevenlabs: '', google: '' }}
-          onSaveApiKey={vi.fn(async () => {})}
-          onDeleteApiKey={vi.fn(async () => true)}
-          onConnectLlmProvider={vi.fn(async () => true)}
-          onDisconnectLlmProvider={vi.fn(async () => true)}
-        />
-      )
-    })
-
-    const localSection = host.querySelector('#llm-settings-ollama')
-    expect(localSection?.textContent).toContain('Gemma 4 E4B Instruct (No Think)')
-    expect(localSection?.textContent).not.toContain('gemma4:e4b-it-q4_K_M:no-think')
+    expect(localSection?.textContent).toContain('No Ollama models are installed yet. Pull a model, then refresh readiness.')
   })
 })

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -247,7 +247,7 @@ export const SettingsApiKeysReact = ({
           <div className="rounded-xl border border-border/60 bg-background/60">
             {shouldShowOllamaEmptyState ? (
               <div className="border border-dashed border-transparent px-3 py-4 text-[10px] text-muted-foreground">
-                No supported Ollama models are detected yet. Pull one of the curated models, then refresh readiness.
+                No Ollama models are installed yet. Pull a model, then refresh readiness.
               </div>
             ) : (
               <div className="max-h-72 divide-y divide-border/60 overflow-y-auto">

--- a/src/renderer/settings-mutations.ts
+++ b/src/renderer/settings-mutations.ts
@@ -7,7 +7,7 @@ Why: Extracted from renderer-app.tsx (Phase 6) to separate settings/preset/API-k
 */
 
 import { DEFAULT_SETTINGS, STT_MODEL_ALLOWLIST, type Settings } from '../shared/domain'
-import type { ImplementedTransformModel, ImplementedTransformProvider } from '../shared/llm'
+import type { ImplementedTransformProvider } from '../shared/llm'
 import type { ApiKeyProvider, ApiKeyStatusSnapshot, AudioInputSource, LlmProviderStatusSnapshot } from '../shared/ipc'
 import { resolveDetectedAudioSource } from './recording-device'
 import { type SettingsValidationErrors, validateTransformationPresetDraft } from './settings-validation'
@@ -30,7 +30,7 @@ export type SettingsMutableState = {
 export interface TransformationPresetDraftInput {
   name: string
   provider: ImplementedTransformProvider
-  model: ImplementedTransformModel
+  model: string
   systemPrompt: string
   userPrompt: string
 }

--- a/src/shared/domain.test.ts
+++ b/src/shared/domain.test.ts
@@ -73,6 +73,18 @@ describe('SettingsSchema post-sunset contract', () => {
     expect(errors.some((error) => error.field === 'transformation.presets.default.model')).toBe(true)
   })
 
+  it('accepts arbitrary non-empty Ollama model ids in settings validation', () => {
+    const next = structuredClone(DEFAULT_SETTINGS)
+    next.transformation.presets[0] = {
+      ...next.transformation.presets[0],
+      provider: 'ollama',
+      model: 'llama3.2:latest'
+    }
+
+    const errors = validateSettings(next)
+    expect(errors.some((error) => error.field === 'transformation.presets.default.model')).toBe(false)
+  })
+
   it('reports invalid shortcut values during explicit settings validation', () => {
     const invalid = structuredClone(DEFAULT_SETTINGS)
     invalid.shortcuts.toggleRecording = 'Opt+Ç'

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -9,9 +9,9 @@ import {
   USER_PROMPT_PLACEHOLDER_COUNT_ERROR,
 } from './prompt-template-safety'
 import {
-  IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST,
   ImplementedTransformModelSchema,
   ImplementedTransformProviderSchema,
+  isAllowedImplementedTransformModel,
   type ImplementedTransformModel,
   type ImplementedTransformProvider
 } from './llm'
@@ -137,8 +137,11 @@ export const STT_MODEL_ALLOWLIST: Record<SttProvider, readonly SttModel[]> = {
   elevenlabs: ['scribe_v2']
 }
 
-export const TRANSFORM_MODEL_ALLOWLIST: Record<TransformProvider, readonly TransformModel[]> =
-  IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST
+export const TRANSFORM_MODEL_ALLOWLIST: Record<TransformProvider, readonly string[]> = {
+  google: ['gemini-2.5-flash'],
+  ollama: [],
+  'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
+}
 
 export const RECORDING_METHOD_ALLOWLIST: readonly RecordingMethod[] = ['cpal']
 export const RECORDING_SAMPLE_RATE_ALLOWLIST: readonly RecordingSampleRateHz[] = [16000, 44100, 48000]
@@ -468,7 +471,7 @@ export const validateSettings = (settings: Settings): ValidationError[] => {
 
   // Cross-field: each preset model must be in allowlist for its provider
   for (const preset of settings.transformation.presets) {
-    if (!TRANSFORM_MODEL_ALLOWLIST[preset.provider].includes(preset.model)) {
+    if (!isAllowedImplementedTransformModel(preset.provider, preset.model)) {
       errors.push({
         field: `transformation.presets.${preset.id}.model`,
         message: `Model ${preset.model} is not allowed for provider ${preset.provider}`

--- a/src/shared/llm.test.ts
+++ b/src/shared/llm.test.ts
@@ -7,15 +7,16 @@ import {
   IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST,
   IMPLEMENTED_TRANSFORM_PROVIDER_IDS,
   LLM_MODEL_ALLOWLIST,
-  LLM_MODEL_LABELS,
-  LLM_PROVIDER_IDS
+  LLM_PROVIDER_IDS,
+  getLlmModelLabel,
+  isAllowedImplementedTransformModel,
+  isAllowedLlmModel
 } from './llm'
 
 describe('shared llm catalog', () => {
   it('captures planned providers in one future-facing catalog', () => {
     expect(LLM_PROVIDER_IDS).toEqual(['google', 'ollama', 'openai-subscription'])
-    expect(LLM_MODEL_ALLOWLIST.ollama).toContain('mitmul/plamo-2-translate')
-    expect(LLM_MODEL_ALLOWLIST.ollama).toContain('sorc/qwen3.5-instruct:0.8b')
+    expect(LLM_MODEL_ALLOWLIST.ollama).toEqual([])
     expect(LLM_MODEL_ALLOWLIST['openai-subscription']).toContain('gpt-5.4-mini')
     expect(LLM_MODEL_ALLOWLIST['openai-subscription']).toContain('gpt-5.4')
     expect(LLM_MODEL_ALLOWLIST['openai-subscription']).toContain('gpt-5.3-codex')
@@ -28,53 +29,22 @@ describe('shared llm catalog', () => {
     expect(IMPLEMENTED_TRANSFORM_PROVIDER_IDS).toEqual(['google', 'ollama', 'openai-subscription'])
     expect(IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST).toEqual({
       google: ['gemini-2.5-flash'],
-      ollama: [
-        'qwen3.5:2b',
-        'qwen3.5:4b',
-        'mitmul/plamo-2-translate',
-        'mitmul/plamo-2-translate:Q2_K',
-        'mitmul/plamo-2-translate:Q3_K_M',
-        'mitmul/plamo-2-translate:Q4_K_M',
-        'mitmul/plamo-2-translate:IQ2_M',
-        'mitmul/plamo-2-translate:IQ2_S',
-        'mitmul/plamo-2-translate:IQ2_XS',
-        'mitmul/plamo-2-translate:IQ2_XXS',
-        'sorc/qwen3.5-instruct:0.8b',
-        'sorc/qwen3.5-instruct-uncensored:2b',
-        'gemma4:e2b-it-q4_K_M:think',
-        'gemma4:e2b-it-q4_K_M:no-think',
-        'gemma4:e4b-it-q4_K_M:think',
-        'gemma4:e4b-it-q4_K_M:no-think'
-      ],
+      ollama: [],
       'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
     })
   })
 
-  it('uses raw model ids as display labels', () => {
-    expect(LLM_MODEL_LABELS).toEqual({
-      'gemini-2.5-flash': 'gemini-2.5-flash',
-      'qwen3.5:2b': 'qwen3.5:2b',
-      'qwen3.5:4b': 'qwen3.5:4b',
-      'mitmul/plamo-2-translate': 'mitmul/plamo-2-translate',
-      'mitmul/plamo-2-translate:Q2_K': 'mitmul/plamo-2-translate:Q2_K',
-      'mitmul/plamo-2-translate:Q3_K_M': 'mitmul/plamo-2-translate:Q3_K_M',
-      'mitmul/plamo-2-translate:Q4_K_M': 'mitmul/plamo-2-translate:Q4_K_M',
-      'mitmul/plamo-2-translate:IQ2_M': 'mitmul/plamo-2-translate:IQ2_M',
-      'mitmul/plamo-2-translate:IQ2_S': 'mitmul/plamo-2-translate:IQ2_S',
-      'mitmul/plamo-2-translate:IQ2_XS': 'mitmul/plamo-2-translate:IQ2_XS',
-      'mitmul/plamo-2-translate:IQ2_XXS': 'mitmul/plamo-2-translate:IQ2_XXS',
-      'sorc/qwen3.5-instruct:0.8b': 'sorc/qwen3.5-instruct:0.8b',
-      'sorc/qwen3.5-instruct-uncensored:2b': 'sorc/qwen3.5-instruct-uncensored:2b',
-      'gemma4:e2b-it-q4_K_M:think': 'gemma4:e2b-it-q4_K_M (thinking)',
-      'gemma4:e2b-it-q4_K_M:no-think': 'gemma4:e2b-it-q4_K_M',
-      'gemma4:e4b-it-q4_K_M:think': 'gemma4:e4b-it-q4_K_M (thinking)',
-      'gemma4:e4b-it-q4_K_M:no-think': 'gemma4:e4b-it-q4_K_M',
-      'gpt-5.4-mini': 'gpt-5.4-mini',
-      'gpt-5.4': 'gpt-5.4',
-      'gpt-5.3-codex': 'gpt-5.3-codex',
-      'gpt-5.2-codex': 'gpt-5.2-codex',
-      'gpt-5.2': 'gpt-5.2',
-      'gpt-5.1-codex-mini': 'gpt-5.1-codex-mini'
-    })
+  it('uses raw model ids as display labels unless a known override exists', () => {
+    expect(getLlmModelLabel('gemini-2.5-flash')).toBe('gemini-2.5-flash')
+    expect(getLlmModelLabel('custom-local-model:latest')).toBe('custom-local-model:latest')
+  })
+
+  it('allows any non-empty Ollama model id while keeping hosted providers strict', () => {
+    expect(isAllowedLlmModel('ollama', 'llama3.2:latest')).toBe(true)
+    expect(isAllowedLlmModel('ollama', '   ')).toBe(false)
+    expect(isAllowedLlmModel('google', 'gemini-2.5-flash')).toBe(true)
+    expect(isAllowedLlmModel('google', 'llama3.2:latest')).toBe(false)
+    expect(isAllowedImplementedTransformModel('openai-subscription', 'gpt-5.4-mini')).toBe(true)
+    expect(isAllowedImplementedTransformModel('openai-subscription', 'llama3.2:latest')).toBe(false)
   })
 })

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -11,22 +11,6 @@ export const LlmProviderSchema = v.picklist([...LLM_PROVIDER_IDS])
 
 export const LLM_MODEL_IDS = [
   'gemini-2.5-flash',
-  'qwen3.5:2b',
-  'qwen3.5:4b',
-  'mitmul/plamo-2-translate',
-  'mitmul/plamo-2-translate:Q2_K',
-  'mitmul/plamo-2-translate:Q3_K_M',
-  'mitmul/plamo-2-translate:Q4_K_M',
-  'mitmul/plamo-2-translate:IQ2_M',
-  'mitmul/plamo-2-translate:IQ2_S',
-  'mitmul/plamo-2-translate:IQ2_XS',
-  'mitmul/plamo-2-translate:IQ2_XXS',
-  'sorc/qwen3.5-instruct:0.8b',
-  'sorc/qwen3.5-instruct-uncensored:2b',
-  'gemma4:e2b-it-q4_K_M:think',
-  'gemma4:e2b-it-q4_K_M:no-think',
-  'gemma4:e4b-it-q4_K_M:think',
-  'gemma4:e4b-it-q4_K_M:no-think',
   'gpt-5.4-mini',
   'gpt-5.4',
   'gpt-5.3-codex',
@@ -34,29 +18,13 @@ export const LLM_MODEL_IDS = [
   'gpt-5.2',
   'gpt-5.1-codex-mini'
 ] as const
-export type LlmModel = (typeof LLM_MODEL_IDS)[number]
-export const LlmModelSchema = v.picklist([...LLM_MODEL_IDS])
+export type KnownLlmModel = (typeof LLM_MODEL_IDS)[number]
+export type LlmModel = string
+export const LlmModelSchema = v.pipe(v.string(), v.minLength(1))
 
-export const LLM_MODEL_ALLOWLIST: Record<LlmProvider, readonly LlmModel[]> = {
+export const LLM_MODEL_ALLOWLIST: Record<LlmProvider, readonly string[]> = {
   google: ['gemini-2.5-flash'],
-  ollama: [
-    'qwen3.5:2b',
-    'qwen3.5:4b',
-    'mitmul/plamo-2-translate',
-    'mitmul/plamo-2-translate:Q2_K',
-    'mitmul/plamo-2-translate:Q3_K_M',
-    'mitmul/plamo-2-translate:Q4_K_M',
-    'mitmul/plamo-2-translate:IQ2_M',
-    'mitmul/plamo-2-translate:IQ2_S',
-    'mitmul/plamo-2-translate:IQ2_XS',
-    'mitmul/plamo-2-translate:IQ2_XXS',
-    'sorc/qwen3.5-instruct:0.8b',
-    'sorc/qwen3.5-instruct-uncensored:2b',
-    'gemma4:e2b-it-q4_K_M:think',
-    'gemma4:e2b-it-q4_K_M:no-think',
-    'gemma4:e4b-it-q4_K_M:think',
-    'gemma4:e4b-it-q4_K_M:no-think'
-  ],
+  ollama: [],
   'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
 }
 
@@ -66,32 +34,30 @@ export const LLM_PROVIDER_LABELS: Record<LlmProvider, string> = {
   'openai-subscription': 'Codex CLI'
 }
 
-export const LLM_MODEL_LABELS: Record<LlmModel, string> = {
+const LLM_MODEL_LABEL_OVERRIDES: Record<KnownLlmModel, string> = {
   'gemini-2.5-flash': 'gemini-2.5-flash',
-  'qwen3.5:2b': 'qwen3.5:2b',
-  'qwen3.5:4b': 'qwen3.5:4b',
-  'mitmul/plamo-2-translate': 'mitmul/plamo-2-translate',
-  'mitmul/plamo-2-translate:Q2_K': 'mitmul/plamo-2-translate:Q2_K',
-  'mitmul/plamo-2-translate:Q3_K_M': 'mitmul/plamo-2-translate:Q3_K_M',
-  'mitmul/plamo-2-translate:Q4_K_M': 'mitmul/plamo-2-translate:Q4_K_M',
-  'mitmul/plamo-2-translate:IQ2_M': 'mitmul/plamo-2-translate:IQ2_M',
-  'mitmul/plamo-2-translate:IQ2_S': 'mitmul/plamo-2-translate:IQ2_S',
-  'mitmul/plamo-2-translate:IQ2_XS': 'mitmul/plamo-2-translate:IQ2_XS',
-  'mitmul/plamo-2-translate:IQ2_XXS': 'mitmul/plamo-2-translate:IQ2_XXS',
-  'sorc/qwen3.5-instruct:0.8b': 'sorc/qwen3.5-instruct:0.8b',
-  'sorc/qwen3.5-instruct-uncensored:2b': 'sorc/qwen3.5-instruct-uncensored:2b',
-  // gemma4 variants: labels use the underlying Ollama model name, with a
-  // human-readable suffix to distinguish thinking from non-thinking mode.
-  'gemma4:e2b-it-q4_K_M:think': 'gemma4:e2b-it-q4_K_M (thinking)',
-  'gemma4:e2b-it-q4_K_M:no-think': 'gemma4:e2b-it-q4_K_M',
-  'gemma4:e4b-it-q4_K_M:think': 'gemma4:e4b-it-q4_K_M (thinking)',
-  'gemma4:e4b-it-q4_K_M:no-think': 'gemma4:e4b-it-q4_K_M',
   'gpt-5.4-mini': 'gpt-5.4-mini',
   'gpt-5.4': 'gpt-5.4',
   'gpt-5.3-codex': 'gpt-5.3-codex',
   'gpt-5.2-codex': 'gpt-5.2-codex',
   'gpt-5.2': 'gpt-5.2',
   'gpt-5.1-codex-mini': 'gpt-5.1-codex-mini'
+}
+
+export const getLlmModelLabel = (model: string): string =>
+  LLM_MODEL_LABEL_OVERRIDES[model as KnownLlmModel] ?? model
+
+const KNOWN_HOSTED_LLM_MODELS = new Set<string>([
+  ...LLM_MODEL_ALLOWLIST.google,
+  ...LLM_MODEL_ALLOWLIST['openai-subscription']
+])
+
+export const isAllowedLlmModel = (provider: LlmProvider, model: string): boolean => {
+  if (provider === 'ollama') {
+    return model.trim().length > 0 && !KNOWN_HOSTED_LLM_MODELS.has(model)
+  }
+
+  return LLM_MODEL_ALLOWLIST[provider].includes(model)
 }
 
 // Current executable transformation support now covers all user-selectable LLM
@@ -102,22 +68,6 @@ export const ImplementedTransformProviderSchema = v.picklist([...IMPLEMENTED_TRA
 
 export const IMPLEMENTED_TRANSFORM_MODEL_IDS = [
   'gemini-2.5-flash',
-  'qwen3.5:2b',
-  'qwen3.5:4b',
-  'mitmul/plamo-2-translate',
-  'mitmul/plamo-2-translate:Q2_K',
-  'mitmul/plamo-2-translate:Q3_K_M',
-  'mitmul/plamo-2-translate:Q4_K_M',
-  'mitmul/plamo-2-translate:IQ2_M',
-  'mitmul/plamo-2-translate:IQ2_S',
-  'mitmul/plamo-2-translate:IQ2_XS',
-  'mitmul/plamo-2-translate:IQ2_XXS',
-  'sorc/qwen3.5-instruct:0.8b',
-  'sorc/qwen3.5-instruct-uncensored:2b',
-  'gemma4:e2b-it-q4_K_M:think',
-  'gemma4:e2b-it-q4_K_M:no-think',
-  'gemma4:e4b-it-q4_K_M:think',
-  'gemma4:e4b-it-q4_K_M:no-think',
   'gpt-5.4-mini',
   'gpt-5.4',
   'gpt-5.3-codex',
@@ -125,31 +75,31 @@ export const IMPLEMENTED_TRANSFORM_MODEL_IDS = [
   'gpt-5.2',
   'gpt-5.1-codex-mini'
 ] as const
-export type ImplementedTransformModel = (typeof IMPLEMENTED_TRANSFORM_MODEL_IDS)[number]
-export const ImplementedTransformModelSchema = v.picklist([...IMPLEMENTED_TRANSFORM_MODEL_IDS])
+export type KnownImplementedTransformModel = (typeof IMPLEMENTED_TRANSFORM_MODEL_IDS)[number]
+export type ImplementedTransformModel = string
+export const ImplementedTransformModelSchema = v.pipe(v.string(), v.minLength(1))
 
 export const IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST: Record<
   ImplementedTransformProvider,
-  readonly ImplementedTransformModel[]
+  readonly string[]
 > = {
   google: ['gemini-2.5-flash'],
-  ollama: [
-    'qwen3.5:2b',
-    'qwen3.5:4b',
-    'mitmul/plamo-2-translate',
-    'mitmul/plamo-2-translate:Q2_K',
-    'mitmul/plamo-2-translate:Q3_K_M',
-    'mitmul/plamo-2-translate:Q4_K_M',
-    'mitmul/plamo-2-translate:IQ2_M',
-    'mitmul/plamo-2-translate:IQ2_S',
-    'mitmul/plamo-2-translate:IQ2_XS',
-    'mitmul/plamo-2-translate:IQ2_XXS',
-    'sorc/qwen3.5-instruct:0.8b',
-    'sorc/qwen3.5-instruct-uncensored:2b',
-    'gemma4:e2b-it-q4_K_M:think',
-    'gemma4:e2b-it-q4_K_M:no-think',
-    'gemma4:e4b-it-q4_K_M:think',
-    'gemma4:e4b-it-q4_K_M:no-think'
-  ],
+  ollama: [],
   'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
+}
+
+const KNOWN_HOSTED_IMPLEMENTED_TRANSFORM_MODELS = new Set<string>([
+  ...IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST.google,
+  ...IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription']
+])
+
+export const isAllowedImplementedTransformModel = (
+  provider: ImplementedTransformProvider,
+  model: string
+): boolean => {
+  if (provider === 'ollama') {
+    return model.trim().length > 0 && !KNOWN_HOSTED_IMPLEMENTED_TRANSFORM_MODELS.has(model)
+  }
+
+  return IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST[provider].includes(model)
 }

--- a/src/shared/local-llm.ts
+++ b/src/shared/local-llm.ts
@@ -29,5 +29,6 @@ export const LOCAL_LLM_MODEL_IDS = [
   'gemma4:e4b-it-q4_K_M:think',
   'gemma4:e4b-it-q4_K_M:no-think'
 ] as const
-export type LocalLlmModelId = (typeof LOCAL_LLM_MODEL_IDS)[number]
-export const LocalLlmModelIdSchema = v.picklist([...LOCAL_LLM_MODEL_IDS])
+export type KnownLocalLlmModelId = (typeof LOCAL_LLM_MODEL_IDS)[number]
+export type LocalLlmModelId = string
+export const LocalLlmModelIdSchema = v.pipe(v.string(), v.minLength(1))


### PR DESCRIPTION
## Summary
- stop hardcoding Ollama models and use the installed model ids reported by Ollama
- keep Google and Codex model validation strict while allowing non-hosted Ollama ids
- update readiness, settings, profiles, tests, and docs for the installed-model flow

## Verification
- pnpm typecheck
- pnpm exec vitest run src/shared/domain.test.ts src/shared/llm.test.ts src/main/orchestrators/preflight-guard.test.ts src/main/services/transformation-service.test.ts src/main/services/llm-provider-readiness-service.test.ts src/main/services/local-llm/ollama-local-llm-runtime.test.ts src/renderer/settings-api-keys-react.test.tsx src/renderer/profiles-panel-react.test.tsx
