### PR TITLE
Fix Codex CLI readiness probing

### DIFF
--- a/src/main/services/codex-cli-service.test.ts
+++ b/src/main/services/codex-cli-service.test.ts
@@ -37,6 +37,16 @@ describe('CodexCliService', () => {
     await expect(service.getReadiness()).resolves.toEqual({ kind: 'ready', version: '0.128.0' })
   })
 
+  it('uses successful login-status exit code even when CLI output has no known wording', async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: 'codex-cli 0.145.0\n', stderr: 'WARNING: using existing config\n' })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'status check complete\n' })
+    const service = new CodexCliService({ runCommand: run })
+
+    await expect(service.getReadiness()).resolves.toEqual({ kind: 'ready', version: '0.145.0' })
+  })
+
   it('finds Codex CLI from a fallback install path when GUI PATH cannot resolve codex', async () => {
     const missing = new Error('spawn codex ENOENT') as Error & { code: string }
     missing.code = 'ENOENT'
@@ -75,7 +85,7 @@ describe('CodexCliService', () => {
 
     await expect(service.getReadiness()).resolves.toEqual({ kind: 'ready', version: '0.128.0' })
     expect(run).toHaveBeenNthCalledWith(1, 'codex', ['--version'])
-    expect(run).toHaveBeenNthCalledWith(2, '/bin/zsh', ['-lc', 'command -v codex'])
+    expect(run).toHaveBeenNthCalledWith(2, '/bin/zsh', ['-ilc', 'command -v codex'])
     expect(run).toHaveBeenNthCalledWith(3, shellResolvedCodex, ['--version'])
     expect(run).toHaveBeenNthCalledWith(4, shellResolvedCodex, ['login', 'status'])
   })

--- a/src/main/services/codex-cli-service.ts
+++ b/src/main/services/codex-cli-service.ts
@@ -121,8 +121,13 @@ export class CodexCliService {
     const codex = this.codexExecutable ?? DEFAULT_CODEX_EXECUTABLE
 
     try {
-      const out = await this.run(codex, ['login', 'status'])
-      return parseLoginStatus(out, version)
+      // `codex login status` documents its exit status as the automation
+      // contract: exit 0 means credentials are present. The human-readable
+      // message is intentionally not part of the readiness contract because
+      // it can change between CLI releases (and may be accompanied by
+      // warnings on stderr).
+      await this.run(codex, ['login', 'status'])
+      return version ? { kind: 'ready', version } : { kind: 'ready' }
     } catch (error) {
       const out = readCommandOutput(error)
       const parsed = parseLoginStatus(out, version ?? undefined)
@@ -259,7 +264,12 @@ export class CodexCliService {
   private async findShellCodexExecutable(): Promise<string | null> {
     for (const shell of this.shellExecutableCandidates) {
       try {
-        const out = await this.run(shell, ['-lc', 'command -v codex'])
+        // Electron launched from Finder/Dock does not inherit the user's
+        // interactive shell PATH. Loading both login and interactive shell
+        // startup files allows version managers and package-manager shims
+        // configured in ~/.zshrc or ~/.bashrc to be discovered safely without
+        // invoking a shell to execute user-controlled command text.
+        const out = await this.run(shell, ['-ilc', 'command -v codex'])
         const path = parseShellCommandPath(out)
         if (path) {
           return path

--- a/src/main/services/llm-provider-readiness-service.test.ts
+++ b/src/main/services/llm-provider-readiness-service.test.ts
@@ -99,12 +99,7 @@ describe('LlmProviderReadinessService', () => {
       status: { kind: 'cli_not_installed' }
     })
     expect(snapshot['openai-subscription'].models).toEqual([
-      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: false },
-      { id: 'gpt-5.4', label: 'gpt-5.4', available: false },
-      { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex', available: false },
-      { id: 'gpt-5.2-codex', label: 'gpt-5.2-codex', available: false },
-      { id: 'gpt-5.2', label: 'gpt-5.2', available: false },
-      { id: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini', available: false }
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: false }
     ])
   })
 
@@ -124,12 +119,7 @@ describe('LlmProviderReadinessService', () => {
       status: { kind: 'cli_login_required' }
     })
     expect(snapshot['openai-subscription'].models).toEqual([
-      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: false },
-      { id: 'gpt-5.4', label: 'gpt-5.4', available: false },
-      { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex', available: false },
-      { id: 'gpt-5.2-codex', label: 'gpt-5.2-codex', available: false },
-      { id: 'gpt-5.2', label: 'gpt-5.2', available: false },
-      { id: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini', available: false }
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: false }
     ])
   })
 
@@ -152,12 +142,7 @@ describe('LlmProviderReadinessService', () => {
       }
     })
     expect(snapshot['openai-subscription'].models).toEqual([
-      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: true },
-      { id: 'gpt-5.4', label: 'gpt-5.4', available: true },
-      { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex', available: true },
-      { id: 'gpt-5.2-codex', label: 'gpt-5.2-codex', available: true },
-      { id: 'gpt-5.2', label: 'gpt-5.2', available: true },
-      { id: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini', available: true }
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini', available: true }
     ])
   })
 

--- a/src/main/services/llm-provider-readiness-service.ts
+++ b/src/main/services/llm-provider-readiness-service.ts
@@ -7,6 +7,7 @@ Why: Replace renderer-side assumptions with one provider-scoped readiness contra
 
 import type { LlmProviderStatusSnapshot } from '../../shared/ipc'
 import {
+  IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST,
   LLM_MODEL_ALLOWLIST,
   getLlmModelLabel,
   type LlmProvider
@@ -138,7 +139,7 @@ export class LlmProviderReadinessService {
         ...(readiness.kind === 'ready' && readiness.version ? { version: readiness.version } : {})
       },
       status,
-      models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
+      models: IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
         id,
         label: getLlmModelLabel(id),
         available: ready

--- a/src/renderer/profiles-panel-react.tsx
+++ b/src/renderer/profiles-panel-react.tsx
@@ -21,6 +21,7 @@ import { Pencil, Plus, Star, Trash2 } from 'lucide-react'
 import type { Settings, TransformationPreset } from '../shared/domain'
 import {
   IMPLEMENTED_TRANSFORM_PROVIDER_IDS,
+  IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST,
   LLM_MODEL_ALLOWLIST,
   LLM_PROVIDER_LABELS,
   getLlmModelLabel,
@@ -95,7 +96,7 @@ const DEFAULT_LLM_PROVIDER_STATUS: LlmProviderStatusSnapshot = {
     provider: 'openai-subscription',
     credential: { kind: 'cli', installed: false },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
+    models: IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({
       id,
       label: getLlmModelLabel(id),
       available: false
@@ -378,7 +379,7 @@ const ProfileEditForm = ({
             const readiness = llmProviderStatus[provider]
             const nextModel =
               readiness.models.find((model) => model.available)?.id ??
-              LLM_MODEL_ALLOWLIST[provider][0] ??
+              IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST[provider][0] ??
               ''
             onChangeDraft({
               provider,

--- a/src/renderer/renderer-app.tsx
+++ b/src/renderer/renderer-app.tsx
@@ -14,7 +14,7 @@ This file is now the thin orchestration layer: boot, state, autosave, and render
 
 import { DEFAULT_SETTINGS, type OutputTextSource, type Settings } from '../shared/domain'
 import { logStructured } from '../shared/error-logging'
-import { LLM_MODEL_ALLOWLIST, getLlmModelLabel } from '../shared/llm'
+import { IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST, LLM_MODEL_ALLOWLIST, getLlmModelLabel } from '../shared/llm'
 import { buildOutputSettingsFromSelection } from '../shared/output-selection'
 import { COMPOSITE_TRANSFORM_ENQUEUED_MESSAGE } from '../shared/ipc'
 import { createRoot, type Root } from 'react-dom/client'
@@ -63,7 +63,7 @@ const createDefaultLlmProviderStatus = (): LlmProviderStatusSnapshot => ({
     provider: 'openai-subscription',
     credential: { kind: 'cli', installed: false },
     status: { kind: 'unknown', message: 'LLM provider readiness has not been loaded yet.' },
-    models: LLM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({ id, label: getLlmModelLabel(id), available: false }))
+    models: IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription'].map((id) => ({ id, label: getLlmModelLabel(id), available: false }))
   }
 })
 

--- a/src/renderer/settings-api-keys-react.tsx
+++ b/src/renderer/settings-api-keys-react.tsx
@@ -8,7 +8,7 @@ Why: Present Gemini, Codex Integration, and Ollama as flat top-level sections
 import { useEffect, useState } from 'react'
 import type { ChangeEvent, ReactNode } from 'react'
 import { Trash2 } from 'lucide-react'
-import { LLM_MODEL_ALLOWLIST, LLM_PROVIDER_LABELS, type LlmProvider } from '../shared/llm'
+import { IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST, LLM_PROVIDER_LABELS, type LlmProvider } from '../shared/llm'
 import type { ApiKeyProvider, LlmProviderStatusSnapshot } from '../shared/ipc'
 import { FIXED_API_KEY_MASK } from './api-key-mask'
 import { ConfirmDeleteApiKeyDialogReact } from './confirm-delete-api-key-dialog-react'
@@ -32,7 +32,7 @@ interface SettingsApiKeysReactProps {
 const GOOGLE_PROVIDER_ID: LlmProvider = 'google'
 const GOOGLE_MODEL_ID = 'gemini-2.5-flash'
 const OPENAI_SUBSCRIPTION_MODEL_ID = 'gpt-5.4-mini'
-const OPENAI_SUBSCRIPTION_MODEL_IDS = LLM_MODEL_ALLOWLIST['openai-subscription']
+const OPENAI_SUBSCRIPTION_MODEL_IDS = IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST['openai-subscription']
 
 const credentialSummary = (provider: LlmProvider, snapshot: LlmProviderStatusSnapshot[LlmProvider]): string => {
   if (snapshot.credential.kind === 'api_key') {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -140,7 +140,7 @@ export const STT_MODEL_ALLOWLIST: Record<SttProvider, readonly SttModel[]> = {
 export const TRANSFORM_MODEL_ALLOWLIST: Record<TransformProvider, readonly string[]> = {
   google: ['gemini-2.5-flash'],
   ollama: [],
-  'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
+  'openai-subscription': ['gpt-5.4-mini']
 }
 
 export const RECORDING_METHOD_ALLOWLIST: readonly RecordingMethod[] = ['cpal']

--- a/src/shared/llm.test.ts
+++ b/src/shared/llm.test.ts
@@ -25,12 +25,12 @@ describe('shared llm catalog', () => {
     expect(LLM_MODEL_ALLOWLIST['openai-subscription']).toContain('gpt-5.1-codex-mini')
   })
 
-  it('keeps executable transformation support aligned with the unified provider catalog', () => {
+  it('keeps executable transformation support narrower than the future catalog when required', () => {
     expect(IMPLEMENTED_TRANSFORM_PROVIDER_IDS).toEqual(['google', 'ollama', 'openai-subscription'])
     expect(IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST).toEqual({
       google: ['gemini-2.5-flash'],
       ollama: [],
-      'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
+      'openai-subscription': ['gpt-5.4-mini']
     })
   })
 

--- a/src/shared/llm.ts
+++ b/src/shared/llm.ts
@@ -68,12 +68,7 @@ export const ImplementedTransformProviderSchema = v.picklist([...IMPLEMENTED_TRA
 
 export const IMPLEMENTED_TRANSFORM_MODEL_IDS = [
   'gemini-2.5-flash',
-  'gpt-5.4-mini',
-  'gpt-5.4',
-  'gpt-5.3-codex',
-  'gpt-5.2-codex',
-  'gpt-5.2',
-  'gpt-5.1-codex-mini'
+  'gpt-5.4-mini'
 ] as const
 export type KnownImplementedTransformModel = (typeof IMPLEMENTED_TRANSFORM_MODEL_IDS)[number]
 export type ImplementedTransformModel = string
@@ -85,7 +80,7 @@ export const IMPLEMENTED_TRANSFORM_MODEL_ALLOWLIST: Record<
 > = {
   google: ['gemini-2.5-flash'],
   ollama: [],
-  'openai-subscription': ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.2', 'gpt-5.1-codex-mini']
+  'openai-subscription': ['gpt-5.4-mini']
 }
 
 const KNOWN_HOSTED_IMPLEMENTED_TRANSFORM_MODELS = new Set<string>([


### PR DESCRIPTION
## Root cause

Two independent readiness assumptions made an authenticated Codex installation appear unavailable:

- The service required `codex login status` to emit one of a small set of human-readable phrases. Current Codex documentation defines exit code 0 as the automation contract; output may include warnings or change wording.
- GUI launches used `<login-shell> -lc`, which does not load interactive `.zshrc`/`.bashrc` setup. Codex installed through nvm, pnpm, or another version manager can therefore be invisible to Electron even when it works in the user's terminal.

The readiness layer also exposed future Codex model IDs as executable/available even though the shipped adapter is intentionally pinned to `gpt-5.4-mini`.

## Changes

- Treat successful `codex login status` execution as authenticated; retain explicit login-required and probe-failure parsing for non-zero exits.
- Discover Codex through an interactive login shell (`-ilc`) while keeping `execFile` and the read-only execution boundary unchanged.
- Align the implemented Codex model catalog, readiness snapshot, profile picker, and Settings model list with `gpt-5.4-mini`; leave the future-facing catalog available for later support.
- Add regression coverage for changed/quiet login output and interactive-shell discovery.

## Validation

Passed:

- Focused Codex/readiness/preflight/adapter/shared/UI tests: 117 tests
- `tsc --noEmit`
- `electron-vite build`
- `git diff --check`
- Current Codex CLI 0.145.0 package behavior: `codex --version`, `codex login status`, and `codex exec --help`; the required `exec -m ... --skip-git-repo-check --sandbox read-only --color never --output-last-message <path> -` flags remain supported.

The full Vitest suite reached 920 passing tests, but 10 unrelated Electron-dependent suites could not load because the restricted environment skipped Electron's postinstall binary download. The repository has no lint script or ESLint binary.

References: https://developers.openai.com/codex/developer-commands, https://developers.openai.com/codex/non-interactive-mode
