### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicta",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "v1 macOS speech-to-text app",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary
- bump the app version from 0.3.3 to 0.3.4 to trigger the macOS release workflow

## Verification
- release workflow will run on merge to main and build/upload the macOS artifacts